### PR TITLE
fix: enable secure session for HEM-7188T1-LEO and correct handshake bugs

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.17"
+  "version": "2.5.18"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.18"
+  "version": "2.5.17"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.16"
+  "version": "2.5.17"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -735,10 +735,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_FLBIN",
             "HEM-7183T1_FLIN",
             "HEM-7183T1_LAP",
-            "HEM-7188T1-LE",
-            # HEM-7188T1-LEO ("X2+ Connect") moved to its own profile: 1 user /
-            # 30 records, and requires the full ECDH secure session (not just
-            # TOKEN_KEY) — see "HEM-7188T1-LEO".
+            # HEM-7188T1 family (LE/LEO — "X2+ Connect") moved to its own
+            # profile: 1 user / 30 records, and HEM-7188T1-LEO requires the
+            # full ECDH secure session (not just TOKEN_KEY) — see "HEM-7188T1".
             # HEM-7194T1 / HEM-7196T1 family shares this modern-stack profile
             # (OS bonding, FE4A parent service, same TX/RX UUIDs and EEPROM layout).
             "HEM-7194T1-FLAP",
@@ -803,20 +802,23 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7382T1-AZAZ",
         ),
     ),
-    # HEM-7188T1-LEO ("X2+ Connect") — same modern-stack family as HEM-7380T1,
-    # but confirmed via HCI btsnoop to need the full ECDH secure session, not
-    # just the TOKEN_KEY handshake: the official app sends a token unlock
-    # (0x11/0x91) and then immediately negotiates a secure session (pairing
-    # request/response, encryption start, mutual challenge) before any record
-    # access, and record-channel traffic afterward is CCM-encrypted too. The
-    # device is also 1 user / 30 records, not the 2 user / 100 record layout
-    # HEM-7380T1 uses. EEPROM addresses below are inherited from HEM-7380T1
-    # (same family/likely same memory map) and are NOT independently verified
-    # for this model, since all GATT traffic after unlock is encrypted in the
-    # capture — confirm against a real read if data looks wrong.
-    "HEM-7188T1-LEO": DeviceConfig(
+    # HEM-7188T1 family ("X2+ Connect") — same modern-stack lineage as
+    # HEM-7380T1, but confirmed via HCI btsnoop (HEM-7188T1-LEO) to need the
+    # full ECDH secure session, not just the TOKEN_KEY handshake: the official
+    # app sends a token unlock (0x11/0x91) and then immediately negotiates a
+    # secure session (pairing request/response, encryption start, mutual
+    # challenge) before any record access, and record-channel traffic
+    # afterward is CCM-encrypted too. The device is also 1 user / 30 records,
+    # not the 2 user / 100 record layout HEM-7380T1 uses. EEPROM addresses
+    # below are inherited from HEM-7380T1 (same family/likely same memory
+    # map) and are NOT independently verified for this model, since all GATT
+    # traffic after unlock is encrypted in the capture — confirm against a
+    # real read if data looks wrong. Only the "-LEO" suffix has been
+    # confirmed via btsnoop; "-LE" is grouped in as the same base model
+    # number and assumed identical hardware.
+    "HEM-7188T1": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
-        model="HEM-7188T1-LEO",
+        model="HEM-7188T1",
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.SECURE_SESSION,
         os_bond_once=True,
@@ -838,6 +840,10 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
+        equivalent_model_ids=(
+            "HEM-7188T1-LE",
+            "HEM-7188T1-LEO",
+        ),
     ),
     # HEM-7142T2 — modern stack, MW3-style EEPROM, stateless 0x11/0x91 token
     # handshake (same pattern as HEM-7155T-MW3; confirmed via HCI btsnoop).

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -736,7 +736,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_FLIN",
             "HEM-7183T1_LAP",
             "HEM-7188T1-LE",
-            "HEM-7188T1-LEO",
+            # HEM-7188T1-LEO ("X2+ Connect") moved to its own profile: 1 user /
+            # 30 records, and requires the full ECDH secure session (not just
+            # TOKEN_KEY) — see "HEM-7188T1-LEO".
             # HEM-7194T1 / HEM-7196T1 family shares this modern-stack profile
             # (OS bonding, FE4A parent service, same TX/RX UUIDs and EEPROM layout).
             "HEM-7194T1-FLAP",
@@ -800,6 +802,42 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         equivalent_model_ids=(
             "HEM-7382T1-AZAZ",
         ),
