### PR TITLE
fix: recover from stale OS bond (AuthenticationFailed) on HEM-7380T1

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.9"
+  "version": "2.5.10"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -694,6 +694,10 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7380T1",
         unlock_mode=UnlockMode.TOKEN_KEY,
+        # AFib family rotates its LTK each session; re-pairing on every
+        # pairing-mode advertisement churns the bond → AuthenticationFailed.
+        # Bond once at setup, then rely on the existing bond for polls.
+        os_bond_once=True,
         endianness="little",
         user_start_addresses=[0x01C4, 0x0804],
         per_user_records_count=[100, 100],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -72,6 +72,13 @@ class DeviceConfig:
     # Enable more aggressive GATT timing for classic custom-key profiles
     # (extra refresh/retry and pre-unlock 0x02 probe).
     aggressive_gatt_timing: bool = False
+    # When True, OS-level bonding is established only once (at config-flow
+    # setup); subsequent pairing-mode advertisements do NOT re-pair — polls
+    # rely on the existing bond + BlueZ on-demand encryption instead.  Repeated
+    # explicit pair() calls churn the bond on devices that rotate their LTK each
+    # session (HEM-7380T1 AFib family), producing org.bluez AuthenticationFailed
+    # on every reconnect.  Only meaningful for host_pairing_mode=OS_BONDING.
+    os_bond_once: bool = False
 
     # EEPROM layout
     endianness: str = "big"

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -253,6 +253,63 @@ async def _bluez_agent_pair(client: BleakClient) -> bool:
         bus.disconnect()
 
 
