### PR TITLE
fix: resolve multi-user extra_state_attributes when aliases are used

### DIFF
--- a/custom_components/omron/sensor.py
+++ b/custom_components/omron/sensor.py
@@ -310,6 +310,24 @@ class OmronBluetoothSensorEntity(
             str(last_state.state)
         )
 
+    def _resolve_user_id_from_key(self) -> str:
+        """Resolve user_id from sensor key using aliases or numeric suffix."""
+        key = str(self._device_key.key)
+        # Reverse search using aliases (dynamic, works when names change)
+        aliases = getattr(self._omron_device_data, '_user_aliases', {})
+        if aliases:
+            from .util import slugify_for_entity_key
+            for u_idx, label in aliases.items():
+                slug = slugify_for_entity_key(label)
+                if slug and key.endswith(f"_{slug}"):
+                    return f"user_{u_idx}"
+        # Fallback: numeric suffix (_2, _user2)
+        import re
+        match = re.search(r'_(?:user)?([0-9]+)$', key)
+        if match:
+            return f"user_{match.group(1)}"
+        return 'user_1'
+
     @property
     def extra_state_attributes(self) -> dict[str, Any] | None:
         """Return the state attributes."""
@@ -317,9 +335,7 @@ class OmronBluetoothSensorEntity(
         try:
             device_id = self._device_key.device_id
             if not device_id:
-                import re
-                match = re.search(r'_([0-9]+)$', str(self._device_key.key))
-                device_id = f"user_{match.group(1)}" if match else 'user_1'
+                device_id = self._resolve_user_id_from_key()
 
             if hasattr(self._omron_device_data, 'omron_extra_attributes'):
                 if device_id in self._omron_device_data.omron_extra_attributes:


### PR DESCRIPTION
This PR fixes a bug in `extra_state_attributes` when using `user_aliases`.

    ### Problem
    In multi-user setups where aliases (e.g., Nicks, Nata or Tom, Alice etc) are configured, the integration generates entity suffixes using the slugified aliases (e.g., `_nicks`, `_nata`).
    However, the `extra_state_attributes` property on `OmronBluetoothSensorEntity` attempted to extract the user index via regex: `re.search(r'_([0-9]+)$', str(self._device_key.key))`.
    This regex only matched numeric suffixes (like `_1`, `_2`), and therefore failed for alias-based suffixes, causing the integration to default to `user_1` for all user sensors (e.g., Nata's sensor received Nicks's TruRead
  attributes).

    ### Fix
    1. Added `_resolve_user_id_from_key` which performs a reverse-lookup through the `_user_aliases` dictionary using the slugified alias labels.
    2. Fallbacks to the numeric suffix regex `r'_(?:user)?([0-9]+)$'` and finally defaults to `user_1`.
    3. Updated `extra_state_attributes` to call `_resolve_user_id_from_key` when `self._device_key.device_id` is empty.