+    ),
+    # HEM-7188T1-LEO ("X2+ Connect") — same modern-stack family as HEM-7380T1,
+    # but confirmed via HCI btsnoop to need the full ECDH secure session, not
+    # just the TOKEN_KEY handshake: the official app sends a token unlock
+    # (0x11/0x91) and then immediately negotiates a secure session (pairing
+    # request/response, encryption start, mutual challenge) before any record
+    # access, and record-channel traffic afterward is CCM-encrypted too. The
+    # device is also 1 user / 30 records, not the 2 user / 100 record layout
+    # HEM-7380T1 uses. EEPROM addresses below are inherited from HEM-7380T1
+    # (same family/likely same memory map) and are NOT independently verified
+    # for this model, since all GATT traffic after unlock is encrypted in the
+    # capture — confirm against a real read if data looks wrong.
+    "HEM-7188T1-LEO": DeviceConfig(
+        **_MODERN_OS_BONDING_BASE,
+        model="HEM-7188T1-LEO",
+        connect_type=ConnectType.WLD3_0,
+        unlock_mode=UnlockMode.SECURE_SESSION,
+        os_bond_once=True,
+        endianness=Endianness.LITTLE,
+        user_start_addresses=[0x01C4],
+        per_user_records_count=[30],
+        record_byte_size=0x10,
+        transmission_block_size=0x38,
+        settings_read_address=0x0010,
+        settings_write_address=0x0054,
+        settings_unread_records_bytes=None,
+        settings_time_sync_bytes=[0x2C, 0x3C],
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
+        index_pointer_layout={
+            "index_region_byte_size": 0x18,
+            "endianness": "little",
+            "users": [
+                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
+            ],
+        },
+        record_parser=RecordParser.CLASSIC_VITAL_14,
     ),
     # HEM-7142T2 — modern stack, MW3-style EEPROM, stateless 0x11/0x91 token
     # handshake (same pattern as HEM-7155T-MW3; confirmed via HCI btsnoop).

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1304,6 +1304,16 @@ class OmronDeviceSession:
     async def _secure_unlock(self) -> None:
         """Perform encrypted secure handshake to unlock the device."""
         _LOGGER.debug("Starting secure handshake unlock for model=%s", self._config.model)
+
+        # The device requires a preliminary stateless token handshake
+        # (0x11/0x91) before it will accept the ECDH pairing request —
+        # confirmed via HCI btsnoop (HEM-7188T1-LEO), where the official app
+        # performs this step immediately before the Pairing Request. Reset
+        # ``_unlocked`` afterward so a later failure in the ECDH stage below
+        # doesn't leave the transport thinking it's already unlocked.
+        await self._token_unlock()
+        self._unlocked = False
+
         from .secure_session import SecureSession
 
         self._secure_session = SecureSession()

--- a/custom_components/omron/omron_ble/secure_session.py
+++ b/custom_components/omron/omron_ble/secure_session.py
@@ -149,7 +149,10 @@ class SecureSession:
             raise RuntimeError("process_pair_resp requires STATE_PAIR_REQ_SENT.")
         if len(resp) != 89:
             raise ValueError(f"Invalid pairing response length: {len(resp)}")
-        if resp[:2] != b"\x70\x81":
+        # Peer (device) responses set the top bit of the frame header rather
+        # than reusing the request's 0x70 — confirmed via HCI btsnoop
+        # (HEM-7188T1-LEO): the device replies with 0xf0 0x81, not 0x70 0x81.
+        if resp[:2] != b"\xf0\x81":
             raise ValueError(f"Invalid pairing response header: {resp[:2].hex()}")
 
         # Parse response fields after the 2-byte header
@@ -227,7 +230,8 @@ class SecureSession:
             raise RuntimeError("build_challenge_req requires STATE_ENC_REQ_SENT.")
         if len(start_enc_resp) != 46:
             raise ValueError(f"Peer Encryption Response must be 46 bytes, got {len(start_enc_resp)}")
-        if start_enc_resp[:2] != b"\x70\x85":
+        # Peer responses use header 0xf0, not 0x70 — see process_pair_resp.
+        if start_enc_resp[:2] != b"\xf0\x85":
             raise ValueError(f"Invalid Encryption Response headers: {start_enc_resp[:2].hex()}")
 
         # Extract peer's encryption challenge and salt
@@ -269,7 +273,8 @@ class SecureSession:
             raise RuntimeError("process_challenge_resp requires STATE_CHALLENGE_REQ_SENT.")
         if len(resp) != 46:
             raise ValueError(f"Peer Challenge Response must be 46 bytes, got {len(resp)}")
-        if resp[:2] != b"\x70\x86":
+        # Peer responses use header 0xf0, not 0x70 — see process_pair_resp.
+        if resp[:2] != b"\xf0\x86":
             raise ValueError(f"Invalid Challenge Response headers: {resp[:2].hex()}")
 
         ciphertext = resp[2:]


### PR DESCRIPTION
HCI btsnoop of the official app pairing with HEM-7188T1-LEO ("X2+ Connect") shows it needs the full ECDH secure session, not just TOKEN_KEY: the app sends a token unlock (0x11/0x91) then immediately negotiates a secure session (pairing request/response, encryption start, mutual challenge) before any record access, and record-channel traffic afterward is CCM-encrypted too. The device is also 1 user / 30 records, not the 2 user / 100 record HEM-7380T1 layout it was previously grouped under.

Splits HEM-7188T1-LEO into its own profile (unlock_mode=SECURE_SESSION, 1 user, 30 records; EEPROM addresses inherited from HEM-7380T1 and not independently verified, since all post-unlock traffic in the capture is encrypted).

Also fixes two secure-session bugs the capture exposed:
- process_pair_resp / build_challenge_req / process_challenge_resp checked peer responses for header 0x70, but the device actually replies with 0xf0 (top bit set) — every previous handshake attempt failed immediately on the first response.
- _secure_unlock() went straight to the ECDH pairing request; the device requires the preliminary token handshake first.

Bump to v2.5.17.