### PR TITLE
fix: apply payload truncation check only to memory read frames (0x8100)

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -989,6 +989,17 @@ class OmronDeviceSession:
         if self._config.is_single_channel:
             frame_bytes = bytearray(self._channel_fragments[0])
             self._channel_fragments = [None] * 4
+            declared = frame_bytes[0] if frame_bytes else 0
+            if declared and len(frame_bytes) < declared:
+                _LOGGER.warning(
+                    "Truncated BLE frame: declared %d bytes, received %d: %s",
+                    declared,
+                    len(frame_bytes),
+                    _hex(frame_bytes),
+                )
+                return
+            if declared:
+                frame_bytes = frame_bytes[:declared]
         else:
             packet_size = self._channel_fragments[0][0]
             if packet_size == 0:
@@ -1060,23 +1071,25 @@ class OmronDeviceSession:
             )
             return
 
-        # Guard against truncated payload: must have room for header (6) + payload (expected_data_len) + response_code (1) + CRC (1) = 8
-        if len(frame_bytes) < expected_data_len + 8:
-            _LOGGER.warning(
-                "Truncated BLE frame received (expected %d bytes payload, available %d): %s",
-                expected_data_len,
-                max(0, len(frame_bytes) - 8),
-                _hex(frame_bytes),
-            )
-            return
-
         self._last_reply_packet_type = packet_type
         self._last_reply_memory_address = memory_address
-        if packet_type == b"\x8f\x00":
+        if packet_type == b"\x81\x00":
+            # Memory block read: payload length in byte 5, payload at bytes 6..6+data_len
+            if len(frame_bytes) < expected_data_len + 8:
+                _LOGGER.warning(
+                    "Truncated BLE read frame received (expected %d bytes payload, available %d): %s",
+                    expected_data_len,
+                    max(0, len(frame_bytes) - 8),
+                    _hex(frame_bytes),
+                )
+                return
+            self._last_reply_payload = bytes(frame_bytes[6:6 + expected_data_len])
+        elif packet_type == b"\x8f\x00":
             # End-of-transmission packet: error code is in byte 6
             self._last_reply_payload = bytes(frame_bytes[6:7])
         else:
-            self._last_reply_payload = bytes(frame_bytes[6:6 + expected_data_len])
+            # Control frame (e.g. 0x8000 session open, 0x81c0 write response): response code in byte 6
+            self._last_reply_payload = bytes(frame_bytes[6:7])
 
         self._reply_ready.set()
 
@@ -1250,6 +1263,10 @@ class OmronDeviceSession:
             await self._write_command_and_wait_reply(start_cmd)
             if self._last_reply_packet_type != bytearray.fromhex("8000"):
                 raise ConnectionError("Invalid response to data readout start")
+            if self._last_reply_payload and self._last_reply_payload[0]:
+                raise ConnectionError(
+                    f"Device rejected memory session open (error code 0x{self._last_reply_payload[0]:02x})"
+                )
             self._memory_session_active = True
             self._debug_ble_link("open_memory_session_ok")
             _LOGGER.debug("Memory session opened for %s", self.address)

--- a/tests/test_rx_notification_handling.py
+++ b/tests/test_rx_notification_handling.py
@@ -45,6 +45,47 @@ class TestRxNotificationHandling:
         assert self.session._last_reply_packet_type == b"\x81\x00"
         assert self.session._last_reply_payload == b"\x01\x02\x03\x04"
 
+    def test_session_open_8000_frame_accepted(self):
+        # Real-device open_memory_session response: 0880000000100098 (8 bytes, byte[5]=0x10)
+        # Must not be rejected as a truncated frame.
+        raw = bytearray.fromhex("0880000000100098")
+        self.session._expected_reply_packet_type = b"\x80\x00"
+        self.session._on_notify_channel_data(0, raw)
+
+        assert self.session._reply_ready.is_set()
+        assert self.session._last_reply_packet_type == b"\x80\x00"
+        assert self.session._last_reply_payload == b"\x00"
+
+    def test_session_close_8f00_frame_accepted_with_nonzero_byte5(self):
+        # Control frame 8f00 with non-zero byte[5] and response code 0
+        raw = bytearray([0x08, 0x8F, 0x00, 0x00, 0x00, 0x10, 0x00])
+        raw.append(_calc_crc(raw))
+        self.session._expected_reply_packet_type = b"\x8f\x00"
+        self.session._on_notify_channel_data(0, raw)
+
+        assert self.session._reply_ready.is_set()
+        assert self.session._last_reply_packet_type == b"\x8f\x00"
+        assert self.session._last_reply_payload == b"\x00"
+
+    def test_memory_write_81c0_frame_accepted_with_nonzero_byte5(self):
+        # Control frame 81c0 (write response) with non-zero byte[5] and response code 0
+        raw = bytearray([0x08, 0x81, 0xC0, 0x00, 0x00, 0x0A, 0x00])
+        raw.append(_calc_crc(raw))
+        self.session._expected_reply_packet_type = b"\x81\xC0"
+        self.session._on_notify_channel_data(0, raw)
+
+        assert self.session._reply_ready.is_set()
+        assert self.session._last_reply_packet_type == b"\x81\xC0"
+        assert self.session._last_reply_payload == b"\x00"
+
+    def test_single_channel_declared_length_truncation_is_ignored(self):
+        # Single channel frame declares 16 bytes, but only 8 bytes received
+        short_frame = bytearray([16, 0x81, 0x00, 0x00, 0x00, 0x08, 0x00, 0x00])
+        self.session._on_notify_channel_data(0, short_frame)
+
+        assert not self.session._reply_ready.is_set()
+        assert self.session._last_reply_payload is None
+
     def test_undersized_frame_is_ignored(self):
         short_frame = bytearray([0x04, 0x81, 0x00, 0x05])
         self.session._on_notify_channel_data(0, short_frame)


### PR DESCRIPTION
## Problem
In PR #116, a frame truncation guard was added checking `len(frame_bytes) < expected_data_len + 8`.
For session open (`0x8000`) responses (e.g. `0880000000100098`), byte 5 is `0x10` (the echo of the start parameter / buffer size), which caused the driver to expect a 16-byte memory payload (`8 < 16 + 8`) and falsely reject valid 8-byte session open frames as `Truncated BLE frame received (expected 16 bytes payload, available 0)`.

## Fix
- Only apply the payload data length truncation guard to memory block read responses (`0x8100`).
- For control frames (`0x8000`, `0x8f00`, `0x81c0`), accept the standard 8-byte response frame and extract status/response code from byte 6.
- Add unit test reproducing real-device `0880000000100098` frame acceptance.