### PR TITLE
fix: isolate BlueZ pairing agent from future annotations and harden fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install pytest
+          pip install pytest dbus-fast
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/custom_components/omron/omron_ble/bluez_agent.py
+++ b/custom_components/omron/omron_ble/bluez_agent.py
@@ -1,0 +1,39 @@
+"""BlueZ Just Works 페어링 에이전트.
+
+이 모듈에는 의도적으로 ``from __future__ import annotations`` 를 넣지 않는다.
+dbus_fast 는 런타임 어노테이션 값에서 D-Bus 시그니처를 만들기 때문에,
+PEP 563 으로 문자열화되면 클래스 정의 시점에
+``Argument 'signature' has incorrect type (expected str, got NoneType)`` 로 죽는다.
+"""
+
+import logging
+from dbus_fast.service import ServiceInterface, method as dbus_method
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class AutoConfirmAgent(ServiceInterface):
+    """Minimal BlueZ pairing agent that auto-accepts Just Works."""
+
+    def __init__(self):
+        super().__init__("org.bluez.Agent1")
+
+    @dbus_method()
+    def Release(self) -> None:  # type: ignore[override]
+        pass
+
+    @dbus_method()
+    def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]  # noqa: F821
+        _LOGGER.debug("BlueZ agent: auto-confirming passkey %06d", passkey)
+
+    @dbus_method()
+    def RequestPasskey(self, device: "o") -> "u":  # type: ignore[override]  # noqa: F821
+        return 0
+
+    @dbus_method()
+    def RequestAuthorization(self, device: "o") -> None:  # type: ignore[override]  # noqa: F821
+        pass
+
+    @dbus_method()
+    def Cancel(self) -> None:  # type: ignore[override]
+        pass

--- a/custom_components/omron/omron_ble/bluez_agent.py
+++ b/custom_components/omron/omron_ble/bluez_agent.py
@@ -1,9 +1,10 @@
-"""BlueZ Just Works 페어링 에이전트.
+"""BlueZ Just Works pairing agent.
 
