### PR TITLE
feat: treat the WLD3.0 bond as single-session, behind one switch

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from .const import MODERN_STACK_PARENT_SERVICE_UUID
 from .devices import (
+    BondPolicy,
     ConnectType,
     DeviceConfig,
     Endianness,
@@ -11,6 +12,16 @@ from .devices import (
     TimeSyncLayout,
     UnlockMode,
 )
+
+# Bond strategy for the whole WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
+# 7188T1 / 7155T-MW3). These cuffs serve data during the pairing session and
+# then reject later connections, which fits a device that does not keep its
+# side of the bond; PER_SESSION drops ours to match, so every connection
+# bonds from scratch instead of offering a key the device has forgotten.
+#
+# Set this to BondPolicy.REUSE to put the family back on a kept bond — that
+# is the only change needed, every dependent behaviour is derived from it.
+_WLD3_BOND_POLICY = BondPolicy.PER_SESSION
 
 _MODERN_OS_BONDING_BASE = {
     "parent_service_uuid": MODERN_STACK_PARENT_SERVICE_UUID,
@@ -549,6 +560,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # Modern-fe4a-firmware HEM-7155T_ESL ("X4 Smart"); WLD3.0 like 7380T1.
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
+        bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8, 0x06A8],
         per_user_records_count=[60, 60],
@@ -706,10 +718,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7380T1",
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        # AFib family rotates its LTK each session; re-pairing on every
-        # pairing-mode advertisement churns the bond → AuthenticationFailed.
-        # Bond once at setup, then rely on the existing bond for polls.
-        os_bond_once=True,
+        bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0804],
         per_user_records_count=[100, 100],
@@ -779,7 +788,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7382T1",
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        os_bond_once=True,
+        bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0BCC],
         per_user_records_count=[60, 60],
@@ -815,7 +824,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7386T1",
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        os_bond_once=True,
+        bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0E4C],
         per_user_records_count=[100, 100],
@@ -858,7 +867,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7188T1",
         connect_type=ConnectType.WLD3_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        os_bond_once=True,
+        bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8],
         per_user_records_count=[14],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -49,6 +49,24 @@ class HostPairingMode(str, Enum):
     NONE = "none"
 
 
+class BondPolicy(StrEnum):
+    """Lifetime of the OS-level BLE bond, for ``host_pairing_mode=OS_BONDING``.
+
+    One switch for the whole bonding strategy, so a profile can be moved
+    between the two without leaving other flags to keep in sync. See
+    ``_WLD3_BOND_POLICY`` in the catalog for the family-wide setting.
+    """
+
+    # Bond once and keep reusing it across connections.
+    REUSE = "reuse"
+    # Treat a bond as good for a single session: drop it when the session
+    # closes so the next connection bonds from scratch. For devices that
+    # invalidate their side of the bond after each session, a kept bond is
+    # worse than none — the host offers an LTK the device no longer holds,
+    # security fails, and the device hangs up.
+    PER_SESSION = "per_session"
+
+
 class ConnectType(StrEnum):
     """OMRON communication type; groups devices by BLE bonding/transfer behaviour."""
 
@@ -109,8 +127,12 @@ class DeviceConfig:
     # (extra refresh/retry and pre-unlock 0x02 probe).
     aggressive_gatt_timing: bool = False
     # Bond once at setup and never re-pair on pairing-mode adverts (avoids bond
-    # churn). Only meaningful for host_pairing_mode=OS_BONDING.
+    # churn). Only meaningful for host_pairing_mode=OS_BONDING, and only when
+    # the profile does not already bond during connect (``pair_on_connect``),
+    # which makes the advert-triggered re-pair a no-op either way.
     os_bond_once: bool = False
+    # Bond lifetime; see BondPolicy. Only meaningful for OS_BONDING profiles.
+    bond_policy: BondPolicy = BondPolicy.REUSE
 
     # EEPROM layout
     endianness: Endianness = Endianness.BIG
