### PR TITLE
Mark battery sensors as diagnostic; unify restore

### DIFF
--- a/custom_components/omron/binary_sensor.py
+++ b/custom_components/omron/binary_sensor.py
@@ -28,6 +28,7 @@ BINARY_SENSOR_DESCRIPTIONS = {
     OmronBinarySensorDeviceClass.BATTERY: BinarySensorEntityDescription(
         key=OmronBinarySensorDeviceClass.BATTERY,
         device_class=BinarySensorDeviceClass.BATTERY,
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     OmronBinarySensorDeviceClass.PROBLEM: BinarySensorEntityDescription(
         key=OmronBinarySensorDeviceClass.PROBLEM,

--- a/custom_components/omron/sensor.py
+++ b/custom_components/omron/sensor.py
@@ -143,6 +143,7 @@ SENSOR_DESCRIPTIONS = {
         device_class=SensorDeviceClass.BATTERY,
         native_unit_of_measurement=Units.PERCENTAGE,
         state_class=SensorStateClass.MEASUREMENT,
+        entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:battery",
     ),
 }
@@ -306,10 +307,6 @@ class OmronBluetoothSensorEntity(
     async def async_added_to_hass(self) -> None:
         """Subscribe to coordinator and restore last state from recorder."""
         await super().async_added_to_hass()
-        # Battery level can be unsupported on some models/firmware sessions.
-        # Avoid showing stale restored values as if they were fresh readings.
-        if self.entity_description.device_class == SensorDeviceClass.BATTERY:
-            return
         if self.entity_description.entity_category == EntityCategory.DIAGNOSTIC:
             return
         last_state = await self.async_get_last_state()


### PR DESCRIPTION
Add EntityCategory.DIAGNOSTIC to battery sensor/entity descriptions in both binary_sensor.py and sensor.py, and remove the previous device_class == BATTERY early-return in async_added_to_hass. This consolidates the logic for skipping restored states (now handled via the diagnostic category) to avoid showing stale battery readings for devices that don't report battery level.