-이 모듈에는 의도적으로 ``from __future__ import annotations`` 를 넣지 않는다.
-dbus_fast 는 런타임 어노테이션 값에서 D-Bus 시그니처를 만들기 때문에,
-PEP 563 으로 문자열화되면 클래스 정의 시점에
-``Argument 'signature' has incorrect type (expected str, got NoneType)`` 로 죽는다.
+Deliberately does NOT use ``from __future__ import annotations``: dbus_fast
+builds the D-Bus method signatures from the *runtime* annotation values, so
+PEP 563 stringisation makes the ``@method()`` decorator fail at class
+definition time with
+``TypeError: Argument 'signature' has incorrect type (expected str, got NoneType)``.
 """
 
 import logging
@@ -23,15 +24,31 @@ class AutoConfirmAgent(ServiceInterface):
         pass
 
     @dbus_method()
-    def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]  # noqa: F821
-        _LOGGER.debug("BlueZ agent: auto-confirming passkey %06d", passkey)
+    def RequestPinCode(self, device: "o") -> "s":  # type: ignore[override]  # noqa: F821
+        return ""
+
+    @dbus_method()
+    def DisplayPinCode(self, device: "o", pincode: "s") -> None:  # type: ignore[override]  # noqa: F821
+        pass
 
     @dbus_method()
     def RequestPasskey(self, device: "o") -> "u":  # type: ignore[override]  # noqa: F821
         return 0
 
     @dbus_method()
+    def DisplayPasskey(self, device: "o", passkey: "u", entered: "q") -> None:  # type: ignore[override]  # noqa: F821
+        _LOGGER.debug("BlueZ agent: DisplayPasskey %06d (entered=%d)", passkey, entered)
+
+    @dbus_method()
+    def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]  # noqa: F821
+        _LOGGER.debug("BlueZ agent: auto-confirming passkey %06d", passkey)
+
+    @dbus_method()
     def RequestAuthorization(self, device: "o") -> None:  # type: ignore[override]  # noqa: F821
+        pass
+
+    @dbus_method()
+    def AuthorizeService(self, device: "o", uuid: "s") -> None:  # type: ignore[override]  # noqa: F821
         pass
 
     @dbus_method()

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -315,36 +315,12 @@ async def _bluez_pairing_agent() -> AsyncIterator[Any]:
         from dbus_fast.aio.message_bus import MessageBus
         from dbus_fast.constants import BusType
         from dbus_fast.message import Message
-        from dbus_fast.service import ServiceInterface, method as dbus_method
-    except ImportError:
+
+        from .bluez_agent import AutoConfirmAgent
+    except Exception as exc:
+        _LOGGER.debug("BlueZ agent unavailable (%s); pairing without an agent", exc)
         yield None
         return
-
-    class _AutoConfirmAgent(ServiceInterface):
-        """Minimal BlueZ pairing agent that auto-accepts Just Works."""
-
-        def __init__(self) -> None:
-            super().__init__("org.bluez.Agent1")
-
-        @dbus_method()
-        def Release(self) -> None:  # type: ignore[override]
-            pass
-
-        @dbus_method()
-        def RequestConfirmation(self, device: "o", passkey: "u") -> None:  # type: ignore[override]  # noqa: F821
-            _LOGGER.debug("BlueZ agent: auto-confirming passkey %06d", passkey)
-
-        @dbus_method()
-        def RequestPasskey(self, device: "o") -> "u":  # type: ignore[override]  # noqa: F821
-            return 0
-
-        @dbus_method()
-        def RequestAuthorization(self, device: "o") -> None:  # type: ignore[override]  # noqa: F821
-            pass
-
-        @dbus_method()
-        def Cancel(self) -> None:  # type: ignore[override]
-            pass
 
     try:
         bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
@@ -355,7 +331,7 @@ async def _bluez_pairing_agent() -> AsyncIterator[Any]:
 
     registered = False
     try:
-        bus.export(_BLUEZ_AGENT_PATH, _AutoConfirmAgent())
+        bus.export(_BLUEZ_AGENT_PATH, AutoConfirmAgent())
         await bus.call(
             Message(
                 destination="org.bluez",

--- a/tests/test_bluez_agent.py
+++ b/tests/test_bluez_agent.py
@@ -8,7 +8,10 @@ PEP 563 으로 인해 어노테이션이 문자열화되어
 """
 
 import ast
+import asyncio
 from pathlib import Path
+import sys
+import types
 import pytest
 
 
@@ -44,17 +47,32 @@ def test_bluez_agent_no_future_annotations():
 
 def test_bluez_pairing_agent_graceful_fallback_on_error(monkeypatch):
     """에이전트 임포트/설정 중 예외 발생 시 크래시 없이 None 으로 안전하게 fallback 해야 한다."""
-    import asyncio
     from custom_components.omron.omron_ble import omron_driver
 
-    # MessageBus 연결 시 예외 발생 시뮬레이션
-    monkeypatch.setattr(
-        "custom_components.omron.omron_ble.bluez_agent.AutoConfirmAgent",
-        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Simulated error")),
-    )
-
-    async def _test():
+    # 1. 기본 환경(D-Bus 미연결 또는 미설치)에서 None fallback 검증
+    async def _test_base():
         async with omron_driver._bluez_pairing_agent() as bus:
             assert bus is None
 
-    asyncio.run(_test())
+    asyncio.run(_test_base())
+
+    # 2. 에이전트 생성/등록 시 임의의 예외(TypeError 등) 발생 시뮬레이션
+    fake_module = types.ModuleType("custom_components.omron.omron_ble.bluez_agent")
+
+    class _BrokenAgent:
+        def __init__(self, *args, **kwargs):
+            raise TypeError("Argument 'signature' has incorrect type")
+
+    fake_module.AutoConfirmAgent = _BrokenAgent
+
+    monkeypatch.setitem(
+        sys.modules,
+        "custom_components.omron.omron_ble.bluez_agent",
+        fake_module,
+    )
+
+    async def _test_exception():
+        async with omron_driver._bluez_pairing_agent() as bus:
+            assert bus is None
+
+    asyncio.run(_test_exception())

