### PR TITLE
debug: probe standard BLS RACP path when the EEPROM scan returns nothing

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.18"
+  "version": "2.5.19"
 }

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -877,6 +877,26 @@ class OmronBluetoothDeviceData(BluetoothData):
         latest_by_user: dict[int, dict[str, Any]] = {}
         if multi_user_mode:
             latest_by_user = await self._driver.get_latest_records_per_user(session)
+            if not latest_by_user:
+                # Diagnostic only: the classic EEPROM index/full-scan path found
+                # nothing usable. Probe the standard BLE Blood Pressure Service
+                # RACP path too so the log shows whether this device exposes
+                # 0x2A35/0x2A52 and, if so, what a "last stored record" request
+                # returns — without changing the (already-failing) result here.
+                try:
+                    diag_record = await self._read_latest_via_bls_racp(client)
+                    _LOGGER.debug(
+                        "Diagnostic BLS RACP probe for %s (EEPROM path returned no "
+                        "records): result=%s",
+                        ble_device.address,
+                        diag_record,
+                    )
+                except Exception as exc:
+                    _LOGGER.debug(
+                        "Diagnostic BLS RACP probe for %s failed: %s",
+                        ble_device.address,
+                        exc,
+                    )
         else:
             record = await self._driver.get_latest_record(session)
             live_record: dict[str, Any] | None = None


### PR DESCRIPTION
For multi-user devices, get_latest_records_per_user() (the classic EEPROM index/full-scan path) was the only historical-record path ever attempted; the existing 0x2A35/0x2A52 (Record Access Control Point) probe was wired up only for single-user devices. When the EEPROM path returns zero valid records, also probe RACP purely for diagnostics — log whether the device even exposes those characteristics and what a "last stored record" request returns — without changing the (already-empty) result. This does not run at all for devices where the EEPROM path already finds records, so it changes nothing for working configurations.

Bump to v2.5.19.