### PR TITLE
feat: add ConnectType, enum-ize category fields, unpair-after-session…

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.14"
+  "version": "2.5.15"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -2,7 +2,15 @@
 from __future__ import annotations
 
 from .const import MODERN_STACK_PARENT_SERVICE_UUID
-from .devices import DeviceConfig, HostPairingMode, UnlockMode
+from .devices import (
+    ConnectType,
+    DeviceConfig,
+    Endianness,
+    HostPairingMode,
+    RecordParser,
+    TimeSyncLayout,
+    UnlockMode,
+)
 
 _MODERN_OS_BONDING_BASE = {
     "parent_service_uuid": MODERN_STACK_PARENT_SERVICE_UUID,
@@ -14,7 +22,7 @@ _MODERN_OS_BONDING_BASE = {
 CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-6320T": DeviceConfig(
         model="HEM-6320T",
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x0370],
         per_user_records_count=[100],
         record_byte_size=0x0E,
@@ -23,7 +31,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0F9A,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
-        time_sync_layout="eeprom_time_linear_10",
+        time_sync_layout=TimeSyncLayout.LINEAR_10,
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",
@@ -31,14 +39,14 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-6320T-Z",
         ),
     ),
     "HEM-6321T": DeviceConfig(
         model="HEM-6321T",
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x0370, 0x08E8],
         per_user_records_count=[100, 100],
         record_byte_size=0x0E,
@@ -47,7 +55,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0F9A,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
-        time_sync_layout="eeprom_time_linear_10",
+        time_sync_layout=TimeSyncLayout.LINEAR_10,
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",
@@ -56,14 +64,14 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-6321T-Z",
         ),
     ),
     "HEM-6401T": DeviceConfig(
         model="HEM-6401T",
-        endianness="little",
+        endianness=Endianness.LITTLE,
         # HEM-6401T exposes multiple data types; only the BP data_5 area is mapped here.
         user_start_addresses=[0x1350],
         per_user_records_count=[100],
@@ -73,7 +81,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0160,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x10, 0x20],
-        time_sync_layout="eeprom_time_hem6401_prefix",
+        time_sync_layout=TimeSyncLayout.HEM6401_PREFIX,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -81,7 +89,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x06, "unread_counter_offset": 0x0E, "write_cursor_mask": 0xFFFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": 0},
             ],
         },
-        record_parser="classic_vital_16_6401_family",
+        record_parser=RecordParser.CLASSIC_VITAL_16_6401_FAMILY,
         equivalent_model_ids=(
             "HEM-6401T-Z",
             "HEM-6402T-Z",
@@ -90,7 +98,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7320T": DeviceConfig(
         model="HEM-7320T",
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02AC, 0x05F4],
         per_user_records_count=[60, 60],
         record_byte_size=0x0E,
@@ -99,7 +107,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0286,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
-        time_sync_layout="eeprom_time_linear_10",
+        time_sync_layout=TimeSyncLayout.LINEAR_10,
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",
@@ -108,7 +116,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-7320T-CA",
             "HEM-7320T-CACS",
@@ -120,8 +128,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7322T": DeviceConfig(
         model="HEM-7322T",
+        connect_type=ConnectType.WLB1_0,
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02AC, 0x0824],
         per_user_records_count=[100, 100],
         record_byte_size=0x0E,
@@ -130,7 +139,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0286,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
-        time_sync_layout="eeprom_time_classic_mixed",
+        time_sync_layout=TimeSyncLayout.CLASSIC_MIXED,
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",
@@ -139,7 +148,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-7321T-CA",
             "HEM-7321T_TI-CA",
@@ -161,7 +170,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7600T": DeviceConfig(
         model="HEM-7600T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02AC],
         per_user_records_count=[100],
         record_byte_size=0x0E,
@@ -171,7 +180,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x14, 0x1E],
         # classic-mixed field order (confirmed from HEM-7600T-E EEPROM dumps)