--- a/tests/test_bluez_agent.py
+++ b/tests/test_bluez_agent.py
@@ -10,8 +10,6 @@ PEP 563 으로 인해 어노테이션이 문자열화되어
 import ast
 import asyncio
 from pathlib import Path
-import sys
-import types
 import pytest
 
 
@@ -45,34 +43,37 @@ def test_bluez_agent_no_future_annotations():
                 )
 
 
-def test_bluez_pairing_agent_graceful_fallback_on_error(monkeypatch):
-    """에이전트 임포트/설정 중 예외 발생 시 크래시 없이 None 으로 안전하게 fallback 해야 한다."""
+def test_bluez_pairing_agent_graceful_fallback_on_agent_init_error(monkeypatch):
+    """에이전트 생성 실패 시 None 으로 fallback 해야 한다."""
+    pytest.importorskip("dbus_fast")
     from custom_components.omron.omron_ble import omron_driver
+    from custom_components.omron.omron_ble.bluez_agent import AutoConfirmAgent
 
-    # 1. 기본 환경(D-Bus 미연결 또는 미설치)에서 None fallback 검증
-    async def _test_base():
+    def _raising_init(self):
+        raise TypeError("Argument 'signature' has incorrect type")
+
+    monkeypatch.setattr(AutoConfirmAgent, "__init__", _raising_init)
+
+    async def _test():
         async with omron_driver._bluez_pairing_agent() as bus:
             assert bus is None
 
-    asyncio.run(_test_base())
+    asyncio.run(_test())
 
-    # 2. 에이전트 생성/등록 시 임의의 예외(TypeError 등) 발생 시뮬레이션
-    fake_module = types.ModuleType("custom_components.omron.omron_ble.bluez_agent")
 
-    class _BrokenAgent:
-        def __init__(self, *args, **kwargs):
-            raise TypeError("Argument 'signature' has incorrect type")
+def test_bluez_pairing_agent_graceful_fallback_on_bus_error(monkeypatch):
+    """시스템 버스 연결 실패 시 None 으로 fallback 해야 한다."""
+    pytest.importorskip("dbus_fast")
+    from custom_components.omron.omron_ble import omron_driver
+    from dbus_fast.aio.message_bus import MessageBus
 
-    fake_module.AutoConfirmAgent = _BrokenAgent
+    async def _failing_connect(*args, **kwargs):
+        raise ConnectionRefusedError("Cannot connect to system bus")
 
-    monkeypatch.setitem(
-        sys.modules,
-        "custom_components.omron.omron_ble.bluez_agent",
-        fake_module,
-    )
+    monkeypatch.setattr(MessageBus, "connect", _failing_connect)
 
-    async def _test_exception():
+    async def _test():
         async with omron_driver._bluez_pairing_agent() as bus:
             assert bus is None
 
-    asyncio.run(_test_exception())
+    asyncio.run(_test())

--- a/tests/test_bluez_agent.py
+++ b/tests/test_bluez_agent.py
@@ -9,7 +9,9 @@ PEP 563 으로 인해 어노테이션이 문자열화되어
 
 import ast
 import asyncio
+import logging
 from pathlib import Path
+import sys
 import pytest
 
 
@@ -22,6 +24,21 @@ def test_bluez_agent_interface_builds():
     agent = AutoConfirmAgent()
     assert agent is not None
     assert agent.name == "org.bluez.Agent1"
+
+    node = agent.introspect()
+    method_names = {method.name for method in node.methods}
+    expected_methods = {
+        "Release",
+        "RequestPinCode",
+        "DisplayPinCode",
+        "RequestPasskey",
+        "DisplayPasskey",
+        "RequestConfirmation",
+        "RequestAuthorization",
+        "AuthorizeService",
+        "Cancel",
+    }
+    assert expected_methods.issubset(method_names)
 
 
 def test_bluez_agent_no_future_annotations():
