### PR TITLE
Defer advertisement-triggered pairing & subscribe AFib I2 channel

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -121,10 +121,6 @@ def process_service_info(
 
     entry_data = coordinator.hass.data[DOMAIN][entry.entry_id]
 
-    # 2. Skip if a GATT session is already running
-    if entry_data.get("poll_in_progress"):
-        return update
-
     is_pairing = getattr(data, "pairing_mode", False)
     is_invalid_time = getattr(data, "invalid_time", False)
     is_forced_transfer = getattr(data, "forced_transfer", False)
@@ -135,6 +131,47 @@ def process_service_info(
         or (is_forced_transfer and coordinator.poll_coordinator is not None)
     )
     if not is_sync_needed:
+        return update
+
+    # 2. Skip if a GATT session is already running.
+    # Pairing is time-sensitive (~30 s window): defer it to run right after the
+    # current session ends instead of silently dropping it.
+    if entry_data.get("poll_in_progress"):
+        if is_pairing and not entry_data.get("pairing_pending"):
+            entry_data["pairing_pending"] = True
+            _LOGGER.debug(
+                "BLE session in progress; pairing deferred for %s",
+                service_info.address,
+            )
+
+            async def _deferred_pairing() -> None:
+                deadline = time.time() + 25
+                while entry_data.get("poll_in_progress") and time.time() < deadline:
+                    await asyncio.sleep(0.5)
+                entry_data.pop("pairing_pending", None)
+                if entry_data.get("poll_in_progress"):
+                    _LOGGER.warning(
+                        "Pairing trigger timed out: BLE session still active after 25 s for %s",
+                        service_info.address,
+                    )
+                    return
+                now2 = time.time()
+                if now2 - entry_data.get("last_attempt_time", 0.0) < POLL_COOLDOWN_SECONDS:
+                    return
+                entry_data["poll_in_progress"] = True
+                entry_data["last_attempt_time"] = now2
+                try:
+                    ble_device = async_ble_device_from_address(coordinator.hass, service_info.address) or service_info.device
+                    async with omron_poll_ble_telemetry(entry_data):
+                        await data.async_retry_pairing(ble_device)
+                    if coordinator.poll_coordinator:
+                        await coordinator.poll_coordinator.async_request_refresh()
+                except Exception as err:
+                    _LOGGER.error("Deferred auto pairing failed: %s", err)
+                finally:
+                    entry_data["poll_in_progress"] = False
+
+            coordinator.hass.async_create_task(_deferred_pairing())
         return update
 
     # 3. Enforce a shared cooldown between GATT session attempts

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .const import (
     CLASSIC_STACK_UNLOCK_CHARACTERISTIC_UUID,
+    MODERN_STACK_I2_CHARACTERISTIC_UUID,
     MODERN_STACK_PARENT_SERVICE_UUID,
 )
 from .devices import DeviceConfig, DeviceModelVariant
@@ -562,13 +563,17 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # HEM-7194T1 family: AFib-capable modern-stack devices, 60 records/user.
     # Verified memory layout from APK DeviceConfig.sys (HEM-7194T1-FLAP):
     #   data_1 at 0x01C4 (60 × 16 B), data_2 at 0x0584 (60 × 16 B)
-    # Subscribes to b305b680 CCCD before WLP4COM session (required per BTSnoop analysis).
+    # Subscribes to b305b680 CCCD before WLP4COM session (required per BTSnoop analysis),
+    # plus 8858eb40 (I2) — secondary notify channel used by the AFib WLP4COM protocol.
     "HEM-7194T1": DeviceConfig(
         model="HEM-7194T1",
         parent_service_uuid=MODERN_STACK_PARENT_SERVICE_UUID,
         rx_channel_uuids=["49123040-aee8-11e1-a74d-0002a5d5c51b"],
         tx_channel_uuids=["db5b55e0-aee7-11e1-965e-0002a5d5c51b"],
-        ctrl_notify_uuids=[CLASSIC_STACK_UNLOCK_CHARACTERISTIC_UUID],
+        ctrl_notify_uuids=[
+            CLASSIC_STACK_UNLOCK_CHARACTERISTIC_UUID,
+            MODERN_STACK_I2_CHARACTERISTIC_UUID,
+        ],
         requires_unlock=False,
         supports_pairing=False,
         supports_os_bonding_only=False,


### PR DESCRIPTION
## Summary

- **Fix dropped pairing advertisements when a poll is running.** Pairing mode is time-sensitive (~30 s window), but the `poll_in_progress` guard in `process_service_info` silently returned when the scheduled poll happened to be in-flight, so the user had to retry pairing repeatedly. Now the guard queues a `_deferred_pairing` task (idempotent via a `pairing_pending` flag) that waits up to 25 s for the current session to release, re-checks the cooldown, and then runs `async_retry_pairing` against a fresh `BLEDevice` from `async_ble_device_from_address`.
- **Hook up `MODERN_STACK_I2_CHARACTERISTIC_UUID` (8858eb40)** for the HEM-7194T1 / HEM-7196T1 family. The constant was declared in `const.py` but never referenced; it is the secondary notify channel the AFib WLP4COM protocol expects, so it now lives in the profile's `ctrl_notify_uuids` next to `b305b680`.
- **Tidy:** move the `poll_in_progress` check below the `is_sync_needed` short-circuit so irrelevant advertisements bail out without touching the dictionary.

## Why

- 사용자 보고: \"광고 데이터 기반 페어링시 BLE session is already in progress 로그가 뜨면서 진행이 안되네.\" Pairing button presses were being lost whenever a scheduled poll happened to overlap.
- Code review caught that `MODERN_STACK_I2_CHARACTERISTIC_UUID` was defined but unused, which would break AFib-capable WLP4COM sessions on real hardware.

## Test plan

- [ ] Trigger pairing while a scheduled poll is running and confirm the debug log shows \`pairing deferred for <addr>\` followed by a successful \`async_retry_pairing\` once the poll completes.
- [ ] Confirm the 25 s timeout warning fires when a session genuinely cannot release in time.
- [ ] On HEM-7194T1-FLAP / HEM-7196T1-FLE, verify the CCCD writes for both \`b305b680\` and \`8858eb40\` happen before WLP4COM commands are sent, and that record polling still completes cleanly.
- [ ] Regression-check HEM-7142T2 to make sure non-pairing advertisements continue to short-circuit without spawning deferred tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)