### PR TITLE
fix: pick latest reading by datetime instead of highest slot index (#88)

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.14"
+  "version": "2.5.15"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -501,7 +501,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
     ),
     # HEM-7155T K4 — modern stack, MW3 EEPROM layout, no secure session.
     "HEM-7155T-K4": DeviceConfig(
@@ -528,7 +527,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7155T_K4-D",
             "HEM-7155T_K4-EBK",
@@ -578,7 +576,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             # HEM-7155T_ESL1 ("X4 Smart", modern firmware): modern FE4A stack
             # with V3 EEPROM at 0x0260, classic plaintext transport over a Just
@@ -612,7 +609,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7143T1-AIN",
             "HEM-7143T1-AP",
@@ -733,7 +729,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7183T1-AP",
             "HEM-7183T1-CAP",
@@ -790,7 +785,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "index_region_byte_size": 0x10,
             "endianness": "big",
             "backtrack_slots": 13,
-            "collect_all_valid_in_index_window": True,
             "skip_full_scan_fallback_when_index_empty": True,
             "users": [
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 13, "slot_index_bias": -1},
@@ -800,7 +794,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "record_step": 0x0E,
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
-        prefer_latest_by_slot_index=True,
         equivalent_model_ids=(
             "HEM-7138K-SH",
             "HEM-7140T1-AP",

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -137,8 +137,6 @@ class DeviceConfig:
 
     # Record layout key -> parser in parse_record()
     record_parser: RecordParser = RecordParser.CLASSIC_VITAL_14
-    # When True, pick latest record by highest EEPROM slot index, then datetime (index-pointer devices).
-    prefer_latest_by_slot_index: bool = False
     equivalent_model_ids: tuple[str, ...] = ()
 
     def __post_init__(self) -> None:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -2087,7 +2087,6 @@ class OmronDeviceDriver:
         record_byte_size = int(layout.get("record_byte_size", self._config.record_byte_size))
         record_step = int(layout.get("record_step", record_byte_size))
         backtrack_slots = int(layout.get("backtrack_slots", 0))
-        collect_all_valid = bool(layout.get("collect_all_valid_in_index_window", False))
         ptr_endian = str(layout.get("endianness", self._config.endianness))
 
         candidates: list[tuple[int, dict[str, Any]]] = []
@@ -2216,9 +2215,7 @@ class OmronDeviceDriver:
                         parsed = None
                         continue
                     candidates.append((idx + 1, parsed))
-                    if not collect_all_valid:
-                        break
-                    parsed = None
+                    break
                 # After the backtrack window completes: if every read came
                 # back all-0xFF, mark this user as definitively empty.
                 if user_had_any_read and user_all_probed_slots_empty:
@@ -2379,18 +2376,9 @@ class OmronDeviceDriver:
     def _select_latest_candidate(
         self, candidates: list[tuple[int, dict[str, Any]]]
     ) -> tuple[int, dict[str, Any]] | None:
-        """Choose the latest record across users using model-specific strategy."""
+        """Choose the latest record across users by datetime, slot index as tiebreaker."""
         if not candidates:
             return None
-
-        if self._config.prefer_latest_by_slot_index:
-            return max(
-                candidates,
-                key=lambda item: (
-                    item[1].get("_slot_index", -1),
-                    item[1].get("datetime", dt.datetime.min),
-                ),
-            )
 
         return max(
             candidates,


### PR DESCRIPTION
Remove collect_all_valid_in_index_window and prefer_latest_by_slot_index so index backtrack stops at the first valid record and latest selection always prefers the newest timestamp.