### PR TITLE
fix: correct second-user index cursor offset for HEM-7155T-ESL

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.7"
+  "version": "2.5.8"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -551,9 +551,13 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
+            # Index entries are 8 bytes per user (uint32 write cursor + uint32
+            # unread counter), confirmed via HCI btsnoop of HEM-7155T-ESL:
+            # user1 cursor at 0x00, user2 cursor at 0x08 (NOT 0x02 — that offset
+            # lands in the high half of user1's word and reads the 0x80 flag).
             "users": [
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
-                {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
+                {"write_cursor_offset": 0x08, "unread_counter_offset": 0x0C, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
         record_parser="classic_vital_14",


### PR DESCRIPTION
The HEM-7155T-ESL ("X4 Smart") index block stores 8 bytes per user (uint32 write cursor + uint32 unread counter): user1 cursor at 0x00, user2 cursor at 0x08. The profile read user2 at 0x02, which lands in the high half of user1's word (the 0x80 flag byte), so it always masked to 0 and resolved to slot 59 — an empty slot — making the integration report both users as empty and skip the readout.

Verified against an HCI capture: the device reads user1 records at the slots the 0x00 cursor predicts (parsing to valid measurements), and the 0x08 offset yields a sane, incrementing user2 cursor where 0x02 stays stuck on the flag byte. Bump to v2.5.8.