### PR TITLE
diag: log connection proxy/source and is_connected across the bond se…

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.11"
+  "version": "2.5.12"
 }

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -84,6 +84,24 @@ async def _bleak_clear_cache(client: BleakClient) -> bool:
         return False
 
 
+def _connection_source(ble_device: BLEDevice) -> str:
+    """Best-effort identifier of the proxy/adapter routing this connection.
+
+    habluetooth records the connectable scanner in ``BLEDevice.details``
+    (``source`` = the ESPHome proxy / local adapter address). BLE bonds are
+    stored per-proxy, so a connection made through a proxy that did NOT bond
+    the device can be rejected/dropped by the device — logging the source lets
+    us correlate failed connections with a non-bonded proxy.
+    """
+    details = getattr(ble_device, "details", None)
+    if isinstance(details, dict):
+        for key in ("source", "scanner", "path"):
+            val = details.get(key)
+            if val:
+                return str(val)
+    return "unknown"
+
+
 async def establish_connection_with_bond_settle(
     ble_device: BLEDevice, name: str
 ) -> BleakClient:
@@ -95,14 +113,24 @@ async def establish_connection_with_bond_settle(
     calling ``establish_connection`` directly so the bond-settle behaviour
     is consistent.
     """
+    source = _connection_source(ble_device)
+    _LOGGER.debug("Connecting to %s via proxy/source=%s", name, source)
     client = await establish_connection(BleakClient, ble_device, name)
     _LOGGER.debug(
-        "BLE link established to %s; settling %.1fs for bonding/encryption "
-        "before first GATT op",
+        "BLE link established to %s via source=%s (is_connected=%s); settling "
+        "%.1fs for bonding/encryption before first GATT op",
         name,
+        source,
+        getattr(client, "is_connected", "?"),
         _POST_CONNECT_BOND_SETTLE_SEC,
     )
     await asyncio.sleep(_POST_CONNECT_BOND_SETTLE_SEC)
+    _LOGGER.debug(
+        "Post-settle state for %s via source=%s: is_connected=%s",
+        name,
+        source,
+        getattr(client, "is_connected", "?"),
+    )
     await _bleak_refresh_services(client)
     return client
 


### PR DESCRIPTION
…ttle

Modern-stack Omron devices over multiple ESPHome BLE proxies intermittently fail discovery with "Required service fe4a not on <addr>", and a follow-up clear_cache reports the device "is not connected" — i.e. the device dropped the link before/around GATT discovery. BLE bonds are stored per-proxy, so a strong hypothesis is that habluetooth routed the connection through a proxy that did not bond the device, which the device then rejects.

Add diagnostics to confirm where/why the link dies:

- _connection_source(): best-effort proxy/adapter id from BLEDevice.details.
- establish_connection_with_bond_settle: log the source at connect attempt, the source + is_connected right after the link is established, and is_connected again after the 1.5s settle — so the logs show which proxy was used and whether the device dropped during the settle vs during discovery.

Bump version to 2.5.12.