-        time_sync_layout="eeprom_time_classic_mixed",
+        time_sync_layout=TimeSyncLayout.CLASSIC_MIXED,
         index_pointer_layout={
             "index_region_byte_size": 0x08,
             "endianness": "big",
@@ -181,7 +190,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         },
         # bit-packed big-endian record layout (confirmed from HEM-7600T-E:
         # byte-aligned classic_vital_14 yielded dia>sys / bpm=26 / no date)
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-7270C",
             "HEM-7271T",
@@ -204,7 +213,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-6232T": DeviceConfig(
         model="HEM-6232T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02E8, 0x0860],
         per_user_records_count=[100, 100],
         record_byte_size=0x0E,
@@ -213,7 +222,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=[0x00, 0x08],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_classic_offset8",
+        time_sync_layout=TimeSyncLayout.CLASSIC_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -222,7 +231,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_6232_family",
+        record_parser=RecordParser.CLASSIC_VITAL_14_6232_FAMILY,
         equivalent_model_ids=(
             "HEM-1026T2-AJC",
             "HEM-1026T2-AJE",
@@ -242,7 +251,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7530T": DeviceConfig(
         model="HEM-7530T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
         per_user_records_count=[90],
         record_byte_size=0x0E,
@@ -253,7 +262,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # field order (same 16-byte block as HEM-6232T, not modern linear order).
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_classic_offset8",
+        time_sync_layout=TimeSyncLayout.CLASSIC_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -263,7 +272,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         },
         # bit-packed record layout (confirmed from HEM-6161T-RU; byte-aligned
         # classic_vital_14 yields bpm=26 and no valid datetime on this family).
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-6231T2-JC",
             "HEM-6231T2-JE",
@@ -283,7 +292,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-6161T": DeviceConfig(
         model="HEM-6161T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
         per_user_records_count=[30],
         record_byte_size=0x0E,
@@ -292,7 +301,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_classic_offset8",
+        time_sync_layout=TimeSyncLayout.CLASSIC_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -300,7 +309,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-6161T-E",
             "HEM-6161T-RU",
@@ -312,7 +321,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7136T": DeviceConfig(
         model="HEM-7136T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
         per_user_records_count=[60],
         record_byte_size=0x0E,
@@ -321,7 +330,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_classic_offset8",
+        time_sync_layout=TimeSyncLayout.CLASSIC_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -329,7 +338,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-7136T-SH3",
             "HEM-7138JT-SH",
@@ -341,7 +350,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-6231T": DeviceConfig(
         model="HEM-6231T",
         aggressive_gatt_timing=True,
-        endianness="big",
+        endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
         per_user_records_count=[100],
         record_byte_size=0x0E,
@@ -350,7 +359,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_classic_offset8",
+        time_sync_layout=TimeSyncLayout.CLASSIC_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -358,7 +367,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14_bitpacked",
+        record_parser=RecordParser.CLASSIC_VITAL_14_BITPACKED,
         equivalent_model_ids=(
             "HEM-6231T-SH",
             "HEM-6231T_Z",
@@ -367,7 +376,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7150T": DeviceConfig(
         model="HEM-7150T",
         aggressive_gatt_timing=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
         per_user_records_count=[60],
         record_byte_size=0x10,
@@ -376,7 +385,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=[0x00, 0x10],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -384,7 +393,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-7150T-CA",
             "HEM-7150T-Z",
@@ -403,7 +412,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7151T": DeviceConfig(
         model="HEM-7151T",
         aggressive_gatt_timing=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
         per_user_records_count=[80],
         record_byte_size=0x10,
@@ -412,7 +421,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=[0x00, 0x10],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -420,15 +429,16 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 79, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-7151T-Z",
         ),
     ),
     "HEM-7155T": DeviceConfig(
         model="HEM-7155T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x0458],
         per_user_records_count=[60, 60],
         record_byte_size=0x10,
@@ -437,7 +447,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=[0x00, 0x10],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -446,7 +456,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-7155T-ALRU",
             "HEM-7155T-D",
@@ -467,8 +477,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7155T-MW": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7155T-MW",
+        connect_type=ConnectType.WLS3_0,
         unlock_mode=UnlockMode.NONE,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x0458],
         per_user_records_count=[60, 60],
         record_byte_size=0x10,
