### PR TITLE
test: add unit test suite and GitHub Actions CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,61 @@
+name: Tests
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Lint
+        run: python -m ruff check custom_components/
+
+  hacs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: HACS Action
+        uses: hacs/action@main
+        with:
+          category: integration
+
+  test:
+    runs-on: ubuntu-latest
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-import asyncio
 import dataclasses
-import datetime as dt
 import logging
 import traceback
 from typing import Any

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.18"
+  "version": "2.5.19"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.19"
+  "version": "2.5.18"
 }

--- a/custom_components/omron/omron_ble/const.py
+++ b/custom_components/omron/omron_ble/const.py
@@ -1,9 +1,9 @@
 """Constants for the Omron BLE module."""
 from __future__ import annotations
 
-DEFAULT_DEVICE_MODEL = "HEM-7142T2"
-
 from sensor_state_data import BaseDeviceClass
+
+DEFAULT_DEVICE_MODEL = "HEM-7142T2"
 
 CTS_CHARACTERISTIC_UUID = "00002a2b-0000-1000-8000-00805f9b34fb"
 BATTERY_LEVEL_UUID = "00002a19-0000-1000-8000-00805f9b34fb"

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -7,8 +7,6 @@ from dataclasses import dataclass, field, replace
 from enum import Enum, StrEnum
 from typing import Any
 
-_LOGGER = logging.getLogger(__name__)
-
 from .const import (
     CLASSIC_STACK_PARENT_SERVICE_UUID,
     MODERN_STACK_PARENT_SERVICE_UUID,
@@ -16,16 +14,16 @@ from .const import (
     CLASSIC_STACK_RX_CHARACTERISTIC_UUIDS,
     CLASSIC_STACK_TX_CHARACTERISTIC_UUIDS,
     CLASSIC_STACK_UNLOCK_CHARACTERISTIC_UUID,
-    DISCOVERABLE_PARENT_SERVICE_UUIDS,
     DEFAULT_DEVICE_MODEL,
 )
-
 from .record_parsers import (
     parse_classic_vital_14,
     parse_classic_vital_16_6401_family,
     parse_classic_vital_14_6232_family,
     parse_classic_vital_14_bitpacked,
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class UnlockMode(str, Enum):
@@ -284,7 +282,11 @@ class DeviceConfig:
 
 
 
-from .device_catalog import CANONICAL_DEVICE_PROFILES
+# Deliberately not at module top: device_catalog.py imports types (DeviceConfig,
+# UnlockMode, etc.) from this module, so importing it back at the top would be
+# circular. Safe here since everything device_catalog.py needs from this module
+# is already defined above.
+from .device_catalog import CANONICAL_DEVICE_PROFILES  # noqa: E402
 
 def _build_model_variant_map() -> dict[str, str]:
     idx: dict[str, str] = {}

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -237,15 +237,15 @@ async def _bluez_agent_pair(client: BleakClient) -> bool:
             pass
 
         @dbus_method()
-        def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]
+        def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]  # noqa: F821
             _LOGGER.debug("BlueZ agent: auto-confirming passkey %06d", passkey)
 
         @dbus_method()
-        def RequestPasskey(self, device: "o") -> "u":  # type: ignore[override]
+        def RequestPasskey(self, device: "o") -> "u":  # type: ignore[override]  # noqa: F821
             return 0
 
         @dbus_method()
-        def RequestAuthorization(self, device: "o") -> None:  # type: ignore[override]
+        def RequestAuthorization(self, device: "o") -> None:  # type: ignore[override]  # noqa: F821
             pass
 
         @dbus_method()

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -17,10 +17,8 @@ from bluetooth_sensor_state_data import BluetoothData
 from home_assistant_bluetooth import BluetoothServiceInfoBleak
 from sensor_state_data import (
     BinarySensorDeviceClass,
-    SensorLibrary,
     SensorUpdate,
     SensorDeviceClass,
-    Units,
 )
 from homeassistant.util import dt as dt_util
 
@@ -721,9 +719,12 @@ class OmronBluetoothDeviceData(BluetoothData):
         has_user_id = bool(flags & 0x08)
         has_status = bool(flags & 0x10)
 
-        sys_val = self._decode_sfloat_le(payload[idx:idx + 2]); idx += 2
-        dia_val = self._decode_sfloat_le(payload[idx:idx + 2]); idx += 2
-        _ = self._decode_sfloat_le(payload[idx:idx + 2]); idx += 2  # MAP
+        sys_val = self._decode_sfloat_le(payload[idx:idx + 2])
+        idx += 2
+        dia_val = self._decode_sfloat_le(payload[idx:idx + 2])
+        idx += 2
+        _ = self._decode_sfloat_le(payload[idx:idx + 2])  # MAP
+        idx += 2
 
         if unit_kpa:
             # Convert kPa to mmHg for HA entities.

