### PR TITLE
fix: bound the poll so a stuck BLE call can't wedge the integration

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -45,6 +45,16 @@ _LOGGER = logging.getLogger(__name__)
 POLL_COOLDOWN_SECONDS = 60
 SETTLE_DELAY_SECONDS = 0.5
 
+# Hard ceiling on one poll. Bleak's BlueZ backend puts no timeout on its
+# read/write/notify D-Bus calls (only ``disconnect`` is bounded), so a wedged
+# bluetoothd leaves the poll awaiting forever. That poll holds ``session_lock``,
+# and from then on every scheduled poll, Refresh Data press and advertisement
+# trigger bails out on the held lock — the integration goes silent with no error
+# logged until Home Assistant restarts. The deadline gives the lock back.
+# Budget: a worst-case connect (~90 s over 4 attempts) plus the memory-session
+# retries. Past that the link is stuck, not slow.
+POLL_TIMEOUT_SECONDS = 180
+
 # When a poll fails mid-flight, keep measurement history but drop stale RSSI/battery
 # unless this poll refreshed those keys (avoids showing outdated diagnostics).
 _STALE_DROP_SENSOR_DEVICE_CLASSES: frozenset = frozenset({
@@ -339,13 +349,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
             async with session_lock:
                 async with omron_poll_ble_telemetry(entry_data):
                     handed_off = True
-                    result = await coordinator.device_data.async_poll(
-                        device, preconnected_session=preconnected_session
-                    )
+                    async with asyncio.timeout(POLL_TIMEOUT_SECONDS):
+                        result = await coordinator.device_data.async_poll(
+                            device, preconnected_session=preconnected_session
+                        )
                 prev_data = poll_coordinator.data
                 if prev_data is not None:
                     result = _merge_poll_sensor_update(prev_data, result)
                 return result
+        except TimeoutError:
+            # Only our own deadline surfaces here: async_poll handles every
+            # Exception internally, so nothing else escapes it as a timeout.
+            # Warn rather than debug — this is the one symptom a user sees when
+            # the BLE stack stops responding, and it used to be invisible.
+            _LOGGER.warning(
+                "Poll for %s exceeded %d s and was cancelled; the BLE stack "
+                "stopped responding mid-poll. Serving cached data — the session "
+                "lock is released, so the next poll can retry",
+                address,
+                POLL_TIMEOUT_SECONDS,
+            )
+            if poll_coordinator.data is not None:
+                return poll_coordinator.data
+            return entry.runtime_data.device_data._finish_update()
         except Exception as err:
             _LOGGER.debug("polling error; keeping last successful poll data: %s", err)
             if poll_coordinator.data is not None:

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
   "iot_class": "local_polling",
-  "version": "2.6.0"
+  "version": "2.6.1"
 }

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1164,7 +1164,7 @@ class OmronBluetoothDeviceData(BluetoothData):
                             )
                         else:
                             memory_session_active = False
-                            last_session_exc: BaseException | None = None
+                            last_session_exc: Exception | None = None
                             for session_attempt in range(3):
                                 try:
                                     pair_first = (
@@ -1184,7 +1184,14 @@ class OmronBluetoothDeviceData(BluetoothData):
                                             memory_session_active=True,
                                         )
                                     break
-                                except BaseException as exc:
+                                # Exception, never BaseException: the poll
+                                # deadline (POLL_TIMEOUT_SECONDS) cancels this
+                                # task exactly once, so swallowing that
+                                # CancelledError here would drop the loop into
+                                # another unbounded GATT wait with no deadline
+                                # left to fire — the wedge the deadline exists
+                                # to break.
+                                except Exception as exc:
                                     last_session_exc = exc
                                     _LOGGER.debug(
                                         "Memory session open attempt %d/3 failed: %s",
@@ -1229,7 +1236,9 @@ class OmronBluetoothDeviceData(BluetoothData):
                                             ble_device,
                                             memory_session_active=True,
                                         )