@@ -480,7 +491,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # 0x0010, time bytes [0x2C, 0x3C], modern offset8 layout). Addresses
         # match the classic HEM-7155T V1 profile exactly.
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -489,15 +500,16 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
     ),
     # HEM-7155T K4 — modern stack, MW3 EEPROM layout, no secure session.
     "HEM-7155T-K4": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7155T-K4",
+        connect_type=ConnectType.WLD2_0,
         unlock_mode=UnlockMode.NONE,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8, 0x06A8],
         per_user_records_count=[60, 60],
         record_byte_size=0x10,
@@ -506,7 +518,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -515,7 +527,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7155T_K4-D",
@@ -536,8 +548,10 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7155T-MW3": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7155T-MW3",
+        # Modern-fe4a-firmware HEM-7155T_ESL ("X4 Smart"); WLD3.0 like 7380T1.
+        connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8, 0x06A8],
         per_user_records_count=[60, 60],
         record_byte_size=0x10,
@@ -550,7 +564,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # 7155T family) so it applies unchanged. EEPROM sync runs before CTS and
         # falls back to it, so CTS still works if these offsets are wrong.
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -563,7 +577,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x08, "unread_counter_offset": 0x0C, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             # HEM-7155T_ESL1 ("X4 Smart", modern firmware): modern FE4A stack
@@ -578,8 +592,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7146T": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7146T",
+        connect_type=ConnectType.WLD1_0,
         unlock_mode=UnlockMode.NONE,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8],
         per_user_records_count=[30],
         record_byte_size=0x0E,
@@ -588,7 +603,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -596,7 +611,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7143T1-AIN",
@@ -620,7 +635,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7342T": DeviceConfig(
         model="HEM-7342T",
         aggressive_gatt_timing=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x06D8],
         per_user_records_count=[100, 100],
         record_byte_size=0x10,
@@ -629,7 +644,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=[0x00, 0x10],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -638,7 +653,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(
             "HEM-7159T_AP3",
             "HEM-7342T-CA",
@@ -670,7 +685,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7361T": DeviceConfig(
         model="HEM-7361T",
         aggressive_gatt_timing=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x06D8],
         per_user_records_count=[100, 100],
         record_byte_size=0x10,
@@ -679,7 +694,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=[0x00, 0x10],
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
@@ -688,17 +703,18 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
     ),
     "HEM-7380T1": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7380T1",
+        connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
         # AFib family rotates its LTK each session; re-pairing on every
         # pairing-mode advertisement churns the bond → AuthenticationFailed.
         # Bond once at setup, then rely on the existing bond for polls.
         os_bond_once=True,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0804],
         per_user_records_count=[100, 100],
         record_byte_size=0x10,
@@ -707,7 +723,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x0054,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x18,
             "endianness": "little",
@@ -716,7 +732,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
                 {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 99, "slot_index_bias": -1},
             ],
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7183T1-AP",
@@ -757,8 +773,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-7142T2": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7142T2",
+        connect_type=ConnectType.WLD1_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        endianness="little",
+        endianness=Endianness.LITTLE,
         # Single on-device measurement buffer region for this profile.
         user_start_addresses=[0x02E8],
         per_user_records_count=[14],
@@ -768,7 +785,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         settings_write_address=0x02A4,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout="eeprom_time_modern_offset8",
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "big",
@@ -782,7 +799,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "record_byte_size": 0x0E,
             "record_step": 0x0E,
         },
-        record_parser="classic_vital_14",
+        record_parser=RecordParser.CLASSIC_VITAL_14,
         prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7138K-SH",

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass, field, replace
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 _LOGGER = logging.getLogger(__name__)
@@ -51,12 +51,50 @@ class HostPairingMode(str, Enum):
     NONE = "none"
 
 
