### PR TITLE
fix: propagate connect exceptions out of BlueZ pairing agent context

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -330,6 +330,7 @@ async def _bluez_pairing_agent() -> AsyncIterator[Any]:
         return
 
     registered = False
+    agent_ready = False
     try:
         bus.export(_BLUEZ_AGENT_PATH, AutoConfirmAgent())
         await bus.call(
@@ -353,11 +354,20 @@ async def _bluez_pairing_agent() -> AsyncIterator[Any]:
                 body=[_BLUEZ_AGENT_PATH],
             )
         )
+        agent_ready = True
         _LOGGER.debug("BlueZ KeyboardDisplay agent registered")
-        yield bus
     except Exception as exc:
         _LOGGER.debug("BlueZ agent registration failed: %s", exc)
-        yield None
+
+    # ``yield`` sits outside the registration try/except above so an
+    # exception raised by the caller's code inside the ``async with`` block
+    # (e.g. a connect timeout) propagates unchanged. athrow() can only be
+    # answered once; yielding a second time from inside that except block
+    # raised "generator didn't stop after athrow()" and masked the real
+    # error, which also skipped the pair=False fallback in
+    # establish_connection_with_bond_settle (it only catches BleakError).
+    try:
+        yield bus if agent_ready else None
     finally:
         if registered:
             try:

--- a/tests/test_bluez_agent.py
+++ b/tests/test_bluez_agent.py
@@ -96,3 +96,52 @@ def test_bluez_pairing_agent_falls_back_on_system_bus_failure(monkeypatch, caplo
         assert "cannot connect to system bus" in caplog.text
 
     asyncio.run(_run())
+
+
+def test_bluez_pairing_agent_propagates_caller_exception(monkeypatch):
+    """``async with`` 블록 본문(예: connect 타임아웃)에서 발생한 예외가 그대로
+    전파돼야 한다. 예전에는 등록 try/except 가 이 예외까지 삼켜서
+    except 블록 안에서 ``yield None`` 을 다시 실행했고, 제너레이터는 athrow() 를
+    두 번 받을 수 없어 ``RuntimeError: generator didn't stop after athrow()`` 로
+    원인이 뒤바뀌었다. establish_connection_with_bond_settle 의 BleakError 폴백은
+    이 RuntimeError 를 잡지 못해 pair=False 재시도가 동작하지 않았다."""
+    pytest.importorskip("dbus_fast")
+    from custom_components.omron.omron_ble import omron_driver
+    from dbus_fast.aio.message_bus import MessageBus
+
+    class FakeBus:
+        def __init__(self):
+            self.calls: list[str] = []
+            self.disconnected = False
+
+        def export(self, path, agent):
+            pass
+
+        async def call(self, message):
+            self.calls.append(message.member)
+            return None
+
+        def disconnect(self):
+            self.disconnected = True
+
+    fake_bus = FakeBus()
+
+    async def _fake_connect(*args, **kwargs):
+        return fake_bus
+
+    monkeypatch.setattr(MessageBus, "connect", _fake_connect)
+
+    class SimulatedConnectTimeout(Exception):
+        pass
+
+    async def _run():
+        with pytest.raises(SimulatedConnectTimeout):
+            async with omron_driver._bluez_pairing_agent() as bus:
+                assert bus is fake_bus
+                raise SimulatedConnectTimeout("simulated establish_connection failure")
+
+    asyncio.run(_run())
+
+    # Registration still happened and cleanup still ran despite the exception.
+    assert fake_bus.calls == ["RegisterAgent", "RequestDefaultAgent", "UnregisterAgent"]
+    assert fake_bus.disconnected


### PR DESCRIPTION
## Summary
- `_bluez_pairing_agent()` yielded from inside its registration `try/except`, so an exception raised in the `async with` body (e.g. a connect timeout on `hci0`) was caught by that `except` and replaced with a second `yield`. A generator can only answer `athrow()` once, so this surfaced as `RuntimeError: generator didn't stop after athrow()` instead of the real error.
- That masked error bypassed the `BleakError` fallback in `establish_connection_with_bond_settle` (the `pair=False` retry never ran), forcing a bond removal + full re-pair on every failed poll.
- Root cause identified from logs in [discussion #119](https://github.com/eigger/hass-omron/discussions/119#discussioncomment-18080299).

## Test plan
- [x] Added `test_bluez_pairing_agent_propagates_caller_exception`, which registers a fake BlueZ agent then raises inside the `async with` body and asserts the original exception (not `RuntimeError`) propagates, with cleanup still running.
- [x] Verified against pre-fix code that the new test reproduces the exact `RuntimeError: generator didn't stop after athrow()` from the user's log.
- [x] `python -m pytest tests/` — 71 passed (WSL Ubuntu; `dbus_fast`'s real transport needs Unix sockets, so this suite doesn't import cleanly on native Windows — matches CI's `ubuntu-latest` runner).
- [x] `python -m ruff check custom_components/` — all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)