@@ -244,38 +266,44 @@ class DeviceConfig:
 
     @property
     def unpair_after_session(self) -> bool:
-        """Drop the OS bond after each session (WLD3.0 devices re-key per session).
+        """Drop the OS bond when the session closes (``BondPolicy.PER_SESSION``).
 
-        Never true when ``os_bond_once`` is set: that flag means "bond once
-        and keep reusing it," which this would otherwise undo at the end of
-        every single session — including the one that just bonded — leaving
-        no bond for the next connection to reuse. Confirmed via HA logs
-        (HEM-7382T1): the post-pairing bond worked, an ignored ``unpair()``
-        ran anyway on session close, and the very next connection attempt
-        (moments later) then failed to complete the post-connect settle on
-        all retries because the bond it needed was gone.
+        Dropping a bond is only safe because ``pair_on_connect`` bonds again
+        on the next connect. Without that, an earlier build dropped the bond
+        and then had nothing to reconnect with: HA logs (HEM-7382T1) showed
+        the post-pairing bond working, ``unpair()`` running on session close,
+        and the very next connection failing the post-connect settle on all
+        retries because the bond it needed was gone.
         """
-        if self.os_bond_once:
-            return False
-        return self.connect_type == ConnectType.WLD3_0
+        return (
+            self.bond_policy == BondPolicy.PER_SESSION
+            and self.host_pairing_mode == HostPairingMode.OS_BONDING
+        )
 
     @property
     def pair_on_connect(self) -> bool:
-        """Bond during connect, before GATT discovery (WLD3.0 family).
+        """Bond during connect, before GATT discovery.
 
-        These cuffs drop the link shortly after connect when security is not
+        WLD3.0 cuffs drop the link shortly after connect when security is not
         already up. Bonding as part of connect establishes it before any
         characteristic is touched, whereas pairing after discovery leaves a
         window where the device sees an unencrypted host poking at GATT —
         which is when the observed disconnects happen. On an already-bonded
         device the backend re-encrypts with the stored LTK rather than
-        re-bonding, so this does not churn the bond that ``os_bond_once``
-        profiles rely on.
+        re-bonding, so this does not churn a kept bond.
+
+        Always true under ``BondPolicy.PER_SESSION``, which is what makes
+        dropping the bond safe: the pairing that replaces it is part of the
+        next connect. Deriving it here rather than asking profiles to set
+        both means "drop the bond but never make a new one" — an earlier
+        regression that left the next connection with nothing to reconnect
+        with — cannot be configured at all.
         """
-        return (
-            self.connect_type == ConnectType.WLD3_0
-            and self.host_pairing_mode == HostPairingMode.OS_BONDING
-        )
+        if self.host_pairing_mode != HostPairingMode.OS_BONDING:
+            return False
+        if self.bond_policy == BondPolicy.PER_SESSION:
+            return True
+        return self.connect_type == ConnectType.WLD3_0
 
     def is_service_compatible(self, service_uuids: list[str]) -> bool:
         """Check whether advertised GATT services match this profile's parent service."""

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -443,10 +443,12 @@ async def _bluez_agent_pair(client: BleakClient) -> bool:
         # agent and disconnects it on the way out — do not close it here.
 
 
-async def _bluez_remove_device(client: BleakClient) -> bool:
+async def _bluez_remove_device(client: BleakClient | BLEDevice) -> bool:
     """Remove the BlueZ device + bond via DBus Adapter1.RemoveDevice.
 
     Used because BleakClient.unpair() is a no-op on the HA/habluetooth backend.
+    Accepts a bare BLEDevice too, so a bond can still be cleared after a
+    connect attempt failed and there is no client to unpair through.
     Returns True on success; False otherwise (caller falls back to unpair()).
     """
     try:
@@ -651,12 +653,41 @@ class OmronDeviceSession:
             raise ConnectionError(
                 "OmronDeviceSession.adopt() sessions cannot connect; open the client first"
             )
