### PR TITLE
Serialize BLE sessions with a per-entry asyncio.Lock (try-acquire only)

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -133,6 +133,14 @@ def process_service_info(
     if not is_sync_needed:
         return update
 
+    _LOGGER.debug(
+        "Advertisement flags for %s: pairing_mode=%s invalid_time=%s forced_transfer=%s",
+        service_info.address,
+        is_pairing,
+        is_invalid_time,
+        is_forced_transfer,
+    )
+
     # 2. Fail fast if a GATT session is already running — try-acquire only, no queueing.
     # The device rejects a second concurrent BLE connection with SMP auth fail
     # (reasons 97/102 on ESP32 proxies), so we drop the trigger and rely on the
@@ -168,6 +176,17 @@ def process_service_info(
             return
         await session_lock.acquire()  # fast-path synchronous return since we just checked
         entry_data["last_attempt_time"] = time.time()
+        if is_pairing:
+            action = "auto-pairing"
+        elif is_invalid_time and not is_forced_transfer:
+            action = "time-sync"
+        else:
+            action = "forced-transfer poll"
+        _LOGGER.debug(
+            "Starting %s session for %s (lock acquired)",
+            action,
+            service_info.address,
+        )
         try:
             await asyncio.sleep(SETTLE_DELAY_SECONDS)
             ble_device = service_info.device

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -166,8 +166,23 @@ def process_service_info(
         return update
 
     async def _run_auto_session() -> None:
-        # Re-check the lock inside the task: another trigger created earlier
-        # might have already grabbed it between scheduling and execution.
+        # forced_transfer-only path has no direct BLE op here — it just kicks
+        # the poll coordinator, which goes through _async_poll_data and handles
+        # its own lock acquisition. Don't hold the lock during request_refresh,
+        # otherwise the child poll would see lock locked and return cached data.
+        if not is_pairing and not is_invalid_time:
+            entry_data["last_attempt_time"] = time.time()
+            _LOGGER.debug(
+                "Triggering scheduled poll via forced-transfer flag for %s",
+                service_info.address,
+            )
+            try:
+                await coordinator.poll_coordinator.async_request_refresh()
+            except Exception as err:
+                _LOGGER.error("Auto polling failed: %s", err)
+            return
+
+        # Pair / time-sync paths own a direct BLE op — hold the lock for that.
         if session_lock.locked():
             _LOGGER.debug(
                 "BLE session lock held when auto-session task started; aborting for %s",
@@ -176,39 +191,38 @@ def process_service_info(
             return
         await session_lock.acquire()  # fast-path synchronous return since we just checked
         entry_data["last_attempt_time"] = time.time()
-        if is_pairing:
-            action = "auto-pairing"
-        elif is_invalid_time and not is_forced_transfer:
-            action = "time-sync"
-        else:
-            action = "forced-transfer poll"
+        action = "auto-pairing" if is_pairing else "time-sync"
         _LOGGER.debug(
             "Starting %s session for %s (lock acquired)",
             action,
             service_info.address,
         )
+        pair_succeeded = False
         try:
             await asyncio.sleep(SETTLE_DELAY_SECONDS)
             ble_device = service_info.device
             if is_pairing:
                 async with omron_poll_ble_telemetry(entry_data):
                     await data.async_retry_pairing(ble_device)
-                if coordinator.poll_coordinator:
-                    await coordinator.poll_coordinator.async_request_refresh()
-            elif is_invalid_time and not is_forced_transfer:
+                pair_succeeded = True
+            else:  # is_invalid_time and not is_forced_transfer
                 async with omron_poll_ble_telemetry(entry_data):
                     await data.async_sync_time(ble_device)
-            else:
-                await coordinator.poll_coordinator.async_request_refresh()
         except Exception as err:
             if is_pairing:
                 _LOGGER.error("Auto pairing failed: %s", err)
-            elif is_invalid_time and not is_forced_transfer:
-                _LOGGER.error("Auto time sync failed: %s", err)
             else:
-                _LOGGER.error("Auto polling failed: %s", err)
+                _LOGGER.error("Auto time sync failed: %s", err)
         finally:
             session_lock.release()
+
+        # Post-pairing refresh runs AFTER the lock release so _async_poll_data
+        # can acquire it for the follow-up data fetch.
+        if pair_succeeded and coordinator.poll_coordinator:
+            try:
+                await coordinator.poll_coordinator.async_request_refresh()
+            except Exception as err:
+                _LOGGER.error("Post-pairing refresh failed: %s", err)
 
     coordinator.hass.async_create_task(_run_auto_session())
 

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -133,45 +133,17 @@ def process_service_info(
     if not is_sync_needed:
         return update
 
-    # 2. Skip if a GATT session is already running.
-    # Pairing is time-sensitive (~30 s window): defer it to run right after the
-    # current session ends instead of silently dropping it.
-    if entry_data.get("poll_in_progress"):
-        if is_pairing and not entry_data.get("pairing_pending"):
-            entry_data["pairing_pending"] = True
-            _LOGGER.debug(
-                "BLE session in progress; pairing deferred for %s",
-                service_info.address,
-            )
-
-            async def _deferred_pairing() -> None:
-                deadline = time.time() + 25
-                while entry_data.get("poll_in_progress") and time.time() < deadline:
-                    await asyncio.sleep(0.5)
-                entry_data.pop("pairing_pending", None)
-                if entry_data.get("poll_in_progress"):
-                    _LOGGER.warning(
-                        "Pairing trigger timed out: BLE session still active after 25 s for %s",
-                        service_info.address,
-                    )
-                    return
-                now2 = time.time()
-                if now2 - entry_data.get("last_attempt_time", 0.0) < POLL_COOLDOWN_SECONDS:
-                    return
-                entry_data["poll_in_progress"] = True
-                entry_data["last_attempt_time"] = now2
-                try:
-                    ble_device = async_ble_device_from_address(coordinator.hass, service_info.address) or service_info.device
-                    async with omron_poll_ble_telemetry(entry_data):
-                        await data.async_retry_pairing(ble_device)
-                    if coordinator.poll_coordinator:
-                        await coordinator.poll_coordinator.async_request_refresh()
-                except Exception as err:
-                    _LOGGER.error("Deferred auto pairing failed: %s", err)
-                finally:
-                    entry_data["poll_in_progress"] = False
-
-            coordinator.hass.async_create_task(_deferred_pairing())
+    # 2. Fail fast if a GATT session is already running — try-acquire only, no queueing.
+    # The device rejects a second concurrent BLE connection with SMP auth fail
+    # (reasons 97/102 on ESP32 proxies), so we drop the trigger and rely on the
+    # next advertisement (devices keep emitting the flag bits for several seconds)
+    # to retry once the session lock is free.
+    session_lock: asyncio.Lock = entry_data["session_lock"]
+    if session_lock.locked():
+        _LOGGER.debug(
+            "BLE session lock held; skipping advertisement trigger for %s",
+            service_info.address,
+        )
         return update
 
     # 3. Enforce a shared cooldown between GATT session attempts
@@ -185,10 +157,17 @@ def process_service_info(
         )
         return update
 
-    entry_data["poll_in_progress"] = True
-    entry_data["last_attempt_time"] = now
-
     async def _run_auto_session() -> None:
+        # Re-check the lock inside the task: another trigger created earlier
+        # might have already grabbed it between scheduling and execution.
+        if session_lock.locked():
+            _LOGGER.debug(
+                "BLE session lock held when auto-session task started; aborting for %s",
+                service_info.address,
+            )
+            return
+        await session_lock.acquire()  # fast-path synchronous return since we just checked
+        entry_data["last_attempt_time"] = time.time()
         try:
             await asyncio.sleep(SETTLE_DELAY_SECONDS)
             ble_device = service_info.device
@@ -210,7 +189,7 @@ def process_service_info(
             else:
                 _LOGGER.error("Auto polling failed: %s", err)
         finally:
-            entry_data["poll_in_progress"] = False
+            session_lock.release()
 
     coordinator.hass.async_create_task(_run_auto_session())
 
@@ -245,6 +224,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     # cause process_service_info to fire another auto-pairing session against
     # a device that was just paired.
     hass.data[DOMAIN][entry.entry_id]['last_attempt_time'] = time.time()
+    # Per-entry serialization lock for BLE GATT sessions. All paths that open
+    # a BLE link (scheduled poll, advertisement-triggered auto-session, deferred
+    # pairing) try-acquire this lock and bail out immediately if it is held —
+    # never queue. Two concurrent BLE connections to the same Omron device
+    # cause SMP auth failures (proxy log: "auth fail reason=97/102").
+    hass.data[DOMAIN][entry.entry_id]['session_lock'] = asyncio.Lock()
 
     # Ensure device registry entry exists even before first successful poll.
     device_registry = dr.async_get(hass)
@@ -296,8 +281,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 return entry.runtime_data.device_data._finish_update()
             coordinator = entry.runtime_data
             entry_data = hass.data[DOMAIN][entry.entry_id]
+            session_lock: asyncio.Lock = entry_data["session_lock"]
 
-            entry_data["poll_in_progress"] = True
+            # Try-acquire only — if another BLE session is in flight (e.g. an
+            # advertisement-triggered auto-pairing started moments ago), skip
+            # this scheduled poll and serve cached data. The next interval (or
+            # a request_refresh from the active session) will retry once the
+            # lock frees. Two concurrent connections to the same Omron device
+            # provoke SMP auth failures, so we never queue here.
+            if session_lock.locked():
+                _LOGGER.debug(
+                    "Skipping scheduled poll: BLE session lock held for %s",
+                    entry_data["address"],
+                )
+                if poll_coordinator.data is not None:
+                    return poll_coordinator.data
+                return entry.runtime_data.device_data._finish_update()
+
+            await session_lock.acquire()  # synchronous fast-path since we just checked
             try:
                 async with omron_poll_ble_telemetry(entry_data):
                     result = await coordinator.device_data.async_poll(device)
@@ -306,7 +307,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                     result = _merge_poll_sensor_update(prev_data, result)
                 return result
             finally:
-                entry_data["poll_in_progress"] = False
+                session_lock.release()
         except Exception as err:
             _LOGGER.debug("polling error; keeping last successful poll data: %s", err)
             if poll_coordinator.data is not None:

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -189,35 +189,33 @@ def process_service_info(
                 service_info.address,
             )
             return
-        await session_lock.acquire()  # fast-path synchronous return since we just checked
-        entry_data["last_attempt_time"] = time.time()
         action = "auto-pairing" if is_pairing else "time-sync"
-        _LOGGER.debug(
-            "Starting %s session for %s (lock acquired)",
-            action,
-            service_info.address,
-        )
         pair_succeeded = False
         try:
-            await asyncio.sleep(SETTLE_DELAY_SECONDS)
-            ble_device = service_info.device
-            if is_pairing:
-                async with omron_poll_ble_telemetry(entry_data):
-                    await data.async_retry_pairing(ble_device)
-                pair_succeeded = True
-            else:  # is_invalid_time and not is_forced_transfer
-                async with omron_poll_ble_telemetry(entry_data):
-                    await data.async_sync_time(ble_device)
+            async with session_lock:
+                entry_data["last_attempt_time"] = time.time()
+                _LOGGER.debug(
+                    "Starting %s session for %s (lock acquired)",
+                    action,
+                    service_info.address,
+                )
+                await asyncio.sleep(SETTLE_DELAY_SECONDS)
+                ble_device = service_info.device
+                if is_pairing:
+                    async with omron_poll_ble_telemetry(entry_data):
+                        await data.async_retry_pairing(ble_device)
+                    pair_succeeded = True
+                else:  # is_invalid_time and not is_forced_transfer
+                    async with omron_poll_ble_telemetry(entry_data):
+                        await data.async_sync_time(ble_device)
         except Exception as err:
             if is_pairing:
                 _LOGGER.error("Auto pairing failed: %s", err)
             else:
                 _LOGGER.error("Auto time sync failed: %s", err)
-        finally:
-            session_lock.release()
 
-        # Post-pairing refresh runs AFTER the lock release so _async_poll_data
-        # can acquire it for the follow-up data fetch.
+        # Lock auto-released by the context manager. Post-pairing refresh runs
+        # AFTER the release so _async_poll_data can acquire it independently.
         if pair_succeeded and coordinator.poll_coordinator:
             try:
                 await coordinator.poll_coordinator.async_request_refresh()
@@ -331,16 +329,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                     return poll_coordinator.data
                 return entry.runtime_data.device_data._finish_update()
 
-            await session_lock.acquire()  # synchronous fast-path since we just checked
-            try:
+            async with session_lock:
                 async with omron_poll_ble_telemetry(entry_data):
                     result = await coordinator.device_data.async_poll(device)
                 prev_data = poll_coordinator.data
                 if prev_data is not None:
                     result = _merge_poll_sensor_update(prev_data, result)
                 return result
-            finally:
-                session_lock.release()
         except Exception as err:
             _LOGGER.debug("polling error; keeping last successful poll data: %s", err)
             if poll_coordinator.data is not None:

--- a/custom_components/omron/button.py
+++ b/custom_components/omron/button.py
@@ -114,13 +114,26 @@ class OmronRetryPairingButtonEntity(ButtonEntity):
             raise HomeAssistantError(f"BLE device not available: {self._address}")
 
         entry_data = self.hass.data[DOMAIN][self._entry_id]
+        session_lock = entry_data["session_lock"]
+        # Fail fast if another BLE session is already running; tell the user to
+        # retry rather than racing the existing connection (concurrent BLE
+        # sessions to the same Omron device cause SMP auth failures).
+        if session_lock.locked():
+            raise HomeAssistantError(
+                f"BLE session already in progress for {self._address}; retry in a moment"
+            )
+        await session_lock.acquire()
         data = entry_data["data"]
         try:
             async with omron_poll_ble_telemetry(entry_data):
                 await data.async_retry_pairing(ble_device)
-            # Mirror setup behavior: run an immediate poll after pairing so
-            # protected GATT paths are exercised and bond/session state settles.
-            poll_coordinator = self._entry.runtime_data.poll_coordinator
-            await poll_coordinator.async_request_refresh()
         except Exception as err:
+            session_lock.release()
             raise HomeAssistantError(f"Failed to retry pairing: {err}") from err
+        # Release the lock before requesting refresh — _async_poll_data must be
+        # able to acquire it for the follow-up poll.
+        session_lock.release()
+        # Mirror setup behavior: run an immediate poll after pairing so
+        # protected GATT paths are exercised and bond/session state settles.
+        poll_coordinator = self._entry.runtime_data.poll_coordinator
+        await poll_coordinator.async_request_refresh()

--- a/custom_components/omron/button.py
+++ b/custom_components/omron/button.py
@@ -122,18 +122,16 @@ class OmronRetryPairingButtonEntity(ButtonEntity):
             raise HomeAssistantError(
                 f"BLE session already in progress for {self._address}; retry in a moment"
             )
-        await session_lock.acquire()
         data = entry_data["data"]
         try:
-            async with omron_poll_ble_telemetry(entry_data):
-                await data.async_retry_pairing(ble_device)
+            async with session_lock:
+                async with omron_poll_ble_telemetry(entry_data):
+                    await data.async_retry_pairing(ble_device)
         except Exception as err:
-            session_lock.release()
             raise HomeAssistantError(f"Failed to retry pairing: {err}") from err
-        # Release the lock before requesting refresh — _async_poll_data must be
-        # able to acquire it for the follow-up poll.
-        session_lock.release()
-        # Mirror setup behavior: run an immediate poll after pairing so
-        # protected GATT paths are exercised and bond/session state settles.
+        # Lock auto-released by the context manager. Mirror setup behavior:
+        # run an immediate poll after pairing so protected GATT paths are
+        # exercised and bond/session state settles. _async_poll_data will
+        # acquire the lock on its own.
         poll_coordinator = self._entry.runtime_data.poll_coordinator
         await poll_coordinator.async_request_refresh()


### PR DESCRIPTION
## Why

ESP32 bluetooth-proxy 환경(HEM-7196T1-FLE / M4 Connect AFib) 로그에서 **두 개의 BLE 세션이 505 ms 간격으로 동시에 열리는 패턴**이 확인됨:

```
10:17:36.209  connection True   ← session A enter
10:17:36.714  connection True   ← session B enter (505 ms later)
10:17:40.683  Poll start
10:17:40.890  OS-level bonding attempt 1/2 failed: Pairing failed due to error: 97
10:17:41.390  attempt 2/2 failed: ...is not connected
```

`omron_poll_ble_telemetry` enter는 세션당 한 번 `connection True`를 set하므로, 505 ms 간격의 두 enter = 두 개의 BLE 세션 동시 진행. 기기는 단일 connection만 받기 때문에 두 번째 세션의 SMP 핸드셰이크가 reject되고(proxy 로그 reason=97/102), 링크가 drop되며 이후 모든 characteristic이 "not found"로 사라짐.

원인 commit: `cd7394c "Remove early skip for BLE scheduled poll"` — `_async_poll_data` 상단의 `poll_in_progress` 가드를 제거. 그 뒤로 스케줄러 폴이 광고 트리거 자동 세션과 병렬 실행 가능해짐. 페어링 모드만 멀쩡했던 이유는 PR #47의 `_deferred_pairing`이 `poll_in_progress`를 명시적으로 기다리며 자체 직렬화를 하고 있었기 때문.

## What

`poll_in_progress` 플래그를 버리고, 모든 BLE 진입점을 **per-entry `asyncio.Lock`** + **try-acquire**(큐잉 금지)로 통일.

- `async_setup_entry`: `entry_data["session_lock"] = asyncio.Lock()` seed.
- `process_service_info`
    - `_deferred_pairing` 및 `pairing_pending` 제거.
    - 태스크 스케줄 전 `session_lock.locked()` 체크. 잡혀 있으면 광고를 drop하고 다음 광고를 기다림 (기기는 동일 플래그를 수 초간 반복 송출하므로 lock이 풀리는 즉시 다음 광고가 재시도함).
    - `_run_auto_session` 내부에서도 `locked()` 재확인 → `await lock.acquire()` (방금 비어 있음을 확인했으므로 synchronous fast-path) → `last_attempt_time` 갱신. 즉 **drop된 트리거는 쿨다운을 갱신하지 않음**.
- `_async_poll_data`: 동일 try-acquire 패턴. lock 잡혀 있으면 캐시 데이터 반환, 두 번째 BLE 세션을 절대 열지 않음.
- `OmronRetryPairingButtonEntity.async_press`: 동일 패턴. lock 잡혀 있으면 `HomeAssistantError` raise (사용자에게 즉시 피드백). follow-up `async_request_refresh`가 lock을 잡을 수 있도록 release 후 호출.

## Test plan

- [ ] HEM-7196T1-FLE를 ESP32 proxy로 polling 시, 광고 트리거와 스케줄러 폴이 절대 동시 실행되지 않는지 (`Skipping scheduled poll: BLE session lock held for ...` 로그가 의도대로 찍히는지) 확인.
- [ ] 페어링 모드 활성화 시, lock 잡혀 있으면 광고 drop되고 다음 광고에서 자연스럽게 retry되는지 확인.
- [ ] Retry Pairing 버튼: lock 잡혀 있을 때 누르면 `BLE session already in progress for ...; retry in a moment` 에러가 즉시 나오는지.
- [ ] 정상 케이스 회귀: classic-pairing 기기(HEM-7322T 등)에서 스케줄러 폴이 정상 완료되는지.

🤖 Generated with [Claude Code](https://claude.com/claude-code)