+class ConnectType(StrEnum):
+    """OMRON communication type; groups devices by BLE bonding/transfer behaviour."""
+
+    UNKNOWN = ""
+    WLB1_0 = "WLB1.0"
+    WLD1_0 = "WLD1.0"
+    WLD2_0 = "WLD2.0"
+    WLD3_0 = "WLD3.0"
+    WLS3_0 = "WLS3.0"
+
+
+class Endianness(StrEnum):
+    """Byte order for EEPROM/record decoding."""
+
+    BIG = "big"
+    LITTLE = "little"
+
+
+class RecordParser(StrEnum):
+    """Record-decoder selector (see record_parsers)."""
+
+    CLASSIC_VITAL_14 = "classic_vital_14"
+    CLASSIC_VITAL_16_6401_FAMILY = "classic_vital_16_6401_family"
+    CLASSIC_VITAL_14_BITPACKED = "classic_vital_14_bitpacked"
+    CLASSIC_VITAL_14_6232_FAMILY = "classic_vital_14_6232_family"
+
+
+class TimeSyncLayout(StrEnum):
+    """EEPROM time-sync field layout selector."""
+
+    LINEAR_10 = "eeprom_time_linear_10"
+    CLASSIC_MIXED = "eeprom_time_classic_mixed"
+    CLASSIC_OFFSET8 = "eeprom_time_classic_offset8"
+    MODERN_OFFSET8 = "eeprom_time_modern_offset8"
+    HEM6401_PREFIX = "eeprom_time_hem6401_prefix"
+
+
 @dataclass
 class DeviceConfig:
     """Configuration for a specific Omron device model."""
 
     # Device identity
     model: str
+    connect_type: ConnectType = ConnectType.UNKNOWN
 
     # BLE channel configuration
     parent_service_uuid: str = CLASSIC_STACK_PARENT_SERVICE_UUID
@@ -72,16 +110,12 @@ class DeviceConfig:
     # Enable more aggressive GATT timing for classic custom-key profiles
     # (extra refresh/retry and pre-unlock 0x02 probe).
     aggressive_gatt_timing: bool = False
-    # When True, OS-level bonding is established only once (at config-flow
-    # setup); subsequent pairing-mode advertisements do NOT re-pair — polls
-    # rely on the existing bond + BlueZ on-demand encryption instead.  Repeated
-    # explicit pair() calls churn the bond on devices that rotate their LTK each
-    # session (HEM-7380T1 AFib family), producing org.bluez AuthenticationFailed
-    # on every reconnect.  Only meaningful for host_pairing_mode=OS_BONDING.
+    # Bond once at setup and never re-pair on pairing-mode adverts (avoids bond
+    # churn). Only meaningful for host_pairing_mode=OS_BONDING.
     os_bond_once: bool = False
 
     # EEPROM layout
-    endianness: str = "big"
+    endianness: Endianness = Endianness.BIG
     user_start_addresses: list[int] = field(default_factory=list)
     per_user_records_count: list[int] = field(default_factory=list)
     record_byte_size: int = 0x0E
@@ -98,11 +132,11 @@ class DeviceConfig:
     # - eeprom_time_modern_offset8: [8:14] = [year-2000, month, day, hour, minute, second]
     # - eeprom_time_classic_offset8: [8:14] = [month, year-2000, hour, day, second, minute]
     # - eeprom_time_hem6401_prefix: [0:6] = [year-2000, month, day, hour, minute, second] in 16-byte block
-    time_sync_layout: str | None = None
+    time_sync_layout: TimeSyncLayout | None = None
     index_pointer_layout: dict[str, Any] | None = None
 
     # Record layout key -> parser in parse_record()
-    record_parser: str = "classic_vital_14"
+    record_parser: RecordParser = RecordParser.CLASSIC_VITAL_14
     # When True, pick latest record by highest EEPROM slot index, then datetime (index-pointer devices).
     prefer_latest_by_slot_index: bool = False
     equivalent_model_ids: tuple[str, ...] = ()
@@ -181,21 +215,21 @@ class DeviceConfig:
             and self.settings_write_address is not None
         )
 
-    def resolved_time_sync_layout(self) -> str:
+    def resolved_time_sync_layout(self) -> TimeSyncLayout:
         """Return effective EEPROM time-layout key for this profile."""
         if self.time_sync_layout is not None:
             return self.time_sync_layout
         if self.settings_time_sync_bytes == [0x2C, 0x3C]:
