### PR TITLE
fix: correct HEM-7188T1 EEPROM memory map, record layout, and connect type

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -746,8 +746,6 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_LAP",
             # HEM-7194T1 / HEM-7196T1 family shares this modern-stack profile
             # (OS bonding, FE4A parent service, same TX/RX UUIDs and EEPROM layout).
-            # HEM-7188T1 (LE/LEO — "X2+ Connect") is grouped under "HEM-7142T2"
-            # instead (single-user token-key transport, not this AFib layout).
             "HEM-7194T1-FLAP",
             "HEM-7194T1-FLCAP",
             "HEM-7194T1_FLBIN",
@@ -849,45 +847,36 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7388T1-AJF3",
         ),
     ),
-    # HEM-7188T1 family ("X2+ Connect") — kept as its own profile because its
-    # protocol family is genuinely different from HEM-7142T2 (connect_type
-    # WLD3.0 vs WLD1.0), so it needs to be independently tunable. Operationally
-    # it currently mirrors HEM-7142T2 (token-key transport, same EEPROM
-    # layout) as a working starting point: a dedicated profile using the
-    # application-layer ECDH secure session was tried, but on a real
-    # HEM-7188T1-LEO that pairing request is rejected outright (error frame
-    # 0xff26), while the plaintext token-key path reads real measurement
-    # values (see hass-omron#92). The record region/layout below is borrowed
-    # from HEM-7142T2 and not independently verified for this model — the
-    # latest reading can come back a few slots stale; refine against an
-    # EEPROM index log once available. Revisit unlock_mode=SECURE_SESSION
-    # once the ECDH rejection is understood.
+    # HEM-7188T1 family ("X2+ Connect" / "M2+") — dedicated single-user profile
+    # with WLD4.0 transport (ConnectType.WLD4_0) and 30-slot 16-byte record
+    # layout at 0x01C4 with index pointer layout at 0x0010.
+    # Operationally uses token-key transport (UnlockMode.TOKEN_KEY): an
+    # application-layer ECDH secure session (0x70 0x01) was tried, but real
+    # devices reject the pairing request with error frame 0xff26, while the
+    # plaintext token-key path reads real measurement values. Revisit
+    # unlock_mode=SECURE_SESSION once the ECDH rejection is understood.
     "HEM-7188T1": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7188T1",
-        connect_type=ConnectType.WLD3_0,
+        connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
         bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
-        user_start_addresses=[0x02E8],
-        per_user_records_count=[14],
-        record_byte_size=0x0E,
+        user_start_addresses=[0x01C4],
+        per_user_records_count=[30],
+        record_byte_size=0x10,
         transmission_block_size=0x38,
-        settings_read_address=0x0260,
-        settings_write_address=0x02A4,
+        settings_read_address=0x0010,
+        settings_write_address=0x0054,
         settings_unread_records_bytes=None,
         settings_time_sync_bytes=[0x2C, 0x3C],
         time_sync_layout=TimeSyncLayout.MODERN_OFFSET8,
         index_pointer_layout={
-            "index_region_byte_size": 0x10,
+            "index_region_byte_size": 0x18,
             "endianness": "little",
-            "backtrack_slots": 0,
             "users": [
-                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 13, "slot_index_bias": -1},
+                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
             ],
-            "record_addresses": [0x02E8],
-            "record_byte_size": 0x0E,
-            "record_step": 0x0E,
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
         equivalent_model_ids=(

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -75,6 +75,7 @@ class ConnectType(StrEnum):
     WLD1_0 = "WLD1.0"
     WLD2_0 = "WLD2.0"
     WLD3_0 = "WLD3.0"
+    WLD4_0 = "WLD4.0"
     WLS3_0 = "WLS3.0"
 
 
@@ -303,7 +304,7 @@ class DeviceConfig:
             return False
         if self.bond_policy == BondPolicy.PER_SESSION:
             return True
-        return self.connect_type == ConnectType.WLD3_0
+        return self.connect_type in (ConnectType.WLD3_0, ConnectType.WLD4_0)
 
     def is_service_compatible(self, service_uuids: list[str]) -> bool:
         """Check whether advertised GATT services match this profile's parent service."""

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -114,28 +114,34 @@ class TestPairOnConnect:
             CANONICAL_DEVICE_PROFILES,
         )
 
-        wld3 = [
+        wld3_4 = [
             c
             for c in CANONICAL_DEVICE_PROFILES.values()
-            if c.connect_type == ConnectType.WLD3_0
+            if c.connect_type in (ConnectType.WLD3_0, ConnectType.WLD4_0)
         ]
-        assert wld3, "카탈로그에 WLD3.0 프로파일이 있어야 한다"
-        assert all(c.pair_on_connect for c in wld3)
+        assert wld3_4, "카탈로그에 WLD3.0/WLD4.0 프로파일이 있어야 한다"
+        assert all(c.pair_on_connect for c in wld3_4)
 
 
 class TestCatalogResolution:
     """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
 
     def test_hem7188t1_leo_resolves_to_own_profile(self):
-        # HEM-7188T1-LEO ("X2+ Connect") keeps its own profile (distinct
-        # connect_type WLD3.0 vs HEM-7142T2's WLD1.0), but currently uses the
-        # plaintext token-key transport operationally, not the ECDH secure
-        # session that the device rejects with 0xff26 (see hass-omron#92).
+        # HEM-7188T1-LEO ("X2+ Connect") keeps its own dedicated profile
+        # (distinct connect_type WLD4.0 vs HEM-7142T2's WLD1.0) with corrected
+        # memory map layout.
         assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1"
         cfg = get_device_config("HEM-7188T1-LEO")
         assert cfg.model == "HEM-7188T1-LEO"
         assert cfg.unlock_mode.value == "token_key"
-        assert cfg.connect_type == ConnectType.WLD3_0
+        assert cfg.connect_type == ConnectType.WLD4_0
+        assert cfg.user_start_addresses == [0x01C4]
+        assert cfg.per_user_records_count == [30]
+        assert cfg.record_byte_size == 0x10
+        assert cfg.settings_read_address == 0x0010
+        assert cfg.settings_write_address == 0x0054
+        assert cfg.index_pointer_layout["index_region_byte_size"] == 0x18
+        assert cfg.index_pointer_layout["users"][0]["slot_index_max"] == 29
 
     def test_hem7188t1_le_resolves_to_same_profile(self):
         assert resolve_profile_model_id("HEM-7188T1-LE") == "HEM-7188T1"


### PR DESCRIPTION
## Summary
Corrects the `HEM-7188T1` ("X2+ Connect" / "M2+") profile configuration:
- Add `ConnectType.WLD4_0` ("WLD4.0") to `ConnectType` enum and assign to `HEM-7188T1`
- Update user record start address to `0x01C4`
- Set record slot count to 30 and record byte size to 16 (`0x10`)
- Update settings read/write addresses to `0x0010` / `0x0054`
- Update index pointer region size to `0x18` with slot index range `0..29`
- Clean up redundant default parameters in `index_pointer_layout` and outdated comments
- Document the history/rationale of `unlock_mode=TOKEN_KEY` due to device-side rejection (`0xff26`) of application-layer ECDH pairing requests