### PR TITLE
fix: restore extra_state_attributes across HA restarts

### DIFF
--- a/custom_components/omron/sensor.py
+++ b/custom_components/omron/sensor.py
@@ -304,6 +304,21 @@ class OmronBluetoothSensorEntity(
         last_state = await self.async_get_last_state()
         if last_state is None:
             return
+
+        # Restore custom attributes (like truread_details) across reboots
+        device_id = self._device_key.device_id
+        if not device_id:
+            device_id = self._resolve_user_id_from_key()
+
+        if not hasattr(self._omron_device_data, 'omron_extra_attributes'):
+            self._omron_device_data.omron_extra_attributes = {}
+        if device_id not in self._omron_device_data.omron_extra_attributes:
+            self._omron_device_data.omron_extra_attributes[device_id] = {}
+
+        for key in ['truread_details', 'measurement_type', 'improper_position']:
+            if key in last_state.attributes:
+                self._omron_device_data.omron_extra_attributes[device_id][key] = last_state.attributes[key]
+
         if last_state.state in (STATE_UNKNOWN, STATE_UNAVAILABLE, None):
             return
         self._restored_native_value = self._parse_restored_state_string(


### PR DESCRIPTION
### What is the problem?
Currently, when Home Assistant restarts, the integration correctly restores the native value of the sensors using `RestoreEntity`. However, the `async_added_to_hass` method in `sensor.py` does not restore `last_state.attributes`. As a result, custom attributes (like `measurement_type`, `truread_details`, and `improper_position`) are entirely lost on restart and remain absent until the next successful Bluetooth advertisement from the device.

### What does this PR do?
This PR adds missing logic to `OmronBluetoothSensorEntity.async_added_to_hass` to explicitly extract these attributes from `last_state.attributes` and persist them back into `self._omron_device_data.omron_extra_attributes` during integration startup, ensuring that recent measurement details (such as TruRead historical buffers) survive HA reboots.

### How to test
1. Take a normal or TruRead measurement with the Omron device.
2. Verify that the sensor entity has custom attributes populated (e.g. `truread_details` or `measurement_type`).
3. Restart Home Assistant.
4. Without taking a new measurement, verify that the sensor retained its custom attributes instead of losing them.