### PR TITLE
ci: pin ruff rule selection so upgrades don't break the lint job

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,13 @@
+# Ruff configuration.
+#
+# CI installs ruff unpinned, so without this file the effective rule set is
+# whatever the latest release happens to enable by default — a ruff upgrade can
+# turn a green branch red without any code change. Pin the selection here
+# instead: E/F are the pycodestyle+pyflakes rules this codebase was already
+# clean against (real errors: undefined names, unused imports, syntax issues).
+[lint]
+select = ["E", "F"]
+
+# Long lines are pervasive in the device catalog and log-message formatting and
+# are not worth churning; everything else in E/F stays enforced.
+ignore = ["E501"]


### PR DESCRIPTION
The Lint job installs ruff unpinned, and the repo had no ruff config, so the effective rule set was whatever the newest release enables by default. Ruff 0.16 widened that default and the job started failing on 129 pre-existing findings across the codebase (66 BLE001, 12 S110, 12 I001, 11 DTZ001, ...) with no code change behind it.

Add ruff.toml selecting E+F — the pycodestyle/pyflakes rules this codebase was already clean against, covering the failures that actually matter (undefined names, unused imports, syntax problems) — and ignore E501, since long lines are pervasive in the device catalog and log formatting. Verified clean on ruff 0.16.0 for both custom_components/ and tests/, on this branch and on master.