-                                except BaseException as fallback_exc:
+                                # Exception, never BaseException — see above:
+                                # cancellation has to reach the poll deadline.
+                                except Exception as fallback_exc:
                                     _LOGGER.debug(
                                         "Fallback memory session readout failed: %s",
                                         fallback_exc,

--- a/tests/test_poll_deadline.py
+++ b/tests/test_poll_deadline.py
@@ -1,0 +1,104 @@
+"""폴 데드라인 회귀 테스트 (hass-omron#110).
+
+bleak 의 BlueZ 백엔드는 read/write/notify D-Bus 호출에 타임아웃을 걸지 않는다
+(경계가 있는 건 disconnect 뿐이다). 그래서 bluetoothd 가 물리면 폴 하나가
+영원히 대기하고, 그 폴이 session_lock 을 쥔 채로 남아 이후의 모든 예약 폴 /
+Refresh Data / 광고 트리거가 "lock held" 로 조용히 빠져나간다. 로그도 안 남고
+HA 재시작 전까지 통합이 죽는다.
+
+이를 막는 두 불변조건을 소스 구조 수준에서 고정한다:
+
+1. _async_poll_data 는 async_poll 을 asyncio.timeout 으로 감싼다.
+2. async_poll 의 예외 핸들러는 CancelledError 를 삼키지 않는다. asyncio.timeout
+   은 마감 시각에 태스크를 딱 한 번만 취소하므로, 그 CancelledError 를 삼키면
+   루프가 다음 무경계 대기로 넘어가고 다시 발동할 데드라인이 남지 않는다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환하는 탓에 실제 인스턴스를
+만들 수 없어(클래스 자체가 MagicMock 이 된다) 런타임 대신 AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "omron"
+
+
+def _parse(relative_path: str) -> ast.Module:
+    return ast.parse((_COMPONENT / relative_path).read_text(encoding="utf-8"))
+
+
+def _find_async_function(tree: ast.AST, name: str) -> ast.AsyncFunctionDef:
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AsyncFunctionDef) and node.name == name:
+            return node
+    raise AssertionError(
+        f"{name} 을(를) 찾지 못했다 — 이름을 바꿨다면 이 테스트도 함께 갱신할 것"
+    )
+
+
+def _caught_names(handler: ast.ExceptHandler) -> list[str]:
+    if handler.type is None:
+        return ["<bare except>"]
+    caught = (
+        handler.type.elts if isinstance(handler.type, ast.Tuple) else [handler.type]
+    )
+    return [ast.unparse(node) for node in caught]
+
+
+class TestPollDeadline:
+    """예약 폴은 반드시 유한 시간 안에 session_lock 을 돌려줘야 한다."""
+
+    def test_poll_is_wrapped_in_asyncio_timeout(self):
+        fn = _find_async_function(_parse("__init__.py"), "_async_poll_data")
+        wrapped = [
+            item
+            for node in ast.walk(fn)
+            if isinstance(node, ast.AsyncWith)
+            for item in node.items
+            if isinstance(item.context_expr, ast.Call)
+            and ast.unparse(item.context_expr.func) == "asyncio.timeout"
+        ]
+        assert wrapped, (
+            "_async_poll_data 는 async_poll 을 asyncio.timeout 으로 감싸야 한다. "
+            "감싸지 않으면 무경계 GATT 대기가 session_lock 을 영구 점유한다."
+        )
+
+    def test_poll_timeout_constant_is_positive(self):
+        tree = _parse("__init__.py")
+        values = [
+            ast.literal_eval(node.value)
+            for node in tree.body
+            if isinstance(node, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "POLL_TIMEOUT_SECONDS"
+                for target in node.targets
+            )
+        ]
+        assert values, "POLL_TIMEOUT_SECONDS 상수가 모듈 최상단에 있어야 한다"
+        assert values[0] > 0
+
+
+class TestCancellationEscapesPoll:
+    """데드라인이 보낸 취소는 async_poll 밖으로 빠져나가야 한다."""
+
+    def test_async_poll_does_not_swallow_cancellation(self):
+        fn = _find_async_function(_parse("omron_ble/parser.py"), "async_poll")
+
+        swallowed: list[str] = []
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.ExceptHandler):
+                continue
+            # 다시 raise 하는 핸들러는 취소가 그대로 전파되므로 문제없다.
+            if any(isinstance(stmt, ast.Raise) for stmt in ast.walk(node)):
+                continue
+            swallowed += [
+                name
+                for name in _caught_names(node)
+                if name
+                in ("BaseException", "<bare except>", "CancelledError",
+                    "asyncio.CancelledError")
+            ]
+
+        assert not swallowed, (
+            f"async_poll 이 {swallowed} 을(를) 삼키고 계속 진행한다. "
+            "CancelledError 를 삼키면 폴 데드라인이 무력화된다 — Exception 으로 좁힐 것."
+        )


### PR DESCRIPTION
## Problem

Reported in #110 (HEM-7146T2-EBK, ESP32 proxy): polling works for a while, then a connect is logged and the device goes completely quiet. `Refresh Data` and `Retry Pairing` do nothing, a reload only occasionally helps, and usually the integration has to be deleted and re-added.

The reporter's log shows errors recurring for ~6 hours (`Memory session failed`, connect timeouts, `TX timeout`) and then stopping entirely. Errors that raise are handled and the lock is released, so those are not what wedges it — the terminal state is a poll that never returns at all.

That is reachable today:

| Layer | Timeout on GATT ops? |
| --- | --- |
| `DataUpdateCoordinator` | No — `_async_update_data` just awaits `update_method()` |
| habluetooth `HaBleakClientWrapper` | No — GATT calls are delegated straight to the backend |
| bleak BlueZ backend | **No** for `read_gatt_char` / `write_gatt_char` / `start_notify` / `stop_notify`; only `disconnect` is bounded |
| bleak ESPHome path | Yes (the 10 s / 20 s values in the reporter's log) |

The reporter's traceback shows the BlueZ path in use, so those unbounded calls are live in their setup. The last error before the silence is `BLE disconnected (open_memory_session)`, whose path runs straight into `start_notify` / `stop_notify`.

Once a poll hangs there it holds `session_lock` forever, and from then on every scheduled poll (`__init__.py`), `Refresh Data` (blocked behind the coordinator's in-flight refresh) and advertisement trigger bails out — at debug level, so nothing appears in the log. A reload does not clear it: `async_shutdown` cancels the *scheduled* refresh, not the in-flight one, so the stuck task keeps holding the BLE link against the new entry.

## Changes

**1. `POLL_TIMEOUT_SECONDS = 180` deadline around the poll** (`__init__.py`)

`async_poll` runs inside `asyncio.timeout(...)`, so the lock always comes back. On expiry we log a **warning** (previously this failure was completely invisible) and serve cached data. The budget covers a worst-case connect (~90 s over 4 attempts) plus the memory-session retries; past that the link is stuck, not slow.

**2. The retry loop no longer swallows cancellation** (`omron_ble/parser.py`)

Two `except BaseException` handlers in the memory-session retry loop are narrowed to `except Exception`. This is required for change 1 to work at all: `asyncio.timeout` cancels the task **exactly once**, so a handler that catches that `CancelledError` and continues sends the loop into the next unbounded GATT wait with no deadline left to fire. `Exception` still covers every error these handlers were written for.

(The two `except BaseException` blocks in `omron_driver.py` re-raise after cleanup and are left alone.)

## Tests

`tests/test_poll_deadline.py` pins both invariants. They are structural (AST) rather than runtime: `conftest.py` replaces `homeassistant` and `bleak` with `MagicMock`, which makes `OmronBluetoothDeviceData` itself a mock, so no real instance can be built to drive a poll.

Verified non-vacuous — all three fail against the pre-fix code:

```
FAILED tests/test_poll_deadline.py::TestPollDeadline::test_poll_is_wrapped_in_asyncio_timeout
FAILED tests/test_poll_deadline.py::TestPollDeadline::test_poll_timeout_constant_is_positive
FAILED tests/test_poll_deadline.py::TestCancellationEscapesPoll::test_async_poll_does_not_swallow_cancellation
```

Full suite after the fix: 33 passed. `ruff check custom_components/ tests/` clean.

## Scope / what this does not fix

- **Not a fix for the underlying link failures.** #110 also shows connection-source ping-pong between a local BlueZ dongle and the ESP32 proxy. For an `OS_BONDING` profile like HEM-7146T the LTK lives on whichever controller bonded, so alternating sources can explain the recurring `StartNotify ... UnknownObject` / memory-session failures. This PR makes the integration survive that instead of dying silently.
- **Cleanup is still unbounded.** After the deadline fires, `aclose()` → `close_memory_session()` / `disconnect()` runs during unwind and can itself block on the same BlueZ calls. Per-operation timeouts on `start_notify` / `stop_notify` / GATT reads and on `aclose()` are the natural follow-up.
- The `Address mismatch: got b'\x02\`', expected 0x03e4` in #110 is a separate defect (a late reply from a retried command satisfies the next command's wait) and is not addressed here.

Refs #110