+async def _bluez_remove_device(client: BleakClient) -> bool:
+    """Remove the BlueZ device and its bond via ``Adapter1.RemoveDevice``.
+
+    BlueZ persists bonds under ``/var/lib/bluetooth`` across reboots, so a
+    stale/rotated bond cannot be cleared by reconnecting or rebooting — it
+    must be explicitly removed.  ``BleakClient.unpair()`` is not implemented
+    on every backend (notably the HA/habluetooth BlueZ wrapper), so go
+    straight to BlueZ over DBus (same transport used by the pairing agent).
+
+    Returns True if RemoveDevice succeeded; False on any failure or when the
+    DBus path is unavailable (caller should fall back to ``unpair()``).
+    """
+    try:
+        from dbus_fast.aio.message_bus import MessageBus
+        from dbus_fast.constants import BusType, MessageType
+        from dbus_fast.message import Message
+    except ImportError:
+        return False
+
+    details = getattr(getattr(client, "_device", None), "details", None) or {}
+    device_path: str | None = details.get("path")
+    if not device_path:
+        backend = getattr(client, "_backend", None)
+        device_path = getattr(getattr(backend, "_device", None), "path", None)
+    if not device_path or "/dev_" not in device_path:
+        return False
+    # Adapter path is the device path minus the trailing dev_XX_.. segment.
+    adapter_path = device_path.rsplit("/", 1)[0]
+
+    try:
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+    except Exception as exc:
+        _LOGGER.debug("BlueZ RemoveDevice: cannot connect to system bus: %s", exc)
+        return False
+    try:
+        reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path=adapter_path,
+                interface="org.bluez.Adapter1",
+                member="RemoveDevice",
+                signature="o",
+                body=[device_path],
+            )
+        )
+        ok = reply.message_type == MessageType.METHOD_RETURN
+        _LOGGER.debug(
+            "BlueZ RemoveDevice(%s) -> %s", device_path, "ok" if ok else reply
+        )
+        return ok
+    except Exception as exc:
+        _LOGGER.debug("BlueZ RemoveDevice failed for %s: %s", device_path, exc)
+        return False
+    finally:
+        bus.disconnect()
+
+
 def _is_non_fatal_os_pairing_error(exc: BaseException) -> bool:
     """Whether an OS-level BLE pairing exception can be safely ignored.
 
@@ -280,6 +337,30 @@ def _is_non_fatal_os_pairing_error(exc: BaseException) -> bool:
         "in progress",
     )
     return any(marker in msg for marker in non_fatal_markers)
+
+
+def _is_stale_bond_auth_error(exc: BaseException) -> bool:
+    """Whether a bonding failure looks like a stale/rotated bond.
+
+    Some Omron AFib devices (notably the HEM-7380T1 family) do not retain
+    their pairing bond across disconnects — they rotate or discard the LTK
+    after each session.  The host's stored bond then no longer matches, so
+    BlueZ rejects re-encryption/re-pairing with ``AuthenticationFailed`` (the
+    link never gets encrypted and later GATT ops fail with ``NotConnected``).
+    This is the signature of "works once right after a fresh bond, then fails
+    on every subsequent connection"; removing the stale bond and re-pairing
+    from a clean slate recovers the device.
+    """
+    msg = str(exc).lower()
+    return any(
+        marker in msg
+        for marker in (
+            "authenticationfailed",
+            "authentication failed",
+            "authenticationrejected",
+            "authentication rejected",
+        )
+    )
 
 
 def _log_pairing_failure_detail(prefix: str, exc: BaseException) -> None:
@@ -1201,6 +1282,7 @@ class OmronDeviceSession:
         _LOGGER.debug("Performing OS-level BLE bonding")
         max_attempts = 2
         last_exc: BaseException | None = None
+        stale_bond_cleared = False
 
         async def _post_bond_refresh() -> None:
             try:
@@ -1225,6 +1307,31 @@ class OmronDeviceSession:
                 return
             except Exception as exc:
                 last_exc = exc
+                # Stale/rotated bond (HEM-7380T1 AFib family): the device
+                # discarded its LTK, so the stored bond no longer matches and
+                # BlueZ raises AuthenticationFailed.  Treating this as
+                # "non-fatal" and continuing leaves the link unencrypted, so the
+                # session then dies with NotConnected.  Instead remove the stale
+                # bond once; RemoveDevice also drops the link, so re-pairing
+                # in-place is impossible — raise and let the next connection
+                # re-pair from a clean slate (self-heals on the following poll).
+                if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
+                    stale_bond_cleared = True
+                    _LOGGER.warning(
+                        "OS-level bonding rejected (%s) for %s — removing stale "
+                        "bond so the next connection can re-pair cleanly",
+                        type(exc).__name__,
+                        self._config.model,
+                    )
+                    # Prefer BlueZ RemoveDevice over DBus (authoritative, works
+                    # even when the backend's unpair() is a no-op); fall back to
+                    # BleakClient.unpair() for non-BlueZ backends.
+                    if not await _bluez_remove_device(self._client):
+                        await self.unpair()
+                    raise ConnectionError(
+                        "Stale BLE bond removed after AuthenticationFailed; "
+                        "retry the poll to re-pair"
+                    ) from exc
                 if _is_non_fatal_os_pairing_error(exc):
                     _LOGGER.warning(
                         "OS-level bonding returned non-fatal error on attempt %d/%d: %s (%r)",

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1252,7 +1252,19 @@ class OmronBluetoothDeviceData(BluetoothData):
                     f"Required service {self._device_config.parent_service_uuid} "
                     f"not found on device {ble_device.address}"
                 )
-            await session.pair()
+            if self._device_config.os_bond_once:
+                # Bond-once profiles (HEM-7380T1 AFib): never re-pair on a
+                # pairing-mode advertisement — the device is already bonded from
+                # config-flow setup and an explicit re-pair churns the bond into
+                # an AuthenticationFailed state. Refresh + time-sync only; the
+                # post-trigger poll reads records over the existing bond.
+                _LOGGER.debug(
+                    "Skipping OS re-pair for %s (os_bond_once): using existing "
+                    "bond + on-demand encryption",
+                    self._device_config.model,
+                )
+            else:
+                await session.pair()
             await session.refresh_services()
             await async_sync_device_time(
                 session.client,


### PR DESCRIPTION
The HEM-7380T1 AFib family rotates/discards its LTK after each session, so the host's stored BlueZ bond goes stale. On reconnect BlueZ rejects re-encryption with org.bluez.Error.AuthenticationFailed; the link stays unencrypted and the memory session then fails with NotConnected. The device "works once right after a fresh bond, then fails on every subsequent connection" — and the stale bond persists across reboots, so no integration version recovers without actively clearing it.

_pair_os_bonding previously swallowed AuthenticationFailed as "non-fatal" and returned, leaving the stale bond in place. Now:

- _is_stale_bond_auth_error(): classify AuthenticationFailed/Rejected.
- _bluez_remove_device(): authoritative Adapter1.RemoveDevice over DBus (BleakClient.unpair() is a no-op on the HA/habluetooth BlueZ backend), with unpair() fallback for non-BlueZ backends.
- On the stale-bond signature, remove the bond once and raise so the next connection re-pairs from a clean slate (self-heals on the following poll).

Bump version to 2.5.10.