-            return "eeprom_time_modern_offset8"
-        return "eeprom_time_classic_mixed"
+            return TimeSyncLayout.MODERN_OFFSET8
+        return TimeSyncLayout.CLASSIC_MIXED
 
     def parse_record(self, data: bytes | bytearray) -> dict[str, Any]:
         """Parse a single record using the device-specific parser."""
         parser_map = {
-            "classic_vital_14": parse_classic_vital_14,
-            "classic_vital_16_6401_family": parse_classic_vital_16_6401_family,
-            "classic_vital_14_bitpacked": parse_classic_vital_14_bitpacked,
-            "classic_vital_14_6232_family": parse_classic_vital_14_6232_family,
+            RecordParser.CLASSIC_VITAL_14: parse_classic_vital_14,
+            RecordParser.CLASSIC_VITAL_16_6401_FAMILY: parse_classic_vital_16_6401_family,
+            RecordParser.CLASSIC_VITAL_14_BITPACKED: parse_classic_vital_14_bitpacked,
+            RecordParser.CLASSIC_VITAL_14_6232_FAMILY: parse_classic_vital_14_6232_family,
         }
         parser = parser_map.get(self.record_parser)
         if parser is None:
@@ -211,6 +245,11 @@ class DeviceConfig:
     def is_classic_stack(self) -> bool:
         """Whether this profile uses the classic 1812 parent-service layout."""
         return not self.is_modern_stack
+
+    @property
+    def unpair_after_session(self) -> bool:
+        """Drop the OS bond after each session (WLD3.0 devices re-key per session)."""
+        return self.connect_type == ConnectType.WLD3_0
 
     def is_service_compatible(self, service_uuids: list[str]) -> bool:
         """Check whether advertised GATT services match this profile's parent service."""

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -72,13 +72,9 @@ async def _bleak_refresh_services(client: BleakClient) -> None:
 
 
 async def _bleak_clear_cache(client: BleakClient) -> bool:
-    """Drop the backend/proxy GATT service cache so the next discovery is fresh.
+    """Force-drop the backend/proxy GATT cache (a stale cache can hide fe4a).
 
-    A plain ``get_services()`` refresh can keep returning a stale cached
-    service list — notably over an ESP32 (bleak_esphome) proxy — which hides
-    the modern-stack ``fe4a`` service even though the device exposes it. This
-    forces the cache to be discarded; unsupported backends (no ``clear_cache``)
-    are a safe no-op.
+    No-op on backends without ``clear_cache``.
     """
     cc = getattr(client, "clear_cache", None)
     if not callable(cc):
@@ -92,14 +88,7 @@ async def _bleak_clear_cache(client: BleakClient) -> bool:
 
 
 def _connection_source(ble_device: BLEDevice) -> str:
-    """Best-effort identifier of the proxy/adapter routing this connection.
-
-    habluetooth records the connectable scanner in ``BLEDevice.details``
-    (``source`` = the ESPHome proxy / local adapter address). BLE bonds are
-    stored per-proxy, so a connection made through a proxy that did NOT bond
-    the device can be rejected/dropped by the device — logging the source lets
-    us correlate failed connections with a non-bonded proxy.
-    """
+    """Best-effort proxy/adapter id (BLEDevice.details source) for connection logs."""
     details = getattr(ble_device, "details", None)
     if isinstance(details, dict):
         for key in ("source", "scanner", "path"):
@@ -112,13 +101,9 @@ def _connection_source(ble_device: BLEDevice) -> str:
 async def establish_connection_with_bond_settle(
     ble_device: BLEDevice, name: str
 ) -> BleakClient:
-    """Connect, wait for bonding/encryption to settle, then refresh GATT cache.
+    """Connect, let bonding/encryption settle, then refresh the GATT cache.
 
-    Wraps ``bleak_retry_connector.establish_connection`` with a fixed
-    :data:`_POST_CONNECT_BOND_SETTLE_SEC` pause plus a service-cache refresh.
-    All Omron integration code paths should use this helper instead of
-    calling ``establish_connection`` directly so the bond-settle behaviour
-    is consistent.
+    Retries if the device drops during the settle (common on multi-proxy setups).
     """
     last_source = "unknown"
     for attempt in range(1, _CONNECT_SETTLE_ATTEMPTS + 1):
