### PR TITLE
Disconnect setup BLE link so first poll after registration succeeds

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -203,6 +203,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]['address'] = address
     hass.data[DOMAIN][entry.entry_id]['data'] = data
+    # Seed the advertisement-trigger cooldown so a lingering pairing-mode
+    # advertisement arriving moments after the config-flow finishes does not
+    # cause process_service_info to fire another auto-pairing session against
+    # a device that was just paired.
+    hass.data[DOMAIN][entry.entry_id]['last_attempt_time'] = time.time()
 
     # Ensure device registry entry exists even before first successful poll.
     device_registry = dr.async_get(hass)

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -285,6 +285,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     
     entry.runtime_data = bt_coordinator
     entry.runtime_data.poll_coordinator = poll_coordinator
+    # Give the radio a moment in case a setup-flow BLE link was just torn down
+    # — initial registration triggers async_setup_entry within ~20 ms of the
+    # config-flow disconnect, before the device is ready to accept a new
+    # connection. 0.5 s is cheap insurance on reloads/restarts too.
+    await asyncio.sleep(0.5)
     await poll_coordinator.async_refresh()
     if not poll_coordinator.last_update_success:
         _LOGGER.warning(

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -421,7 +421,19 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             client = await establish_connection(BleakClient, ble_device, address)
             self._cached_client = client
 
-        await async_pair_and_sync_device(client, ble_device, model, config)
+        try:
+            await async_pair_and_sync_device(client, ble_device, model, config)
+        finally:
+            # Tear down the setup-time BLE link cleanly so async_setup_entry's
+            # initial poll starts from a fresh connection. Without this the
+            # first poll after device registration hits a TX timeout on the
+            # half-closed link and the user has to manually refresh.
+            try:
+                if self._cached_client is not None and self._cached_client.is_connected:
+                    await self._cached_client.disconnect()
+            except Exception as exc:
+                _LOGGER.debug("Setup disconnect cleanup failed: %s", exc)
+            self._cached_client = None
 
     async def async_step_bluetooth_confirm(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary

처음 디바이스를 등록한 직후 첫 poll이 TX timeout (4.3 s) + `Memory session open failed` + `Characteristic 49123040… was not found`로 항상 실패하고, 그 뒤 수동 새로고침을 누르면 정상 동작하던 문제 수정.

### Repro (HEM-7142T2)

```
00:05:30.651  Successfully paired and synced with HEM-7142T2
00:05:30.673  Poll start                     ← 22 ms 만에 초기 poll 시작
00:05:35.004  TX timeout, retry 1/4
00:05:35.004  stop_notify … was not found    ← 링크가 이미 끊겨 있음
00:05:36.007  Memory session open attempt 3/3 failed
00:05:36.008  Poll interrupted (disconnected)
```

### Root cause

Config flow가 `async_fetch_device_model_number` / `_async_do_pairing`에서 `BleakClient`를 만들어 setup-time pair + EEPROM time sync까지 끝낸 뒤, **그 client를 disconnect 하지 않은 채** `async_create_entry()`로 넘어감. 그 직후 `async_setup_entry`가 호출되고 ~20 ms 만에 `_async_poll_data` → `establish_connection`이 fire. 이 시점에 link는 teardown 중이라 `establish_connection`이 stale handle을 반환하고, 이후 GATT write는 응답 없이 timeout으로 끝남.

### Fix

1. **config_flow.py — `_async_do_pairing`**: `async_pair_and_sync_device`를 try/finally로 감싸고 finally에서 항상 `self._cached_client.disconnect()` 호출 + 레퍼런스 nil화. `async_create_entry`가 fire되는 순간 BLE 상태가 깨끗해짐.
2. **`__init__.py` — `async_setup_entry`**: 첫 `poll_coordinator.async_refresh()` 전에 `await asyncio.sleep(0.5)`. config-flow disconnect 또는 HA restart 직후 라디오가 정착될 시간 확보 (reload에서도 0.5 s 비용은 무시 가능).

## Test plan

- [ ] HEM-7142T2를 새로 등록하고 첫 poll이 TX timeout 없이 데이터를 가져오는지 확인 (수동 refresh 없이도 측정값이 보여야 함).
- [ ] HA 재시작 후 기존 엔트리들이 정상적으로 첫 poll에 성공하는지 확인.
- [ ] Config-flow 도중 pairing 단계에서 예외가 던져졌을 때도 finally가 동작해 cached_client가 누수되지 않는지 확인.
- [ ] `requires_unlock=True`인 classic 모델 (예: HEM-7322T)에서 같은 흐름 회귀 테스트.

🤖 Generated with [Claude Code](https://claude.com/claude-code)