@@ -43,37 +60,39 @@ def test_bluez_agent_no_future_annotations():
                 )
 
 
-def test_bluez_pairing_agent_graceful_fallback_on_agent_init_error(monkeypatch):
-    """에이전트 생성 실패 시 None 으로 fallback 해야 한다."""
-    pytest.importorskip("dbus_fast")
+def test_bluez_pairing_agent_falls_back_when_agent_module_broken(monkeypatch, caplog):
+    """새 except Exception(임포트 실패) 경로를 검증한다 — 기존 '시스템 버스 없음' 경로와 구분."""
     from custom_components.omron.omron_ble import omron_driver
-    from custom_components.omron.omron_ble.bluez_agent import AutoConfirmAgent
 
-    def _raising_init(self):
-        raise TypeError("Argument 'signature' has incorrect type")
+    # sys.modules 에 None 을 넣으면 from .bluez_agent import ... 가 ImportError 를 낸다
+    monkeypatch.setitem(
+        sys.modules, "custom_components.omron.omron_ble.bluez_agent", None
+    )
 
-    monkeypatch.setattr(AutoConfirmAgent, "__init__", _raising_init)
+    async def _run():
+        with caplog.at_level(logging.DEBUG, logger=omron_driver.__name__):
+            async with omron_driver._bluez_pairing_agent() as bus:
+                assert bus is None
+        assert "BlueZ agent unavailable" in caplog.text
 
-    async def _test():
-        async with omron_driver._bluez_pairing_agent() as bus:
-            assert bus is None
-
-    asyncio.run(_test())
+    asyncio.run(_run())
 
 
-def test_bluez_pairing_agent_graceful_fallback_on_bus_error(monkeypatch):
-    """시스템 버스 연결 실패 시 None 으로 fallback 해야 한다."""
+def test_bluez_pairing_agent_falls_back_on_system_bus_failure(monkeypatch, caplog):
+    """시스템 버스 연결 실패 시 기존의 'cannot connect to system bus' 경로를 검증한다."""
     pytest.importorskip("dbus_fast")
     from custom_components.omron.omron_ble import omron_driver
     from dbus_fast.aio.message_bus import MessageBus
 
     async def _failing_connect(*args, **kwargs):
-        raise ConnectionRefusedError("Cannot connect to system bus")
+        raise ConnectionRefusedError("Simulated system bus failure")
 
     monkeypatch.setattr(MessageBus, "connect", _failing_connect)
 
-    async def _test():
-        async with omron_driver._bluez_pairing_agent() as bus:
-            assert bus is None
+    async def _run():
+        with caplog.at_level(logging.DEBUG, logger=omron_driver.__name__):
+            async with omron_driver._bluez_pairing_agent() as bus:
+                assert bus is None
+        assert "cannot connect to system bus" in caplog.text
 
-    asyncio.run(_test())
+    asyncio.run(_run())