@@ -137,8 +122,7 @@ async def establish_connection_with_bond_settle(
             getattr(client, "is_connected", "?"),
             _POST_CONNECT_BOND_SETTLE_SEC,
         )
-        # Let bonding/encryption settle, but poll the link so a drop is caught
-        # immediately rather than after waiting out the full settle.
+        # Settle for bonding/encryption, polling so a drop is caught early.
         waited = 0.0
         while waited < _POST_CONNECT_BOND_SETTLE_SEC:
             await asyncio.sleep(_SETTLE_POLL_STEP_SEC)
@@ -153,12 +137,8 @@ async def establish_connection_with_bond_settle(
             await _bleak_refresh_services(client)
             return client
 
-        # Dropped during the settle. On multi-proxy ESPHome setups this is
-        # almost always a connection routed through a proxy that did not bond
-        # the device (bonds are stored per-proxy) — the device drops the link.
-        # We cannot target a proxy, but re-running establish_connection lets
-        # habluetooth re-score the paths, so a retry may land on a working /
-        # bonded proxy.
+        # Dropped during settle; retry — re-establishing lets habluetooth
+        # re-score and possibly route through a working/bonded proxy.
         _LOGGER.warning(
             "%s dropped ~%.2fs into the post-connect settle via source=%s "
             "(attempt %d/%d) — retrying",
@@ -169,7 +149,6 @@ async def establish_connection_with_bond_settle(
             await client.disconnect()
         except Exception as exc:
             _LOGGER.debug("disconnect after settle-drop ignored: %s", exc)
-        # Retry immediately — no fixed delay; re-establish re-scores the paths.
 
     raise BleakError(
         f"{name} dropped during the post-connect settle on all "
@@ -344,16 +323,10 @@ async def _bluez_agent_pair(client: BleakClient) -> bool:
 
 
 async def _bluez_remove_device(client: BleakClient) -> bool:
-    """Remove the BlueZ device and its bond via ``Adapter1.RemoveDevice``.
+    """Remove the BlueZ device + bond via DBus Adapter1.RemoveDevice.
 
-    BlueZ persists bonds under ``/var/lib/bluetooth`` across reboots, so a
-    stale/rotated bond cannot be cleared by reconnecting or rebooting — it
-    must be explicitly removed.  ``BleakClient.unpair()`` is not implemented
-    on every backend (notably the HA/habluetooth BlueZ wrapper), so go
-    straight to BlueZ over DBus (same transport used by the pairing agent).
-
-    Returns True if RemoveDevice succeeded; False on any failure or when the
-    DBus path is unavailable (caller should fall back to ``unpair()``).
+    Used because BleakClient.unpair() is a no-op on the HA/habluetooth backend.
+    Returns True on success; False otherwise (caller falls back to unpair()).
     """
     try:
         from dbus_fast.aio.message_bus import MessageBus
@@ -430,17 +403,7 @@ def _is_non_fatal_os_pairing_error(exc: BaseException) -> bool:
 
 
 def _is_stale_bond_auth_error(exc: BaseException) -> bool:
-    """Whether a bonding failure looks like a stale/rotated bond.
-
-    Some Omron AFib devices (notably the HEM-7380T1 family) do not retain
-    their pairing bond across disconnects — they rotate or discard the LTK
-    after each session.  The host's stored bond then no longer matches, so
-    BlueZ rejects re-encryption/re-pairing with ``AuthenticationFailed`` (the
-    link never gets encrypted and later GATT ops fail with ``NotConnected``).
-    This is the signature of "works once right after a fresh bond, then fails
-    on every subsequent connection"; removing the stale bond and re-pairing
-    from a clean slate recovers the device.
-    """
+    """Whether a bonding failure looks like a stale/rotated bond (AuthenticationFailed)."""
     msg = str(exc).lower()
     return any(
         marker in msg
@@ -575,19 +538,8 @@ class OmronDeviceSession:
         await _bleak_refresh_services(self.client)
 
     async def verify_parent_service(self) -> bool:
-        """Ensure the profile's parent service is present, refreshing if needed.
-
-        Repeating a plain ``get_services()`` is pointless once it has returned a
-        list without the parent service — it just re-reads the same cached list.
-        So the sequence keeps only the *meaningful* steps:
-
-        1. check the current services,
-        2. refresh once (the cache may simply be unpopulated right after connect),
-        3. if still missing, force a fresh discovery via ``clear_cache()`` (the
-           only move different from step 2 — it drops a stale backend/proxy cache
-           that can hide ``fe4a``). Bail out immediately if the backend cannot
-           clear its cache, rather than looping uselessly.
-        """
+        """Ensure the parent service is present: check, refresh once, then
+        clear_cache + re-discover (the only step that beats a stale cache)."""
         parent_uuid = self._config.parent_service_uuid
 
         def _present() -> bool:
@@ -684,6 +636,10 @@ class OmronDeviceSession:
                     await self.close_memory_session()
                 except Exception:
                     pass
+            # Drop the bond while still connected so the next connection re-pairs
+            # fresh (WLD3.0 devices re-key each session).
+            if self._config.unpair_after_session and client.is_connected:
+                await self.unpair()
             if self._owns_connection and client.is_connected:
                 await client.disconnect()
                 disconnected = True
@@ -1453,14 +1409,8 @@ class OmronDeviceSession:
                 return
             except Exception as exc:
                 last_exc = exc
-                # Stale/rotated bond (HEM-7380T1 AFib family): the device
-                # discarded its LTK, so the stored bond no longer matches and
-                # BlueZ raises AuthenticationFailed.  Treating this as
-                # "non-fatal" and continuing leaves the link unencrypted, so the
-                # session then dies with NotConnected.  Instead remove the stale
-                # bond once; RemoveDevice also drops the link, so re-pairing
-                # in-place is impossible — raise and let the next connection
-                # re-pair from a clean slate (self-heals on the following poll).
+                # Stale bond → AuthenticationFailed. Remove it and raise; the
+                # next connection re-pairs from a clean slate.
                 if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
                     stale_bond_cleared = True
                     _LOGGER.warning(
@@ -1469,9 +1419,6 @@ class OmronDeviceSession:
                         type(exc).__name__,
                         self._config.model,
                     )
-                    # Prefer BlueZ RemoveDevice over DBus (authoritative, works
-                    # even when the backend's unpair() is a no-op); fall back to
-                    # BleakClient.unpair() for non-BlueZ backends.
                     if not await _bluez_remove_device(self._client):
                         await self.unpair()
                     raise ConnectionError(

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1253,11 +1253,8 @@ class OmronBluetoothDeviceData(BluetoothData):
                     f"not found on device {ble_device.address}"
                 )
             if self._device_config.os_bond_once:
-                # Bond-once profiles (HEM-7380T1 AFib): never re-pair on a
-                # pairing-mode advertisement — the device is already bonded from
-                # config-flow setup and an explicit re-pair churns the bond into
-                # an AuthenticationFailed state. Refresh + time-sync only; the
-                # post-trigger poll reads records over the existing bond.
+                # Bond-once profiles: never re-pair on a pairing-mode advert
+                # (re-pairing churns the bond). Refresh + time-sync only.
                 _LOGGER.debug(
                     "Skipping OS re-pair for %s (os_bond_once): using existing "
                     "bond + on-demand encryption",


### PR DESCRIPTION
… for WLD3.0

- DeviceConfig.connect_type (ConnectType StrEnum) records each profile's OMRON communication type. The modern-firmware HEM-7155T_ESL (HEM-7155T-MW3) is grouped as WLD3.0 alongside the HEM-7380T1 AFib family — they share the modern fe4a stack and bonding behaviour.
- Restore unpair-after-session as a property gated on the WLD3.0 group: those devices re-key their bond each session, so the bond is dropped at session teardown to force a clean fresh pairing on the next connection.
- Convert the categorical string fields to StrEnums for type safety and clean logs: endianness -> Endianness, record_parser -> RecordParser, time_sync_layout -> TimeSyncLayout (str-compatible, so comparisons/struct/dict lookups are unchanged).
- Trim verbose docstrings/comments.

Bump version to 2.5.15.