--- a/custom_components/omron/omron_ble/secure_session.py
+++ b/custom_components/omron/omron_ble/secure_session.py
@@ -6,13 +6,11 @@ transport used by OMRON BLE healthcare devices over the fe4a GATT service.
 
 from __future__ import annotations
 
-import struct
 import secrets
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from cryptography.hazmat.primitives.asymmetric import ec
-    from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+    pass
 
 # Protocol constants
 PACKET_HEADER_SIZE = 13

--- a/custom_components/omron/types.py
+++ b/custom_components/omron/types.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import TYPE_CHECKING, TypeAlias
 
 from homeassistant.config_entries import ConfigEntry
+
+if TYPE_CHECKING:
+    from .coordinator import OmronBluetoothProcessorCoordinator
 
 OmronConfigEntry: TypeAlias = ConfigEntry["OmronBluetoothProcessorCoordinator"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,59 @@
+"""pytest 설정 — homeassistant/bleak 없이 단위 테스트 실행 가능하도록 mock.
+
+sensor_state_data / bluetooth_sensor_state_data 도 함께 mock 한다: 실제 설치판을
+쓰면 그 내부가 real habluetooth -> real bleak.backends.* 를 요구해 훨씬 무거운
+의존성 체인으로 번진다. BluetoothData/BaseDeviceClass를 서브클래싱하는 코드는
+MagicMock을 베이스로 둬도 임포트 시점에는 에러 없이 통과하므로(실제 인스턴스화나
+상속된 동작을 쓰지 않는 한) 이 테스트 범위에서는 mock으로 충분하다.
+"""
+import sys
+from unittest.mock import MagicMock
+
+
+class MockBase:
+    """제네릭 서브클래싱(예: BaseClass[T])을 지원하는 기본 Mock 클래스."""
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __class_getitem__(cls, item):
+        return cls
+
+
+# ── Mock Home Assistant Modules ────────────────────────────────────────────
+
+sys.modules["homeassistant"] = MagicMock()
+sys.modules["homeassistant.components"] = MagicMock()
+sys.modules["homeassistant.components.bluetooth"] = MagicMock()
+sys.modules["homeassistant.config_entries"] = MagicMock()
+sys.modules["homeassistant.const"] = MagicMock()
+sys.modules["homeassistant.core"] = MagicMock()
+sys.modules["homeassistant.helpers"] = MagicMock()
+sys.modules["homeassistant.helpers.device_registry"] = MagicMock()
+sys.modules["homeassistant.util"] = MagicMock()
+sys.modules["homeassistant.util.dt"] = MagicMock()
+
+# OmronBluetoothProcessorCoordinator(PassiveBluetoothProcessorCoordinator[SensorUpdate])
+# 처럼 실제로 서브클래싱 + 제네릭 첨자가 쓰이므로 MockBase 사용.
+_ha_bt_processor = MagicMock()
+_ha_bt_processor.PassiveBluetoothProcessorCoordinator = MockBase
+sys.modules["homeassistant.components.bluetooth.passive_update_processor"] = _ha_bt_processor
+
+# DataUpdateCoordinator[T] / CoordinatorEntity 도 서브클래싱 대비 MockBase.
+_ha_update_coordinator = MagicMock()
+_ha_update_coordinator.DataUpdateCoordinator = MockBase
+_ha_update_coordinator.CoordinatorEntity = MockBase
+sys.modules["homeassistant.helpers.update_coordinator"] = _ha_update_coordinator
+
+# ── Mock bleak (BLE hardware I/O — 실제 설치 없이 타입 참조만 필요) ──────────
+
+sys.modules["bleak"] = MagicMock()
+sys.modules["bleak.backends.device"] = MagicMock()
+sys.modules["bleak.exc"] = MagicMock()
+sys.modules["bleak_retry_connector"] = MagicMock()
+
+# ── Mock sensor_state_data / bluetooth_sensor_state_data / home_assistant_bluetooth ──
+
+sys.modules["sensor_state_data"] = MagicMock()
+sys.modules["bluetooth_sensor_state_data"] = MagicMock()
+sys.modules["home_assistant_bluetooth"] = MagicMock()

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,0 +1,68 @@
+"""devices.py / device_catalog.py 단위 테스트."""
+from custom_components.omron.omron_ble.devices import (
+    ConnectType,
+    DeviceConfig,
+    get_device_config,
+    resolve_profile_model_id,
+)
+
+
+class TestUnpairAfterSession:
+    """unpair_after_session 은 os_bond_once=True 인 기기에서는 항상 False여야 한다.
+
+    두 플래그가 같이 켜져 있으면 (HEM-7380T1/HEM-7382T1/HEM-7188T1) 세션이
+    끝날 때마다 os_bond_once가 재사용하려는 본드를 unpair()가 지워버려
+    다음 연결이 post-connect settle에서 실패하는 회귀가 있었다.
+    """
+
+    def test_wld3_without_bond_once_unpairs(self):
+        cfg = DeviceConfig(model="test", connect_type=ConnectType.WLD3_0)
+        assert cfg.unpair_after_session is True
+
+    def test_wld3_with_bond_once_never_unpairs(self):
+        cfg = DeviceConfig(
+            model="test", connect_type=ConnectType.WLD3_0, os_bond_once=True
+        )
+        assert cfg.unpair_after_session is False
+
+    def test_non_wld3_never_unpairs(self):
+        cfg = DeviceConfig(model="test", connect_type=ConnectType.UNKNOWN)
+        assert cfg.unpair_after_session is False
+
+    def test_non_wld3_with_bond_once_never_unpairs(self):
+        cfg = DeviceConfig(
+            model="test", connect_type=ConnectType.UNKNOWN, os_bond_once=True
+        )
+        assert cfg.unpair_after_session is False
+
+
+class TestCatalogResolution:
+    """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
+
+    def test_hem7188t1_leo_resolves_to_hem7188t1_profile(self):
+        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1"
+        # get_device_config keeps the requested variant string as .model (so
+        # logs/UI show "HEM-7188T1-LEO"), while every other field is copied
+        # from the canonical "HEM-7188T1" profile.
+        cfg = get_device_config("HEM-7188T1-LEO")
+        assert cfg.model == "HEM-7188T1-LEO"
+        assert cfg.per_user_records_count == [30]
+
+    def test_hem7188t1_le_resolves_to_same_profile(self):
+        assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7188T1"
+
+    def test_hem7155t_esl_is_classic_not_modern(self):
+        # HEM-7155T_ESL (classic stack) must NOT resolve to the modern
+        # HEM-7155T-MW3 profile that HEM-7155T_ESL1 uses.
+        assert resolve_profile_model_id("HEM-7155T_ESL") == "HEM-7155T"
+        assert resolve_profile_model_id("HEM-7155T_ESL1") == "HEM-7155T-MW3"
+
+    def test_hem7382t1_has_own_profile_with_shifted_time_section(self):
+        cfg = get_device_config("HEM-7382T1")
+        assert cfg.model == "HEM-7382T1"
+        assert cfg.settings_time_sync_bytes == [0x30, 0x40]
+
+    def test_unknown_model_falls_back_to_default(self):
+        from custom_components.omron.omron_ble.const import DEFAULT_DEVICE_MODEL
+
+        assert resolve_profile_model_id("NOT-A-REAL-MODEL") == DEFAULT_DEVICE_MODEL

--- a/tests/test_eeprom_time.py
+++ b/tests/test_eeprom_time.py
@@ -1,0 +1,28 @@
+"""EEPROM 시간 디코드(_decode_eeprom_time_payload) 단위 테스트.
+
+바이트는 실기기 HA 디버그 로그의 "EEPROM time raw" 라인에서 그대로 가져왔고,
+같은 로그의 "Device ... time is already in sync (...)" 라인과 대조해 검증됐다.
+"""
+import datetime
+
+from custom_components.omron.omron_ble.omron_driver import (
+    _decode_eeprom_time_payload,
+)
+
+
+class TestModernOffset8:
+    def test_hem7382t1(self):
+        # addr=0x0010+0x30 size=16 raw=c6a40100000000001a070f113b13fa00
+        # -> "Device HEM-7382T1 time is already in sync (2026-07-15 17:59:19)"
+        raw = bytearray.fromhex("c6a40100000000001a070f113b13fa00")
+        assert _decode_eeprom_time_payload("eeprom_time_modern_offset8", raw) == (
+            datetime.datetime(2026, 7, 15, 17, 59, 19)
+        )
+
+    def test_hem7142t2(self):
+        # addr=0x0260+0x2C size=16 raw=c8a80000000000001a06120e3509ee00
+        # -> "Device HEM-7142T2 time is already in sync (2026-06-18 14:53:09)"
+        raw = bytearray.fromhex("c8a80000000000001a06120e3509ee00")
+        assert _decode_eeprom_time_payload("eeprom_time_modern_offset8", raw) == (
+            datetime.datetime(2026, 6, 18, 14, 53, 9)
+        )

--- a/tests/test_record_parsers.py
+++ b/tests/test_record_parsers.py
@@ -1,0 +1,64 @@
+"""record_parsers.py 단위 테스트.
+
+바이트 문자열은 실기기 HA 디버그 로그에서 그대로 가져온 것으로, 로그에 함께
+찍힌 sys/dia/bpm/datetime 파싱 결과와 대조해 검증됐다 (HEM-7142T2, 2026-06-18).
+"""
+import datetime
+
+import pytest
+
+from custom_components.omron.omron_ble.record_parsers import (
+    parse_classic_vital_14,
+    parse_classic_vital_14_bitpacked,
+)
+
+
+class TestParseClassicVital14:
+    def test_slot13_hem7142t2(self):
+        # User1 [HEM-7142T2] slot=13 raw=6558541a331ade1800004c00ba00
+        # -> sys=126 dia=88 bpm=84 dt=2026-06-17 19:35:30
+        raw = bytes.fromhex("6558541a331ade1800004c00ba00")
+        record = parse_classic_vital_14(raw, endianness="little")
+        assert record["sys"] == 126
+        assert record["dia"] == 88
+        assert record["bpm"] == 84
+        assert record["datetime"] == datetime.datetime(2026, 6, 17, 19, 35, 30)
+
+    def test_slot7_hem7142t2(self):
+        # User1 [HEM-7142T2] slot=7 raw=6457431a7316161c000046001900
+        # -> sys=125 dia=87 bpm=67 dt=2026-05-19 19:48:22
+        raw = bytes.fromhex("6457431a7316161c000046001900")
+        record = parse_classic_vital_14(raw, endianness="little")
+        assert record["sys"] == 125
+        assert record["dia"] == 87
+        assert record["bpm"] == 67
+        assert record["datetime"] == datetime.datetime(2026, 5, 19, 19, 48, 22)
+
+    def test_empty_slot_all_ff_raises(self):
+        raw = bytes.fromhex("ff" * 14)
+        with pytest.raises(ValueError):
+            parse_classic_vital_14(raw, endianness="little")
+
+    def test_zero_filled_slot_raises(self):
+        # sys byte alone (0x00) is a valid decode (25 mmHg) but the rest being
+        # all-zero is the device's "never written" placeholder, not a real
+        # reading — must still raise.
+        raw = bytes(14)
+        with pytest.raises(ValueError):
+            parse_classic_vital_14(raw, endianness="little")
+
+    def test_sys_above_0xe1_is_empty_marker(self):
+        raw = bytes([0xE2]) + bytes(13)
+        with pytest.raises(ValueError):
+            parse_classic_vital_14(raw, endianness="little")
+
+
+class TestParseClassicVital14Bitpacked:
+    def test_hem7600t_slot23(self):
+        # HEM-7600T-E slot=23 raw=5b781a4819d71b42000014006996
+        # -> sys=145 dia=91 bpm=72 (confirmed against device EEPROM dump)
+        raw = bytes.fromhex("5b781a4819d71b42000014006996")
+        record = parse_classic_vital_14_bitpacked(raw, endianness="big")
+        assert record["sys"] == 145
+        assert record["dia"] == 91
+        assert record["bpm"] == 72


### PR DESCRIPTION
Mirrors the sibling BLE HACS integrations (hass-niimbot, hass-gicisky): homeassistant/bleak/sensor_state_data family are mocked in tests/conftest.py (sys.modules stubs, no real HA/bleak install) so the pure protocol/parsing layer can be tested without hardware or a full Home Assistant environment.

Covers the exact bugs found and fixed by hand this cycle, using byte strings taken directly from real device logs as oracles:
- record_parsers.parse_classic_vital_14 / _bitpacked (HEM-7142T2, HEM-7600T)
- EEPROM time decode for the modern_offset8 layout (HEM-7382T1, HEM-7142T2)
- DeviceConfig.unpair_after_session precedence vs. os_bond_once (regression guard for the HEM-7380T1/7382T1/7188T1 bond-churn bug)
- catalog variant resolution (HEM-7188T1-LEO/-LE, HEM-7155T_ESL/_ESL1)

Also fixes every pre-existing `ruff check custom_components/` finding so CI starts clean, matching the sibling repos: unused imports, a real missing TYPE_CHECKING import in types.py (OmronBluetoothProcessorCoordinator was referenced but never imported), a documented noqa for device_catalog's necessarily-late import (avoids a real circular import with devices.py), noqa's for dbus_next's "o"/"u" D-Bus signature annotations (false-positive forward-ref lookups, not real undefined names), and split-up semicolon statements in the BLS RACP decoder.

Adds .github/workflows/tests.yml (lint + HACS validation + pytest matrix on 3.12/3.13/3.14), same structure as hass-kma/hass-opinet/hass-niimbot/ hass-gicisky. Bump to v2.5.19.