-        self._client = await establish_connection_with_bond_settle(
-            self._ble_device,
-            self.address,
-            pair_on_connect=self._config.pair_on_connect,
-            model=self._config.model,
-        )
+        try:
+            self._client = await establish_connection_with_bond_settle(
+                self._ble_device,
+                self.address,
+                pair_on_connect=self._config.pair_on_connect,
+                model=self._config.model,
+            )
+        except BaseException:
+            # A half-established bond is worse than none for PER_SESSION
+            # profiles: the next connect would offer a key the device does
+            # not hold. Clear it here, where aclose() cannot (no client).
+            # Never let the cleanup mask the connect failure — including when
+            # we got here through cancellation and the await is cancelled too.
+            if self._config.unpair_after_session:
+                try:
+                    if await _bluez_remove_device(self._ble_device):
+                        _LOGGER.debug(
+                            "Removed bond for %s after a failed connect",
+                            self.address,
+                        )
+                    else:
+                        # Proxy backends need a client for the unpair RPC and
+                        # there is none after a failed connect, so any bond the
+                        # proxy stored stays until the next successful session.
+                        _LOGGER.debug(
+                            "Could not clear the bond for %s after a failed "
+                            "connect (no DBus path for this backend)",
+                            self.address,
+                        )
+                except Exception as exc:
+                    _LOGGER.debug(
+                        "Bond cleanup after failed connect to %s skipped: %s",
+                        self.address, exc,
+                    )
+            raise
         return self
 
     async def refresh_services(self) -> None:
@@ -762,10 +793,20 @@ class OmronDeviceSession:
                     await self.close_memory_session()
                 except Exception:
                     pass
