### PR TITLE
fix: use bit-packed record parser for HEM-7600T; rename parser

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.4.3"
+  "version": "2.4.4"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -132,7 +132,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_7322_family",
+        record_parser="classic_vital_14_bitpacked",
         equivalent_model_ids=(
             DeviceModelVariant("HEM-7321T-CA", unverified=False),
             DeviceModelVariant("HEM-7321T_TI-CA", unverified=False),
@@ -172,7 +172,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        # bit-packed big-endian record layout (confirmed from HEM-7600T-E:
+        # byte-aligned classic_vital_14 yielded dia>sys / bpm=26 / no date)
+        record_parser="classic_vital_14_bitpacked",
         equivalent_model_ids=(
             DeviceModelVariant("HEM-7270C", unverified=False),
             DeviceModelVariant("HEM-7271T", unverified=False),

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -23,7 +23,7 @@ from .record_parsers import (
     parse_classic_vital_14,
     parse_classic_vital_16_6401_family,
     parse_classic_vital_14_6232_family,
-    parse_classic_vital_14_7322_family,
+    parse_classic_vital_14_bitpacked,
 )
 
 
@@ -131,7 +131,7 @@ class DeviceConfig:
         parser_map = {
             "classic_vital_14": parse_classic_vital_14,
             "classic_vital_16_6401_family": parse_classic_vital_16_6401_family,
-            "classic_vital_14_7322_family": parse_classic_vital_14_7322_family,
+            "classic_vital_14_bitpacked": parse_classic_vital_14_bitpacked,
             "classic_vital_14_6232_family": parse_classic_vital_14_6232_family,
         }
         parser = parser_map.get(self.record_parser)

--- a/custom_components/omron/omron_ble/record_parsers.py
+++ b/custom_components/omron/omron_ble/record_parsers.py
@@ -20,10 +20,15 @@ def _bytearray_bits_to_int(
     return shifted & bitmask
 
 
-def parse_classic_vital_14_7322_family(
+def parse_classic_vital_14_bitpacked(
     data: bytes | bytearray, endianness: str
 ) -> dict[str, Any]:
-    """Classic 14-byte parser for HEM-7322T family."""
+    """Classic 14-byte bit-packed vital record (big-endian bitfields).
+
+    Unlike ``parse_classic_vital_14`` (byte-aligned fields), this layout packs
+    sys/dia/bpm/date into a continuous bitfield read big-endian.  Used by the
+    HEM-7322T and HEM-7600T families.
+    """
     record: dict[str, Any] = {}
     record["dia"] = _bytearray_bits_to_int(data, endianness, 0, 7)
     record["sys"] = _bytearray_bits_to_int(data, endianness, 8, 15) + 25


### PR DESCRIPTION
HEM-7600T-E records decoded as garbage under classic_vital_14 (byte-aligned): dia>sys, bpm=26, no valid date. The device actually uses the bit-packed big-endian layout — the latest record decodes to sys=145, dia=91, bpm=72, 2026-06-14 23:45 under that parser. Point the HEM-7600T profile at it.

Also rename parse_classic_vital_14_7322_family ->
parse_classic_vital_14_bitpacked (and the "classic_vital_14_7322_family" profile key -> "classic_vital_14_bitpacked"): the layout is a generic bit-packed big-endian format shared by the HEM-7322T and HEM-7600T families, so a format-descriptive name is clearer than a single model number. HEM-7322T profile updated to the new key; no other references.

Manifest 2.4.3 -> 2.4.4.