### PR TITLE
fix: group HEM-7188T1-LE/-LEO under HEM-7142T2 (token-key, not ECDH)

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.23"
+  "version": "2.5.24"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -735,11 +735,10 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_FLBIN",
             "HEM-7183T1_FLIN",
             "HEM-7183T1_LAP",
-            # HEM-7188T1 family (LE/LEO — "X2+ Connect") moved to its own
-            # profile: 1 user / 30 records, and HEM-7188T1-LEO requires the
-            # full ECDH secure session (not just TOKEN_KEY) — see "HEM-7188T1".
             # HEM-7194T1 / HEM-7196T1 family shares this modern-stack profile
             # (OS bonding, FE4A parent service, same TX/RX UUIDs and EEPROM layout).
+            # HEM-7188T1 (LE/LEO — "X2+ Connect") is grouped under "HEM-7142T2"
+            # instead (single-user token-key transport, not this AFib layout).
             "HEM-7194T1-FLAP",
             "HEM-7194T1-FLCAP",
             "HEM-7194T1_FLBIN",
@@ -841,51 +840,17 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7388T1-AJF3",
         ),
     ),
-    # HEM-7188T1 family ("X2+ Connect") — same modern-stack lineage as
-    # HEM-7380T1, but confirmed via HCI btsnoop (HEM-7188T1-LEO) to need the
-    # full ECDH secure session, not just the TOKEN_KEY handshake: the official
-    # app sends a token unlock (0x11/0x91) and then immediately negotiates a
-    # secure session (pairing request/response, encryption start, mutual
-    # challenge) before any record access, and record-channel traffic
-    # afterward is CCM-encrypted too. The device is also 1 user / 30 records,
-    # not the 2 user / 100 record layout HEM-7380T1 uses. EEPROM addresses
-    # below are inherited from HEM-7380T1 (same family/likely same memory
-    # map) and are NOT independently verified for this model, since all GATT
-    # traffic after unlock is encrypted in the capture — confirm against a
-    # real read if data looks wrong. Only the "-LEO" suffix has been
-    # confirmed via btsnoop; "-LE" is grouped in as the same base model
-    # number and assumed identical hardware.
-    "HEM-7188T1": DeviceConfig(
-        **_MODERN_OS_BONDING_BASE,
-        model="HEM-7188T1",
-        connect_type=ConnectType.WLD3_0,
-        unlock_mode=UnlockMode.SECURE_SESSION,
-        os_bond_once=True,
-        endianness=Endianness.LITTLE,
-        user_start_addresses=[0x01C4],
-        per_user_records_count=[30],
-        record_byte_size=0x10,
-        transmission_block_size=0x38,
-        settings_read_address=0x0010,
-        settings_write_address=0x0054,
-        settings_unread_records_bytes=None,
-        settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
-        index_pointer_layout={
-            "index_region_byte_size": 0x18,
-            "endianness": "little",
-            "users": [
-                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
-            ],
-        },
-        record_parser=RecordParser.CLASSIC_VITAL_14,
-        equivalent_model_ids=(
-            "HEM-7188T1-LE",
-            "HEM-7188T1-LEO",
-        ),
-    ),
     # HEM-7142T2 — modern stack, MW3-style EEPROM, stateless 0x11/0x91 token
-    # handshake (same pattern as HEM-7155T-MW3; confirmed via HCI btsnoop).
+    # handshake (same pattern as HEM-7155T-MW3).
+    #
+    # HEM-7188T1-LE/-LEO ("X2+ Connect") are grouped here. They were previously
+    # given a dedicated profile using the application-layer ECDH secure session,
+    # but on a real HEM-7188T1-LEO that pairing request is rejected outright
+    # (error frame 0xff26) while the plaintext token-key path reads real
+    # measurement values (see hass-omron#92) — so the secure session is not
+    # required for record access on this device. Their record region may differ
+    # slightly from the 14-slot HEM-7142T2 layout (the latest reading can read
+    # a few slots stale); refine with an EEPROM index log if needed.
     "HEM-7142T2": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7142T2",
@@ -923,6 +888,8 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7142T2-Z",
             "HEM-7142T2-ZAZ",
             "HEM-7142T2_JAZ",
+            "HEM-7188T1-LE",
+            "HEM-7188T1-LEO",
             "HEM-716BT2-ZAZ",
             "HEM-716CT2-Z",
         ),

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -10,7 +10,7 @@ from custom_components.omron.omron_ble.devices import (
 class TestUnpairAfterSession:
     """unpair_after_session 은 os_bond_once=True 인 기기에서는 항상 False여야 한다.
 
-    두 플래그가 같이 켜져 있으면 (HEM-7380T1/HEM-7382T1/HEM-7188T1) 세션이
+    두 플래그가 같이 켜져 있으면 (HEM-7380T1/HEM-7382T1) 세션이
     끝날 때마다 os_bond_once가 재사용하려는 본드를 unpair()가 지워버려
     다음 연결이 post-connect settle에서 실패하는 회귀가 있었다.
     """
@@ -39,17 +39,20 @@ class TestUnpairAfterSession:
 class TestCatalogResolution:
     """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
 
-    def test_hem7188t1_leo_resolves_to_hem7188t1_profile(self):
-        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1"
+    def test_hem7188t1_leo_resolves_to_hem7142t2_profile(self):
+        # HEM-7188T1-LEO ("X2+ Connect") uses the plaintext token-key transport
+        # (grouped under HEM-7142T2), not the ECDH secure session that the
+        # device rejects with 0xff26 (see hass-omron#92).
+        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7142T2"
         # get_device_config keeps the requested variant string as .model (so
         # logs/UI show "HEM-7188T1-LEO"), while every other field is copied
-        # from the canonical "HEM-7188T1" profile.
+        # from the canonical "HEM-7142T2" profile.
         cfg = get_device_config("HEM-7188T1-LEO")
         assert cfg.model == "HEM-7188T1-LEO"
-        assert cfg.per_user_records_count == [30]
+        assert cfg.unlock_mode.value == "token_key"
 
     def test_hem7188t1_le_resolves_to_same_profile(self):
-        assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7188T1"
+        assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7142T2"
 
     def test_hem7155t_esl_is_classic_not_modern(self):
         # HEM-7155T_ESL (classic stack) must NOT resolve to the modern


### PR DESCRIPTION
HEM-7188T1-LEO ("X2+ Connect") had a dedicated profile using the application-layer ECDH secure session, but a real device rejects that pairing request outright with error frame 0xff26 — even with OS SMP bonding skipped and the phone fully unpaired. The plaintext token-key path (as used by HEM-7142T2) instead reads real measurement values from the same device, so the secure session is not required for record access here (see hass-omron#92).

Remove the dedicated SECURE_SESSION profile and group HEM-7188T1-LE/-LEO under HEM-7142T2 (single-user token-key transport). The record region may differ slightly from the 14-slot HEM-7142T2 layout — the latest reading can come back a few slots stale — which, like the normal-mode connection-drop seen on this WLD family, is left as a follow-up to refine against an EEPROM index log.

The SECURE_SESSION machinery is left intact (no profile uses it now) in case it's revisited. Bump to v2.5.24.