### PR TITLE
fix: give HEM-7188T1 its own profile again (still token-key for now)

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.5.24"
+  "version": "2.5.25"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -840,17 +840,54 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7388T1-AJF3",
         ),
     ),
+    # HEM-7188T1 family ("X2+ Connect") — kept as its own profile because its
+    # protocol family is genuinely different from HEM-7142T2 (connect_type
+    # WLD3.0 vs WLD1.0), so it needs to be independently tunable. Operationally
+    # it currently mirrors HEM-7142T2 (token-key transport, same EEPROM
+    # layout) as a working starting point: a dedicated profile using the
+    # application-layer ECDH secure session was tried, but on a real
+    # HEM-7188T1-LEO that pairing request is rejected outright (error frame
+    # 0xff26), while the plaintext token-key path reads real measurement
+    # values (see hass-omron#92). The record region/layout below is borrowed
+    # from HEM-7142T2 and not independently verified for this model — the
+    # latest reading can come back a few slots stale; refine against an
+    # EEPROM index log once available. Revisit unlock_mode=SECURE_SESSION
+    # once the ECDH rejection is understood.
+    "HEM-7188T1": DeviceConfig(
+        **_MODERN_OS_BONDING_BASE,
+        model="HEM-7188T1",
+        connect_type=ConnectType.WLD3_0,
+        unlock_mode=UnlockMode.TOKEN_KEY,
+        os_bond_once=True,
+        endianness=Endianness.LITTLE,
+        user_start_addresses=[0x02E8],
+        per_user_records_count=[14],
+        record_byte_size=0x0E,
+        transmission_block_size=0x38,
+        settings_read_address=0x0260,
+        settings_write_address=0x02A4,
+        settings_unread_records_bytes=None,
+        settings_time_sync_bytes=[0x2C, 0x3C],
+        time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
+        index_pointer_layout={
+            "index_region_byte_size": 0x10,
+            "endianness": "little",
+            "backtrack_slots": 0,
+            "users": [
+                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 13, "slot_index_bias": -1},
+            ],
+            "record_addresses": [0x02E8],
+            "record_byte_size": 0x0E,
+            "record_step": 0x0E,
+        },
+        record_parser=RecordParser.CLASSIC_VITAL_14,
+        equivalent_model_ids=(
+            "HEM-7188T1-LE",
+            "HEM-7188T1-LEO",
+        ),
+    ),
     # HEM-7142T2 — modern stack, MW3-style EEPROM, stateless 0x11/0x91 token
     # handshake (same pattern as HEM-7155T-MW3).
-    #
-    # HEM-7188T1-LE/-LEO ("X2+ Connect") are grouped here. They were previously
-    # given a dedicated profile using the application-layer ECDH secure session,
-    # but on a real HEM-7188T1-LEO that pairing request is rejected outright
-    # (error frame 0xff26) while the plaintext token-key path reads real
-    # measurement values (see hass-omron#92) — so the secure session is not
-    # required for record access on this device. Their record region may differ
-    # slightly from the 14-slot HEM-7142T2 layout (the latest reading can read
-    # a few slots stale); refine with an EEPROM index log if needed.
     "HEM-7142T2": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7142T2",
@@ -888,8 +925,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7142T2-Z",
             "HEM-7142T2-ZAZ",
             "HEM-7142T2_JAZ",
-            "HEM-7188T1-LE",
-            "HEM-7188T1-LEO",
             "HEM-716BT2-ZAZ",
             "HEM-716CT2-Z",
         ),

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -39,20 +39,19 @@ class TestUnpairAfterSession:
 class TestCatalogResolution:
     """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
 
-    def test_hem7188t1_leo_resolves_to_hem7142t2_profile(self):
-        # HEM-7188T1-LEO ("X2+ Connect") uses the plaintext token-key transport
-        # (grouped under HEM-7142T2), not the ECDH secure session that the
-        # device rejects with 0xff26 (see hass-omron#92).
-        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7142T2"
-        # get_device_config keeps the requested variant string as .model (so
-        # logs/UI show "HEM-7188T1-LEO"), while every other field is copied
-        # from the canonical "HEM-7142T2" profile.
+    def test_hem7188t1_leo_resolves_to_own_profile(self):
+        # HEM-7188T1-LEO ("X2+ Connect") keeps its own profile (distinct
+        # connect_type WLD3.0 vs HEM-7142T2's WLD1.0), but currently uses the
+        # plaintext token-key transport operationally, not the ECDH secure
+        # session that the device rejects with 0xff26 (see hass-omron#92).
+        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1"
         cfg = get_device_config("HEM-7188T1-LEO")
         assert cfg.model == "HEM-7188T1-LEO"
         assert cfg.unlock_mode.value == "token_key"
+        assert cfg.connect_type == ConnectType.WLD3_0
 
     def test_hem7188t1_le_resolves_to_same_profile(self):
-        assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7142T2"
+        assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7188T1"
 
     def test_hem7155t_esl_is_classic_not_modern(self):
         # HEM-7155T_ESL (classic stack) must NOT resolve to the modern


### PR DESCRIPTION
#106 folded HEM-7188T1-LE/-LEO's equivalent_model_ids straight into HEM-7142T2. That loses the distinction that matters: HEM-7188T1 is a different protocol family (connect_type WLD3.0, matching HEM-7380T1's AFib lineage) from HEM-7142T2 (WLD1.0), and HEM-7142T2 is a currently-working profile that shouldn't gain HEM-7188T1's baggage as that device gets iterated on separately.

Restore "HEM-7188T1" as its own canonical profile. It currently mirrors HEM-7142T2's operational settings (unlock_mode=TOKEN_KEY, same EEPROM layout as a working starting point) because the ECDH secure session is rejected by a real device (0xff26, hass-omron#92), but keeps connect_type=WLD3.0 and os_bond_once=True so it can be tuned independently once that's revisited.

Bump to v2.5.25.