--- a/tests/test_bluez_agent.py
+++ b/tests/test_bluez_agent.py
@@ -1,0 +1,60 @@
+"""BlueZ 페어링 에이전트 회귀 테스트.
+
+dbus_fast 는 런타임 어노테이션에서 D-Bus 시그니처를 만든다.
+bluez_agent.py 에 ``from __future__ import annotations`` 가 포함되면
+PEP 563 으로 인해 어노테이션이 문자열화되어
+``TypeError: Argument 'signature' has incorrect type (expected str, got NoneType)``
+크래시가 발생하므로, 모듈 분리 및 어노테이션 보존 불변조건을 검증한다.
+"""
+
+import ast
+from pathlib import Path
+import pytest
+
+
+def test_bluez_agent_interface_builds():
+    """dbus_fast 는 어노테이션에서 시그니처를 만든다 — 이 모듈에
+    from __future__ import annotations 가 들어가면 임포트/클래스 생성 시점에 깨진다."""
+    pytest.importorskip("dbus_fast")
+    from custom_components.omron.omron_ble.bluez_agent import AutoConfirmAgent
+
+    agent = AutoConfirmAgent()
+    assert agent is not None
+    assert agent.name == "org.bluez.Agent1"
+
+
+def test_bluez_agent_no_future_annotations():
+    """bluez_agent.py 에는 from __future__ import annotations 가 포함되지 않아야 한다."""
+    agent_file = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components"
+        / "omron"
+        / "omron_ble"
+        / "bluez_agent.py"
+    )
+    tree = ast.parse(agent_file.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ImportFrom) and node.module == "__future__":
+            for alias in node.names:
+                assert alias.name != "annotations", (
+                    "bluez_agent.py 에 from __future__ import annotations 가 포함되면 안 됩니다. "
+                    "dbus_fast 의 런타임 시그니처 분석이 깨집니다."
+                )
+
+
+def test_bluez_pairing_agent_graceful_fallback_on_error(monkeypatch):
+    """에이전트 임포트/설정 중 예외 발생 시 크래시 없이 None 으로 안전하게 fallback 해야 한다."""
+    import asyncio
+    from custom_components.omron.omron_ble import omron_driver
+
+    # MessageBus 연결 시 예외 발생 시뮬레이션
+    monkeypatch.setattr(
+        "custom_components.omron.omron_ble.bluez_agent.AutoConfirmAgent",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("Simulated error")),
+    )
+
+    async def _test():
+        async with omron_driver._bluez_pairing_agent() as bus:
+            assert bus is None
+
+    asyncio.run(_test())


### PR DESCRIPTION
## Summary
Fixes a crash (`TypeError: Argument 'signature' has incorrect type (expected str, got NoneType)`) when pairing on local BlueZ adapters with `pair_on_connect=True` (e.g. WLD3.0 / WLD4.0 models) or during OS-bonding pairing.

Ref: [#119 (comment)](https://github.com/eigger/hass-omron/discussions/119#discussioncomment-18031285)

## Root Cause
`dbus_fast`'s `@method()` decorator creates D-Bus signatures by inspecting runtime type annotations. When `from __future__ import annotations` (PEP 563) is enabled in `omron_driver.py`, type annotations are stringified at compile time, leading to `None` signature resolution and raising `TypeError` at class definition time.

Proxy connections (e.g. ESPHome proxy) do not have a BlueZ D-Bus path and skipped the agent, which is why proxy connections reached pairing while local BlueZ connections crashed immediately before BLE pairing.

## Affected Paths
1. `pair_on_connect=True` path (`custom_components/omron/omron_ble/omron_driver.py:118`): `TypeError` propagated upwards as `"Unexpected error during pairing"`.
2. `_pair_os_bonding` path (`custom_components/omron/omron_ble/omron_driver.py:379` via `_bluez_agent_pair`): caught by retry loop `except Exception:`, logged quietly as `"OS-level bonding attempt N failed: TypeError(...)"`.

## Changes
1. **Module Separation (`bluez_agent.py`)**: Moved `AutoConfirmAgent` into a dedicated module without `from __future__ import annotations`.
2. **Complete `org.bluez.Agent1` Interface**: Implemented all BlueZ `Agent1` methods (`Release`, `RequestPinCode`, `DisplayPinCode`, `RequestPasskey`, `DisplayPasskey`, `RequestConfirmation`, `RequestAuthorization`, `AuthorizeService`, `Cancel`) to prevent `org.freedesktop.DBus.Error.UnknownMethod` errors.
3. **Hardened Fallback**: In `_bluez_pairing_agent()`, wrapped agent import and registration in `except Exception:` so that if agent initialization fails for any reason, it logs debug info and yields `None` (falling back to connect/pair without agent) rather than crashing the connect attempt.
4. **Regression Tests (`test_bluez_agent.py`)**:
   - Verify `AutoConfirmAgent` builds and introspects all 9 methods when `dbus_fast` is present.
   - AST test to enforce that `bluez_agent.py` does not contain `from __future__ import annotations`.
   - Distinct fallback tests verifying both module import failure (`"BlueZ agent unavailable"`) and system bus failure (`"cannot connect to system bus"`).