### PR TITLE
feat: add HEM-7155T-EBL variant and document HEM-7155T support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A custom integration for Home Assistant to connect and poll data directly from O
 | **HEM-6232T** | BP6350/RS7 Intelli IT | Wrist | ✅ |
 | **HEM-7142T2** | BP7150/M2 Intelli IT | Upper Arm | ✅ |
 | **HEM-7151T** | BP5250/M3 Comfort | Upper Arm | ✅ |
+| **HEM-7155T** | BP7350/M4 Intelli IT | Upper Arm | ✅ |
 | **HEM-7320T** | BP7450/M7 Intelli IT | Upper Arm | ✅ |
 | **HEM-7322T** | BP786/M6 Intelli IT | Upper Arm | ✅ |
 | **HEM-7343T** | BP5450/Platinum Series | Upper Arm | ✅ |

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.3.6"
+  "version": "2.4.0"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -375,6 +375,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             DeviceModelVariant("HEM-7155T-ALRU", unverified=False),
             DeviceModelVariant("HEM-7155T-D", unverified=False),
             DeviceModelVariant("HEM-7155T-EBK", unverified=False),
+            DeviceModelVariant("HEM-7155T-EBL", unverified=False),
             DeviceModelVariant("HEM-7155T_AP", unverified=False),
             DeviceModelVariant("HEM-7155T_ASH3BK", unverified=False),
             DeviceModelVariant("HEM-7155T_ASH3SL", unverified=False),


### PR DESCRIPTION
Add the HEM-7155T-EBL regional variant to the device catalog so setup auto-detects and lists it correctly. Document HEM-7155T (BP7350/M4 Intelli IT) in the README supported models table. Bump version to 2.4.0.