### PR TITLE
fix: correct HEM-7600T time_sync_layout to classic_mixed

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.4.2"
+  "version": "2.4.3"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -163,7 +163,8 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0286,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
-        time_sync_layout="eeprom_time_linear_10",
+        # classic-mixed field order (confirmed from HEM-7600T-E EEPROM dumps)
+        time_sync_layout="eeprom_time_classic_mixed",
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",


### PR DESCRIPTION
The HEM-7600T profile used eeprom_time_linear_10, but the device's actual EEPROM time-sync section is in classic-mixed field order (month, year, hour, day, second, minute).  Decoding live HEM-7600T-E dumps confirms this: linear_10 yields invalid values (month=26 etc.), while classic_mixed yields valid timestamps.

With the wrong layout the device time can't be parsed, so the integration treats it as out-of-sync and attempts a time WRITE.  That write targets the TX characteristic (db5b55e0) which the ESP32 proxy's stale cache reports as "not found", leaving the session broken (error 229 on close). With the correct layout an already-synced device skips the write entirely.

Manifest 2.4.2 -> 2.4.3.