### PR TITLE
feat: drop OS bond after session for HEM-7380T1 AFib family

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.3.5"
+  "version": "2.3.6"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -564,6 +564,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         requires_unlock=False,
         supports_pairing=False,
         supports_os_bonding_only=True,
+        # Drop the bond after each session; a leftover bond is rejected on the
+        # next normal-mode connection.
+        unpair_after_session=True,
         endianness="little",
         user_start_addresses=[0x01C4, 0x0804],
         per_user_records_count=[100, 100],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -62,6 +62,10 @@ class DeviceConfig:
     # True: faster GATT refresh / RX→unlock timing for classic custom-key pairing. False: conservative defaults.
     # HEM-7380T1 uses OS bonding only; stays False.
     legacy_pairing_workarounds: bool = False
+    # Remove the OS-level bond at the end of every BLE session so the next
+    # connection starts bond-less. Needed for profiles that reject a leftover
+    # bond on normal-mode reconnect (HEM-7380T1 AFib family).
+    unpair_after_session: bool = False
 
     # EEPROM layout
     endianness: str = "big"

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -923,6 +923,25 @@ class GattTransport:
         _LOGGER.debug("Device paired successfully with new key")
         await asyncio.sleep(1.0)
 
+    async def unpair(self) -> None:
+        """Remove the OS-level bond for this device (best-effort).
+
+        Not all backends implement ``BleakClient.unpair``; unsupported ones
+        raise ``NotImplementedError``. All failures are swallowed so this
+        never breaks the surrounding teardown.
+        """
+        try:
+            await self._client.unpair()
+            _LOGGER.debug("Removed OS bond for %s after session", self._config.model)
+        except NotImplementedError:
+            _LOGGER.debug(
+                "unpair() not supported by this BLE backend for %s; "
+                "bond (if any) left in place",
+                self._config.model,
+            )
+        except Exception as exc:
+            _LOGGER.debug("unpair() failed for %s (ignored): %s", self._config.model, exc)
+
 
 def _decode_eeprom_time_payload(layout: str, cached: bytearray) -> dt.datetime:
     """Decode wall time from an EEPROM time-sync section (naive datetime)."""

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1260,6 +1260,13 @@ class OmronBluetoothDeviceData(BluetoothData):
                     except Exception:
                         pass
 
+                # Tear down the OS bond for profiles that must stay bond-less.
+                if (
+                    transport is not None
+                    and self._device_config.unpair_after_session
+                ):
+                    await transport.unpair()
+
                 if client and client.is_connected:
                     try:
                         await client.disconnect()


### PR DESCRIPTION
The AFib family (HEM-7380T1/7196/X7) only serves data in pairing mode and rejects a leftover OS bond on normal-mode reconnect, causing an auth error/disconnect. Add an unpair_after_session profile flag and tear down the bond at the end of every session so the next connection starts bond-less.