### PR TITLE
Add English translations for config flow UI.

### DIFF
--- a/custom_components/omron/translations/en.json
+++ b/custom_components/omron/translations/en.json
@@ -1,0 +1,82 @@
+{
+  "config": {
+    "flow_title": "{name}",
+    "step": {
+      "user": {
+        "description": "Choose a device to set up.",
+        "data": {
+          "address": "Device"
+        }
+      },
+      "bluetooth_confirm": {
+        "title": "Confirm Device",
+        "description": "To configure {name}, first put the device into pairing mode, then press Submit (Confirm)."
+      },
+      "select_model": {
+        "title": "Select Device Model",
+        "description": "If the Bluetooth advertisement name includes a known code (for example **HEM-7600T**), it is selected by default—confirm or change it. Otherwise choose the model printed on the cuff or in Omron Connect. The list has **{model_total}** entries: **{profile_count}** hardware profiles plus **{variant_count}** regional or bundle codes that share a profile. If your exact code is missing, pick the closest model; wrong EEPROM layouts show up as empty or bad readings—check the log for **profile=** lines.",
+        "data": {
+          "device_model": "Device Model",
+          "scan_interval": "Update Interval (seconds)"
+        }
+      },
+      "user_aliases": {
+        "title": "User names on the cuff",
+        "description": "This model stores **{num_users}** user profiles. Enter a short name for each (defaults: user1, user2, …). These names appear in sensor names and entity IDs instead of generic user numbers.",
+        "data": {
+          "user_alias_1": "User 1 name",
+          "user_alias_2": "User 2 name",
+          "user_alias_3": "User 3 name",
+          "user_alias_4": "User 4 name"
+        }
+      },
+      "pairing": {
+        "title": "Pair {model}",
+        "description": "Submit (Confirm) will start pairing from Home Assistant. First put the cuff in pairing mode—for most models, hold the Bluetooth button until **-P-** appears—then press Submit."
+      },
+      "pairing_os": {
+        "title": "Pair {model}",
+        "description": "Submit (Confirm) will start pairing from Home Assistant. First set the device to pairing or discoverable mode as in the manual, then press Submit."
+      }
+    },
+    "error": {
+      "pairing_failed": "Pairing failed. Make sure the device is in pairing mode (-P- on display) and try again.",
+      "decryption_failed": "The provided bindkey did not work, sensor data could not be decrypted. Please check it and try again.",
+      "expected_32_characters": "Expected a 32 character hexadecimal bindkey.",
+      "duplicate_user_aliases": "Each user slot must have a different name (case-insensitive)."
+    },
+    "abort": {
+      "reauth_successful": "Re-authentication was successful",
+      "no_devices_found": "No unconfigured devices found on the network",
+      "already_in_progress": "Configuration flow is already in progress",
+      "already_configured": "Device is already configured",
+      "not_supported": "This device is not supported."
+    }
+  },
+  "options": {
+    "step": {
+      "init": {
+        "title": "Omron Bluetooth",
+        "description": "How often Home Assistant should poll the blood pressure monitor for new readings (60–86400 seconds). Lower values use more battery on the cuff.\n\n**Profile slots on this device:** {num_users}. When there is more than one, set a display name per slot below (defaults user1, user2, …). Renaming a slot creates new sensor entities for that slot.",
+        "data": {
+          "scan_interval": "Update Interval (seconds)",
+          "user_alias_1": "User 1 name",
+          "user_alias_2": "User 2 name",
+          "user_alias_3": "User 3 name",
+          "user_alias_4": "User 4 name"
+        }
+      }
+    },
+    "error": {
+      "duplicate_user_aliases": "Each user slot must have a different name (case-insensitive)."
+    }
+  },
+  "entity": {
+    "text": {
+      "device_alias": {
+        "name": "Device nickname",
+        "description": "Optional note only; does not rename the device or change any IDs."
+      }
+    }
+  }
+}


### PR DESCRIPTION
Custom integrations load runtime strings from translations/*.json only; without en.json, non-Korean users saw raw translation keys during setup.