-            # Drop the bond while still connected so the next connection re-pairs
-            # fresh (WLD3.0 devices re-key each session).
-            if self._config.unpair_after_session and client.is_connected:
-                await self.unpair()
+            # Drop the bond so the next connection bonds from scratch
+            # (BondPolicy.PER_SESSION). Prefer the DBus RemoveDevice, which
+            # also works once the link is down; unpair() is the fallback and
+            # is what actually reaches the ESP32 on proxy backends.
+            if self._config.unpair_after_session:
+                if not await _bluez_remove_device(client):
+                    if client.is_connected:
+                        await self.unpair()
+                    else:
+                        _LOGGER.debug(
+                            "Bond for %s left in place: link already down and "
+                            "no DBus path to remove it through",
+                            addr,
+                        )
             if self._owns_connection and client.is_connected:
                 await client.disconnect()
                 disconnected = True

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -1,5 +1,6 @@
 """devices.py / device_catalog.py 단위 테스트."""
 from custom_components.omron.omron_ble.devices import (
+    BondPolicy,
     ConnectType,
     DeviceConfig,
     HostPairingMode,
@@ -9,33 +10,51 @@ from custom_components.omron.omron_ble.devices import (
 )
 
 
-class TestUnpairAfterSession:
-    """unpair_after_session 은 os_bond_once=True 인 기기에서는 항상 False여야 한다.
+class TestBondPolicy:
+    """세션 종료 시 본드 삭제 여부는 bond_policy 하나로 결정된다."""
 
-    두 플래그가 같이 켜져 있으면 (HEM-7380T1/HEM-7382T1) 세션이
-    끝날 때마다 os_bond_once가 재사용하려는 본드를 unpair()가 지워버려
-    다음 연결이 post-connect settle에서 실패하는 회귀가 있었다.
-    """
-
-    def test_wld3_without_bond_once_unpairs(self):
-        cfg = DeviceConfig(model="test", connect_type=ConnectType.WLD3_0)
+    def test_per_session_drops_the_bond(self):
+        cfg = DeviceConfig(
+            model="test",
+            host_pairing_mode=HostPairingMode.OS_BONDING,
+            unlock_mode=UnlockMode.TOKEN_KEY,
+            bond_policy=BondPolicy.PER_SESSION,
+        )
         assert cfg.unpair_after_session is True
 
-    def test_wld3_with_bond_once_never_unpairs(self):
+    def test_reuse_keeps_the_bond(self):
         cfg = DeviceConfig(
-            model="test", connect_type=ConnectType.WLD3_0, os_bond_once=True
+            model="test",
+            host_pairing_mode=HostPairingMode.OS_BONDING,
+            unlock_mode=UnlockMode.TOKEN_KEY,
+            bond_policy=BondPolicy.REUSE,
         )
         assert cfg.unpair_after_session is False
 
-    def test_non_wld3_never_unpairs(self):
-        cfg = DeviceConfig(model="test", connect_type=ConnectType.UNKNOWN)
+    def test_reuse_is_the_default(self):
+        cfg = DeviceConfig(model="test")
+        assert cfg.bond_policy == BondPolicy.REUSE
         assert cfg.unpair_after_session is False
 
-    def test_non_wld3_with_bond_once_never_unpairs(self):
-        cfg = DeviceConfig(
-            model="test", connect_type=ConnectType.UNKNOWN, os_bond_once=True
-        )
+    def test_non_os_bonding_never_unpairs(self):
+        # 클래식(커스텀 키) 기기에는 지울 OS 본드가 없다.
+        cfg = DeviceConfig(model="test", bond_policy=BondPolicy.PER_SESSION)
+        assert cfg.host_pairing_mode == HostPairingMode.CUSTOM_KEY
         assert cfg.unpair_after_session is False
+
+    def test_per_session_always_pairs_on_connect(self):
+        # 본드를 버리는 프로파일은 connect 에서 다시 본딩하는 게 파생으로 보장된다
+        # (connect_type 이 WLD3.0 이 아니어도). 본드도 없고 재페어링도 없는 조합은
+        # 설정 자체가 불가능해야 한다.
+        cfg = DeviceConfig(
+            model="test",
+            connect_type=ConnectType.WLD1_0,
+            host_pairing_mode=HostPairingMode.OS_BONDING,
+            unlock_mode=UnlockMode.TOKEN_KEY,
+            bond_policy=BondPolicy.PER_SESSION,
+        )
+        assert cfg.unpair_after_session is True
+        assert cfg.pair_on_connect is True
 
 
 class TestPairOnConnect:


### PR DESCRIPTION
WLD3.0 cuffs hand over data during the pairing session and then reject later connections. That fits a device that does not keep its side of the bond: the host reconnects offering an LTK the cuff has forgotten, security fails, and the cuff hangs up. Keeping our bond is then worse than having none.

Add BondPolicy (REUSE / PER_SESSION) as the single knob for bond lifetime, and put the WLD3.0 family on PER_SESSION via one catalog constant, _WLD3_BOND_POLICY. unpair_after_session is now derived from the policy rather than from os_bond_once, so there is no second flag to keep in sync — flipping that one constant back to REUSE restores the previous behaviour and nothing else has to change.

Dropping the bond is only safe when something re-establishes it, so pair_on_connect is derived to be true under PER_SESSION rather than left for profiles to set alongside it. "Drop the bond but never make a new one" — the earlier regression that left the next connection with nothing to reconnect with — is therefore not configurable at all, instead of being a rule a profile could forget and a test would have to catch.

Strengthen the bond cleanup so the policy actually holds:
- _bluez_remove_device accepts a bare BLEDevice, so a bond can be cleared after a connect attempt failed and there is no client left
- aclose() prefers DBus RemoveDevice (which works with the link already down) and falls back to unpair(), the path that reaches the ESP32 on proxy backends
- connect() clears the bond when it fails, guarded so the cleanup can never mask the connect error — including under cancellation — and logs when a proxy backend leaves one behind

Version unchanged (2.6.0).