### PR TITLE
fix: correct HEM-7142T2 index cursor endianness for latest slot

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -783,9 +783,8 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
             "index_region_byte_size": 0x10,
-            "endianness": "big",
-            "backtrack_slots": 13,
-            "skip_full_scan_fallback_when_index_empty": True,
+            "endianness": "little",
+            "backtrack_slots": 0,
             "users": [
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 13, "slot_index_bias": -1},
             ],

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1913,16 +1913,9 @@ class OmronDeviceDriver:
         self, transport: OmronDeviceSession
     ) -> dict[str, Any] | None:
         """Read latest record using index first, then fallback to full scan."""
-        layout = self._config.index_pointer_layout or {}
         indexed = await self._get_latest_via_index(transport)
         if indexed is not None:
             return indexed
-        if bool(layout.get("skip_full_scan_fallback_when_index_empty")):
-            _LOGGER.debug(
-                "Index path returned no valid candidate for model=%s; skipping full scan fallback",
-                self._config.model,
-            )
-            return None
         _LOGGER.debug(
             "%s index path did not yield a valid latest record; falling back to full scan",
             self._config.model,


### PR DESCRIPTION
Use little-endian cursor parsing so slot 13 points at the newest record instead of misreading slot 7 under big-endian. Drop the 14-slot backtrack workaround and remove skip_full_scan_fallback_when_index_empty.