### PR TITLE
fix: don't unpair after session on devices that bond once and reuse it

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.17"
+  "version": "2.5.18"
 }

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -246,7 +246,19 @@ class DeviceConfig:
 
     @property
     def unpair_after_session(self) -> bool:
-        """Drop the OS bond after each session (WLD3.0 devices re-key per session)."""
+        """Drop the OS bond after each session (WLD3.0 devices re-key per session).
+
+        Never true when ``os_bond_once`` is set: that flag means "bond once
+        and keep reusing it," which this would otherwise undo at the end of
+        every single session — including the one that just bonded — leaving
+        no bond for the next connection to reuse. Confirmed via HA logs
+        (HEM-7382T1): the post-pairing bond worked, an ignored ``unpair()``
+        ran anyway on session close, and the very next connection attempt
+        (moments later) then failed to complete the post-connect settle on
+        all retries because the bond it needed was gone.
+        """
+        if self.os_bond_once:
+            return False
         return self.connect_type == ConnectType.WLD3_0
 
     def is_service_compatible(self, service_uuids: list[str]) -> bool:


### PR DESCRIPTION
unpair_after_session (drop the OS bond on session close, for WLD3.0's per-session re-keying) and os_bond_once (bond once at setup and keep reusing that bond) are contradictory when both apply to the same profile: HEM-7380T1, HEM-7382T1, and HEM-7188T1 all set both flags, so every session — including the one that just bonded — dropped the bond it was supposed to keep reusing.

A user's HEM-7382T1 log shows the failure this causes: a pairing/time-sync session completes fine (reusing the existing bond, per the "Skipping OS re-pair" log line), unpair() then runs anyway on session close (fails with a BlueZ error, ignored), and the very next connection attempt — moments later, part of the same post-pairing refresh — then fails to complete the post-connect settle on all 3 retries because the bond it needed is gone. The poll's fallback-to-cached-data behavior masked this as "success: True" in the coordinator, matching the user's report of HA appearing to keep communicating with the device despite it no longer actually reading data.

os_bond_once now takes precedence: unpair_after_session is false whenever it's set. Bump to v2.5.18.