### PR TITLE
experiment: put WLD4.0 on a kept bond and recover stale bonds on connect

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.7"
+  "version": "2.7.8-beta.1"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -13,8 +13,8 @@ from .devices import (
     UnlockMode,
 )
 
-# Bond strategy for the whole WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
-# 7188T1 / 7155T-MW3). These cuffs serve data during the pairing session and
+# Bond strategy for the WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
+# 7155T-MW3). These cuffs serve data during the pairing session and
 # then reject later connections, which fits a device that does not keep its
 # side of the bond; PER_SESSION drops ours to match, so every connection
 # bonds from scratch instead of offering a key the device has forgotten.
@@ -22,6 +22,26 @@ from .devices import (
 # Set this to BondPolicy.REUSE to put the family back on a kept bond — that
 # is the only change needed, every dependent behaviour is derived from it.
 _WLD3_BOND_POLICY = BondPolicy.PER_SESSION
+
+# Bond strategy for the WLD4.0 family (HEM-7188T1 / 7191T1 / 7196T1).
+#
+# These profiles used to share _WLD3_BOND_POLICY, but only because they were
+# classified WLD3.0 at the time (#109); #112 reclassified HEM-7188T1 as
+# WLD4.0 without revisiting the bond policy it had inherited. No WLD4.0 cuff
+# ever supplied the evidence PER_SESSION was derived from.
+#
+# Field reports (issue #92, HEM-7188T1-LEO) show the premise PER_SESSION
+# rests on does not hold here: dropping the bond assumes the next connect can
+# bond again, but this cuff answers a fresh bond request with
+# AuthenticationCanceled / error 102 once it has left pairing mode. Dropping
+# the bond therefore guarantees the next connect fails rather than recovering.
+#
+# Note what has actually shipped for these profiles: a kept bond went out
+# only in builds that still used unlock_mode=SECURE_SESSION, which the device
+# rejects outright (error frame 0xff26), and pair_on_connect did not exist
+# yet. "Kept bond + TOKEN_KEY + security up before GATT" has never been in a
+# release, so REUSE here is an untested combination, not a revisited one.
+_WLD4_BOND_POLICY = BondPolicy.REUSE
 
 _MODERN_OS_BONDING_BASE = {
     "parent_service_uuid": MODERN_STACK_PARENT_SERVICE_UUID,
@@ -1015,7 +1035,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7191T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[60],
@@ -1046,7 +1066,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7196T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0584],
         per_user_records_count=[60, 60],
@@ -1223,7 +1243,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7188T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[30],

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -45,6 +45,9 @@ _POST_CONNECT_BOND_SETTLE_SEC: float = 1.5
 # of waiting out the full settle before retrying.
 _CONNECT_SETTLE_ATTEMPTS: int = 3
 _SETTLE_POLL_STEP_SEC: float = 0.25
+# Give BlueZ a moment to tear the device object down after RemoveDevice;
+# pairing again while it is still going away draws the same rejection.
+_BOND_REMOVE_SETTLE_SEC: float = 0.5
 _UNLOCK_PROBE_WAIT_TIMEOUT_SEC: float = 2.0
 _UNLOCK_AUTH_WAIT_TIMEOUT_SEC: float = 5.0
 _PAIRING_SETTLE_AGGRESSIVE_SEC: float = 0.25
@@ -167,6 +170,8 @@ async def establish_connection_with_bond_settle(
         except BleakError as exc:
             if pair_this_attempt:
                 client = None
+                rebond_exc: BaseException | None = None
+                bond_removed = False
                 if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
                     # Not "this cuff won't bond" but "the bond we hold is not
                     # one it still honours": BlueZ offered the stored LTK and
@@ -187,40 +192,68 @@ async def establish_connection_with_bond_settle(
                         source,
                         exc,
                     )
-                    if not await _bluez_remove_device(ble_device):
-                        _LOGGER.debug(
-                            "No DBus path to remove the stale bond for %s; "
-                            "retrying the bond anyway",
+                    bond_removed = await _bluez_remove_device(ble_device)
+                    if not bond_removed:
+                        # Proxy backends have no DBus path to remove through, so
+                        # the bond the proxy holds stays and the retry below
+                        # re-offers the same key. Say so rather than letting the
+                        # retry look like a cleared-bond attempt.
+                        _LOGGER.warning(
+                            "Could not remove the bond for %s on this backend "
+                            "(no BlueZ DBus path — ESPHome proxy links keep "
+                            "their bond); the retry re-offers the same key",
                             name,
                         )
+                    else:
+                        await asyncio.sleep(_BOND_REMOVE_SETTLE_SEC)
                     try:
                         client = await _connect_once(ble_device, name, pair=True)
                     except BleakError as retry_exc:
-                        _LOGGER.debug(
-                            "Re-bonding %s after clearing the stale bond failed "
-                            "(%s); falling back to connect without pair",
-                            name,
-                            retry_exc,
-                        )
+                        rebond_exc = retry_exc
                 if client is None:
-                    # The device refused to bond (e.g. error 102 when the cuff is
-                    # in normal transfer mode instead of pairing mode). Fall back to
-                    # connecting without pair so stateless/token-key transfers succeed.
-                    _LOGGER.warning(
-                        "Bonding %s [%s] during connect via source=%s failed "
-                        "(attempt %d/%d): %s; falling back to connect without pair",
-                        name,
-                        model or "?",
-                        source,
-                        attempt,
-                        _CONNECT_SETTLE_ATTEMPTS,
-                        exc,
-                    )
+                    if rebond_exc is not None:
+                        # Both halves belong in the WARNING: a field report that
+                        # only shows warnings must be able to tell "the cuff
+                        # discarded its key" from "we removed the bond and were
+                        # then refused a new one", which read identically if the
+                        # second error is left at debug level.
+                        _LOGGER.warning(
+                            "Bonding %s [%s] during connect via source=%s failed "
+                            "(attempt %d/%d): the stored bond was rejected (%s), "
+                            "and bonding again after %s was refused too (%s) — "
+                            "falling back to connect without pair. The cuff has "
+                            "to be in pairing mode to accept a new bond.",
+                            name,
+                            model or "?",
+                            source,
+                            attempt,
+                            _CONNECT_SETTLE_ATTEMPTS,
+                            exc,
+                            "removing it" if bond_removed else "failing to remove it",
+                            rebond_exc,
+                        )
+                    else:
+                        # The device refused to bond (e.g. error 102 when the cuff is
+                        # in normal transfer mode instead of pairing mode). Fall back to
+                        # connecting without pair so stateless/token-key transfers succeed.
+                        _LOGGER.warning(
+                            "Bonding %s [%s] during connect via source=%s failed "
+                            "(attempt %d/%d): %s; falling back to connect without pair",
+                            name,
+                            model or "?",
+                            source,
+                            attempt,
+                            _CONNECT_SETTLE_ATTEMPTS,
+                            exc,
+                        )
                     pair_this_attempt = False
                     try:
                         client = await _connect_once(ble_device, name, pair=False)
-                    except Exception:
-                        raise exc
+                    except Exception as fallback_exc:
+                        # Surface the bonding failure as the cause, but keep the
+                        # unpaired attempt's error in the chain instead of
+                        # dropping it on the floor.
+                        raise exc from fallback_exc
             else:
                 raise
         if pair_this_attempt:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -139,6 +139,10 @@ async def establish_connection_with_bond_settle(
     # Cleared if the backend reports it cannot pair at connect time, so the
     # remaining attempts fall back instead of failing repeatedly.
     pair_this_attempt = pair_on_connect
+    # A stale bond is worth clearing exactly once per call: after that a
+    # repeated auth failure is the device refusing to bond, not a key
+    # mismatch, and removing the bond again would just churn it.
+    stale_bond_cleared = False
     for attempt in range(1, _CONNECT_SETTLE_ATTEMPTS + 1):
         source = _connection_source(ble_device)
         last_source = source
@@ -162,24 +166,61 @@ async def establish_connection_with_bond_settle(
             client = await _connect_once(ble_device, name, pair=False)
         except BleakError as exc:
             if pair_this_attempt:
-                # The device refused to bond (e.g. error 102 when the cuff is
-                # in normal transfer mode instead of pairing mode). Fall back to
-                # connecting without pair so stateless/token-key transfers succeed.
-                _LOGGER.warning(
-                    "Bonding %s [%s] during connect via source=%s failed "
-                    "(attempt %d/%d): %s; falling back to connect without pair",
-                    name,
-                    model or "?",
-                    source,
-                    attempt,
-                    _CONNECT_SETTLE_ATTEMPTS,
-                    exc,
-                )
-                pair_this_attempt = False
-                try:
-                    client = await _connect_once(ble_device, name, pair=False)
-                except Exception:
-                    raise exc
+                client = None
+                if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
+                    # Not "this cuff won't bond" but "the bond we hold is not
+                    # one it still honours": BlueZ offered the stored LTK and
+                    # the device rejected it. bleak skips Pair() while BlueZ
+                    # still lists the device as paired, so the bond has to go
+                    # before a retry can be a real bond rather than the same
+                    # rejected key again. Without this a kept-bond (REUSE)
+                    # profile has no way back from a rotated key short of the
+                    # user deleting and re-adding the device.
+                    stale_bond_cleared = True
+                    _LOGGER.warning(
+                        "Bonding %s [%s] via source=%s was rejected as a stale "
+                        "bond (%s) — removing it so this attempt can bond from "
+                        "scratch instead of re-offering a key the cuff has "
+                        "forgotten",
+                        name,
+                        model or "?",
+                        source,
+                        exc,
+                    )
+                    if not await _bluez_remove_device(ble_device):
+                        _LOGGER.debug(
+                            "No DBus path to remove the stale bond for %s; "
+                            "retrying the bond anyway",
+                            name,
+                        )
+                    try:
+                        client = await _connect_once(ble_device, name, pair=True)
+                    except BleakError as retry_exc:
+                        _LOGGER.debug(
+                            "Re-bonding %s after clearing the stale bond failed "
+                            "(%s); falling back to connect without pair",
+                            name,
+                            retry_exc,
+                        )
+                if client is None:
+                    # The device refused to bond (e.g. error 102 when the cuff is
+                    # in normal transfer mode instead of pairing mode). Fall back to
+                    # connecting without pair so stateless/token-key transfers succeed.
+                    _LOGGER.warning(
+                        "Bonding %s [%s] during connect via source=%s failed "
+                        "(attempt %d/%d): %s; falling back to connect without pair",
+                        name,
+                        model or "?",
+                        source,
+                        attempt,
+                        _CONNECT_SETTLE_ATTEMPTS,
+                        exc,
+                    )
+                    pair_this_attempt = False
+                    try:
+                        client = await _connect_once(ble_device, name, pair=False)
+                    except Exception:
+                        raise exc
             else:
                 raise
         if pair_this_attempt:

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1226,9 +1226,13 @@ class OmronBluetoothDeviceData(BluetoothData):
                                 ):
                                     _LOGGER.warning(
                                         "Memory session failed for OS-bonding device %s "
-                                        "(model=%s): %s. Ensure OS-level BLE bonding is "
-                                        "complete — remove and re-add the device if this "
-                                        "error persists.",
+                                        "(model=%s): %s. This usually means the link came "
+                                        "up without encryption — these cuffs only serve "
+                                        "the memory characteristics over a bonded link. "
+                                        "Put the cuff back in pairing mode (blinking -P-) "
+                                        "and press Retry Pairing. Removing and re-adding "
+                                        "the integration pairs it once and then hits this "
+                                        "same error on the next poll, so it is not a fix.",
                                         ble_device.address,
                                         self._device_config.model,
                                         last_session_exc,

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -219,3 +219,76 @@ def test_no_bond_recovery_when_not_pairing_on_connect(
 
     assert remove_device_recorder == []
     assert connect.pair_args == [False]
+
+
+def test_proxy_backend_says_the_bond_could_not_be_removed(
+    monkeypatch, settle_free, caplog
+):
+    """프록시 링크: 본드를 못 지웠다는 사실이 WARNING 으로 드러나야 한다.
+
+    ``_bluez_remove_device`` 는 로컬 BlueZ DBus path 가 필요하다. 프록시에서는
+    제거가 실패하고 재시도가 **같은 키를 다시 내미는** 것이 되는데, 이게 조용히
+    지나가면 로그만 보고 "본드를 지우고 재본딩했는데도 거부당했다" 로 잘못
+    읽힌다.
+    """
+    async def _fail_remove(obj):
+        return False
+
+    monkeypatch.setattr(omron_driver, "_bluez_remove_device", _fail_remove)
+    connect = ConnectRecorder([_stale_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with caplog.at_level("WARNING", logger="custom_components.omron.omron_ble.omron_driver"):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+            )
+        )
+
+    assert any("Could not remove the bond" in r.getMessage() for r in caplog.records)
+    assert connect.pair_args == [True, True]
+
+
+def test_failed_rebond_reports_both_errors_at_warning(
+    monkeypatch, settle_free, remove_device_recorder, caplog
+):
+    """복구 후 재본딩까지 실패하면 두 에러가 모두 WARNING 에 남아야 한다.
+
+    재본딩 오류가 DEBUG 에만 있으면, WARNING 만 수집하는 필드 리포트에서
+    "커프가 키를 버렸다" 와 "본드를 지운 뒤 새 본드를 거부당했다" 가 구분되지
+    않는다 — 이 실험의 판정이 정확히 그 구분에 달려 있다.
+    """
+    connect = ConnectRecorder(
+        [_stale_bond_error(), _refused_bond_error(), None]
+    )
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with caplog.at_level("WARNING", logger="custom_components.omron.omron_ble.omron_driver"):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+            )
+        )
+
+    warnings = " | ".join(r.getMessage() for r in caplog.records)
+    assert "AuthenticationFailed" in warnings, "원래 stale-bond 에러"
+    assert "AuthenticationCanceled" in warnings, "재본딩 거부 에러(retry_exc)"
+    assert "removing it" in warnings, "본드를 실제로 지웠는지 여부"
+    assert connect.pair_args == [True, True, False]
+
+
+@pytest.mark.parametrize(
+    "variant", ("HEM-7188T1-LE", "HEM-7188T1-LEO")
+)
+def test_variants_inherit_the_wld4_bond_policy(variant):
+    """카탈로그 variant 도 canonical 과 같은 본드 정책을 써야 한다.
+
+    필드에서 실제로 선택되는 이름은 canonical 이 아니라 variant 다. variant 가
+    정책을 물려받지 못하면 실험 빌드가 제보자 기기에서 아무것도 바꾸지 않는다.
+    """
+    from custom_components.omron.omron_ble.devices import get_device_config
+
+    config = get_device_config(variant)
+    assert config.bond_policy == BondPolicy.REUSE
+    assert config.unpair_after_session is False
+    assert config.pair_on_connect is True

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -1,0 +1,221 @@
+"""WLD4.0 본드 정책(REUSE) 및 stale-bond 복구 회귀 테스트.
+
+배경(이슈 #92, HEM-7188T1-LEO):
+
+PER_SESSION 은 "본드를 버려도 다음 연결이 다시 본딩하니까 안전하다"는 전제
+위에 서 있는데, 이 커프는 페어링 모드를 벗어나면 새 본드를 AuthenticationCanceled
+/ error 102 로 거부한다. 전제가 깨지므로 본드를 버리는 순간 다음 연결은 확정
+실패다.
+
+WLD4.0 프로필들이 PER_SESSION 이었던 건 #109 당시 WLD3.0 으로 분류돼 있었기
+때문이고, #112 가 WLD4.0 으로 정정하면서 본드 정책은 따라오지 않았다.
+
+REUSE 로 되돌리는 것만으로는 실험이 성립하지 않는다: 커프가 자기 LTK 를 정말
+버린다면 저장된 키로 암호화가 거부되는데, stale-bond 복구는
+``_pair_os_bonding()`` 안에만 있고 ``pair()`` 는 ``pair_on_connect`` 면 조기
+반환하므로 그 경로에 도달하지 못한다. 그래서 복구를 connect 경로에도 연결한다.
+"""
+import asyncio
+
+import pytest
+
+from custom_components.omron.omron_ble import omron_driver
+from custom_components.omron.omron_ble.device_catalog import (
+    CANONICAL_DEVICE_PROFILES,
+)
+from custom_components.omron.omron_ble.devices import BondPolicy, ConnectType
+
+
+# ── 카탈로그 정책 ──────────────────────────────────────────────────────────
+
+WLD4_PROFILES = ("HEM-7188T1", "HEM-7191T1", "HEM-7196T1")
+
+
+@pytest.mark.parametrize("profile", WLD4_PROFILES)
+def test_wld4_keeps_the_bond_but_still_brings_security_up_first(profile):
+    """WLD4.0 은 본드를 유지하되 pair_on_connect 는 그대로 True 여야 한다.
+
+    본드만 유지하고 pair_on_connect 를 잃으면 2.5.23 시절 구성으로 돌아간다 —
+    연결 후 GATT 를 건드리는 동안 보안이 올라와 있지 않아 커프가 링크를 끊던
+    바로 그 조합(#108). 두 조건이 동시에 성립해야 한다.
+    """
+    config = CANONICAL_DEVICE_PROFILES[profile]
+
+    assert config.connect_type == ConnectType.WLD4_0
+    assert config.bond_policy == BondPolicy.REUSE
+    assert config.unpair_after_session is False, "본드가 세션 종료 시 삭제되면 안 된다"
+    assert config.pair_on_connect is True, "보안은 GATT 디스커버리 전에 올라와야 한다"
+
+
+def test_wld3_bond_policy_is_untouched():
+    """WLD3.0 패밀리는 검증된 PER_SESSION 동작을 그대로 유지한다."""
+    wld3 = [
+        (name, cfg)
+        for name, cfg in CANONICAL_DEVICE_PROFILES.items()
+        if cfg.connect_type == ConnectType.WLD3_0
+    ]
+    assert wld3, "WLD3.0 프로필이 하나도 없다면 이 가드는 의미가 없다"
+    for name, cfg in wld3:
+        assert cfg.bond_policy == BondPolicy.PER_SESSION, name
+        assert cfg.unpair_after_session is True, name
+
+
+# ── stale-bond 복구 ────────────────────────────────────────────────────────
+
+class FakeBLEDevice:
+    def __init__(self):
+        self.address = "D5:4F:40:C4:5A:E2"
+        self.details = {
+            "path": "/org/bluez/hci0/dev_D5_4F_40_C4_5A_E2",
+            "props": {},
+            "source": "hci0",
+        }
+
+
+class FakeClient:
+    def __init__(self):
+        self.is_connected = True
+
+
+class ConnectRecorder:
+    """``_connect_once`` 대역 — pair 인자 시퀀스를 기록한다."""
+
+    def __init__(self, errors):
+        self.errors = list(errors)
+        self.pair_args: list[bool] = []
+
+    async def __call__(self, ble_device, name, *, pair):
+        self.pair_args.append(pair)
+        if self.errors:
+            exc = self.errors.pop(0)
+            if exc is not None:
+                raise exc
+        return FakeClient()
+
+
+@pytest.fixture
+def settle_free(monkeypatch):
+    """post-connect settle 의 실제 대기/GATT 갱신을 제거한다."""
+    async def _noop_sleep(delay, *args, **kwargs):
+        return None
+
+    async def _noop_refresh(client):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(omron_driver, "_bleak_refresh_services", _noop_refresh)
+
+
+@pytest.fixture
+def remove_device_recorder(monkeypatch):
+    calls: list[str] = []
+
+    async def _fake_remove(obj):
+        calls.append(getattr(obj, "address", "?"))
+        return True
+
+    monkeypatch.setattr(omron_driver, "_bluez_remove_device", _fake_remove)
+    return calls
+
+
+class FakeBleakError(Exception):
+    """conftest 가 bleak 을 MagicMock 으로 대체하므로 실제 예외 클래스가 없다.
+
+    드라이버가 ``except BleakError`` 로 잡을 수 있도록 진짜 예외 클래스를
+    심어 준다.
+    """
+
+
+@pytest.fixture(autouse=True)
+def real_bleak_error(monkeypatch):
+    monkeypatch.setattr(omron_driver, "BleakError", FakeBleakError)
+
+
+def _stale_bond_error():
+    return FakeBleakError(
+        "[org.bluez.Error.AuthenticationFailed] Authentication Failed"
+    )
+
+
+def _refused_bond_error():
+    return FakeBleakError(
+        "[org.bluez.Error.AuthenticationCanceled] Authentication Canceled"
+    )
+
+
+def test_stale_bond_is_cleared_and_rebonded_not_downgraded(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """AuthenticationFailed 면 본드를 지우고 pair=True 로 다시 시도한다.
+
+    바로 pair=False 로 내려가면 비암호화 링크가 되고, 그 위에서 토큰 언락과
+    메모리 세션이 실패한다 — 이슈 #92 에서 보고된 그 경로다.
+    """
+    connect = ConnectRecorder([_stale_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    client = asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert isinstance(client, FakeClient)
+    assert remove_device_recorder == ["D5:4F:40:C4:5A:E2"], "본드를 지워야 한다"
+    # 두 번째 시도도 pair=True — 비암호화 폴백으로 내려가지 않았다.
+    assert connect.pair_args == [True, True]
+
+
+def test_refused_bond_still_falls_back_to_unpaired_connect(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """stale-bond 가 아닌 거부(error 102 등)는 기존 pair=False 폴백 그대로."""
+    connect = ConnectRecorder([_refused_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert remove_device_recorder == [], "멀쩡한 본드를 지우면 안 된다"
+    assert connect.pair_args == [True, False]
+
+
+def test_stale_bond_recovery_runs_at_most_once(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """복구 후에도 같은 인증 실패가 나면 본드 문제가 아니다 — 다시 지우지 않는다."""
+    connect = ConnectRecorder(
+        [_stale_bond_error(), _stale_bond_error(), None]
+    )
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert len(remove_device_recorder) == 1
+    # 지우고 재본딩(True) → 또 실패 → 비암호화 폴백(False).
+    assert connect.pair_args == [True, True, False]
+
+
+def test_no_bond_recovery_when_not_pairing_on_connect(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """pair_on_connect=False 프로필에서는 이 경로가 아예 열리지 않는다."""
+    connect = ConnectRecorder([_stale_bond_error()])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with pytest.raises(Exception):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=False, model="HEM-7142T2"
+            )
+        )
+
+    assert remove_device_recorder == []
+    assert connect.pair_args == [False]

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -16,6 +16,7 @@ REUSE 로 되돌리는 것만으로는 실험이 성립하지 않는다: 커프�
 반환하므로 그 경로에 도달하지 못한다. 그래서 복구를 connect 경로에도 연결한다.
 """
 import asyncio
+import pathlib
 
 import pytest
 
@@ -292,3 +293,22 @@ def test_variants_inherit_the_wld4_bond_policy(variant):
     assert config.bond_policy == BondPolicy.REUSE
     assert config.unpair_after_session is False
     assert config.pair_on_connect is True
+
+
+def test_memory_session_warning_does_not_advise_re_adding_the_device():
+    """실패 안내가 "제거 후 재추가"로 유도하면 안 된다.
+
+    재추가는 커프가 페어링 모드일 때 한 번 성공하고 다음 폴에서 같은 에러로
+    돌아온다(discussions#119, 2.7.7 로그). 이슈 #125 의 "clear Bluetooth cache"
+    와 같은 오도 패턴이라, 실제로 통하는 동작(페어링 모드 + Retry Pairing)을
+    가리켜야 한다.
+    """
+    source = pathlib.Path(
+        "custom_components/omron/omron_ble/parser.py"
+    ).read_text()
+    start = source.index("Memory session failed for OS-bonding device")
+    message = source[start : start + 800]
+
+    assert "remove and re-add the device" not in message
+    assert "pairing mode" in message
+    assert "Retry Pairing" in message

--- a/tests/test_pairing_session_handoff.py
+++ b/tests/test_pairing_session_handoff.py
@@ -1,9 +1,13 @@
 """Pairing-session handoff regression tests (discussions#119).
 
-WLD3.0 cuffs (HEM-7380T1 / 7188T1 and friends) serve data during the pairing
+WLD3.0 cuffs (HEM-7380T1 and friends) serve data during the pairing
 session and reject later connections — see the _WLD3_BOND_POLICY comment in
-device_catalog.py. Closing the link after pairing and letting the follow-up
-poll reconnect is therefore what makes that poll time out.
+device_catalog.py. HEM-7188T1 shows the same handoff symptom but is WLD4.0
+and no longer shares that bond policy (see _WLD4_BOND_POLICY); the handoff
+below is what it has in common with them, not the bond lifetime.
+
+Closing the link after pairing and letting the follow-up poll reconnect is
+therefore what makes that poll time out.
 
 The config flow already parked its session in _setup_sessions so the first
 poll reuses the same link, but the advertisement-triggered auto-pairing


### PR DESCRIPTION
> **Draft — do not merge before real-device verification.** This is a field experiment for issue #92 (HEM-7188T1-LEO), not a fix with evidence behind it yet.

## Why this isn't a repeat of an earlier setting

It looks like reverting to `REUSE`, which the WLD4.0 profiles effectively had before. Tracing what actually shipped says otherwise:

| Release | Bond | `pair_on_connect` | `unlock_mode` | What blocked it |
|---|---|---|---|---|
| ≤ 2.5.23 | kept (`os_bond_once=True`) | did not exist | `SECURE_SESSION` | device rejects the ECDH pairing request outright (`0xff26`) — unlock never got off the ground |
| master 7/27–8/1 (#107) | kept | none → True on 8/1 | `TOKEN_KEY` | **never released** |
| 2.6.0 → now | dropped (`PER_SESSION`) | True | `TOKEN_KEY` | only the first session works |

The `2.6.0` tag points at `e21fe6b` (#109) itself, and #108 (which introduced `pair_on_connect`) landed 19 minutes earlier in that same release. So **"kept bond + `TOKEN_KEY` + security up before GATT" has never been in a release.** The kept-bond builds that did ship failed for an unrelated reason — the wrong unlock mode.

## Why `PER_SESSION` is wrong here specifically

`unpair_after_session` rests on "dropping the bond is safe because `pair_on_connect` bonds again on the next connect". Field reports show that premise does not hold for this cuff: once it leaves pairing mode it answers a *fresh* bond request with `AuthenticationCanceled` / error 102. Dropping the bond therefore guarantees the next connect fails rather than recovering.

These profiles inherited `PER_SESSION` only because they were classified WLD3.0 when #109 landed. #112 reclassified `HEM-7188T1` as WLD4.0 without revisiting the policy, and no WLD4.0 cuff ever supplied the evidence `PER_SESSION` was derived from.

## Second reproduction (2.7.7, local BlueZ)

[discussions#119](https://github.com/eigger/hass-omron/discussions/119#discussioncomment-18110921) reproduces the same chain independently — different reporter, different variant (`HEM-7188T1-**LE**`, not `-LEO`), and a **local hci0 adapter** (`source=2C:CF:67:E6:50:E0`, which habluetooth reports as `preferred order: hci0`; the `via proxy/source=` wording in our own log line is generic).

The pairing session itself is completely healthy — protocol, token unlock, EEPROM map, index cursor and parser all work, and real values come back:

```
22:55:31.486  Bonded ... before service discovery
22:55:34.679  Token unlock OK (nonce=d7fedf54)
22:55:35.699  Memory session opened
22:55:36.570  slot=3 parsed: sys=151 dia=80 bpm=76 dt=2026-08-19 22:19:28
22:55:39.300  Removed OS bond for HEM-7188T1-LE after session     <-- PER_SESSION
```

Two minutes later, "Refresh Data":

```
22:57:48.410  Bonding ... failed: [org.bluez.Error.AuthenticationCanceled]
              ; falling back to connect without pair
22:57:48.631  BLE link established (is_connected=True)             <-- unencrypted
22:57:50.941  Memory session open attempt 1/3: [NotConnected]      <-- dropped on first GATT op
22:57:51.445  attempt 2/3: [NotConnected]
22:57:51.948  attempt 3/3: [NotConnected]
```

So the only thing standing between this device and working polls is bond lifetime. Nothing else in the stack is implicated.

**The recovery path added here does not fire on this log, and should not.** `AuthenticationCanceled` is deliberately not matched by `_is_stale_bond_auth_error`:

```
[org.bluez.Error.AuthenticationCanceled]  stale=False   non_fatal=True
[org.bluez.Error.AuthenticationFailed]    stale=True    non_fatal=True
```

There is no stale bond to clear — we had just removed it ourselves. What fixes *this* log is the catalog half alone; the recovery is insurance for the opposite hypothesis. (It also answers the review concern that a false positive could contaminate the experiment: the error these cuffs actually produce on this path does not reach the trigger.)

**What this log still cannot answer:** whether a *kept* bond would have reconnected. The bond was already gone, so "reconnect on a kept bond" is never observed — which is exactly what the prerelease has to establish.

## Changes

**1. Split `_WLD4_BOND_POLICY` (`REUSE`) out of `_WLD3_BOND_POLICY`** — applies to `HEM-7188T1` / `HEM-7191T1` / `HEM-7196T1`. The WLD3.0 family keeps its verified `PER_SESSION` behaviour untouched.

`pair_on_connect` stays true, which is the part that makes this different from the 2.5.23 shape: bleak skips `Pair()` while BlueZ still lists the device as paired (`if pair and not manager.is_paired(...)`), so the stored LTK comes up *before* any GATT op rather than after discovery.

```
HEM-7155T-MW3   WLD3.0   per_session   pair_on_conn=True   unpair_after=True    unchanged
HEM-7376/7377/7380/7386T1  WLD3.0  per_session  True  True                      unchanged
HEM-7188T1      WLD4.0   reuse         pair_on_conn=True   unpair_after=False   changed
HEM-7191T1      WLD4.0   reuse         pair_on_conn=True   unpair_after=False   changed
HEM-7196T1      WLD4.0   reuse         pair_on_conn=True   unpair_after=False   changed
```

**2. Recover stale bonds on the connect path.** Without this the experiment cannot fail informatively. If the cuff really does forget its side of the bond, the stored LTK gets rejected — and the only handler for that lives in `_pair_os_bonding()`, which `pair()` skips entirely under `pair_on_connect`, making it dead code for all eight profiles that bond during connect:

```
pair_on_connect=True  → stale-bond recovery reachable? NO   (8 profiles)
  HEM-7155T-MW3, HEM-7188T1, HEM-7191T1, HEM-7196T1,
  HEM-7376T1, HEM-7377T1, HEM-7380T1, HEM-7386T1
pair_on_connect=False → reachable? YES  (5 profiles)
  HEM-7142T2, HEM-7146T, HEM-7155T-K4, HEM-7155T-MW, HEM-716BT2
```

So `establish_connection_with_bond_settle` now clears the bond **once** on an `AuthenticationFailed`-class error and retries as a real bond, instead of silently downgrading to an unpaired link — which is the link the token unlock and memory session then fail on, exactly as reported in #92.

## How to read the result

- **Reconnect succeeds** → the cuff keeps its LTK; `PER_SESSION` was never needed here → merge.
- **Stale-bond warning fires** → the cuff does discard it, now stated unambiguously instead of surfacing as "characteristic not found" → the device needs a button press per session, and polling has to move to an advertisement-triggered design.

Either way the two hypotheses separate, which is what the current code cannot do.

## Test plan
- [x] `pytest tests -q` — 119 passed (13 in `tests/test_bond_policy_recovery.py`)
- [x] Each half verified to fail when reverted independently (catalog-only revert → 3 failures; driver-only revert → 2 failures; each new log guard → 1 failure)
- [ ] **Real HEM-7188T1-LEO: pair, read, then reconnect / "Refresh Data"** — the whole point of the branch
- [ ] Confirm no regression on a WLD3.0 cuff (HEM-7380T1 family), which this deliberately does not touch

**What the verification report needs to state**, because the result is not readable without it:

1. **Backend: local BlueZ adapter or ESPHome proxy.** `_bluez_remove_device` needs a BlueZ DBus path, so on a proxy the bond cannot be removed and the retry re-offers the same key. The branch now warns explicitly when that happens, but the report still has to say which backend produced the log. (The logs driving this PR — karl-petter's, Johannes-42's and andyrozman's — are `org.bluez.*`, i.e. local adapters; JamesH1978's reproduction is esp32 proxy.)
2. **If the reconnect succeeds: was the cuff in pairing mode?** "Reconnected on the kept bond" and "re-bonded because the cuff happened to be in pairing mode" are the same success line and opposite conclusions.
3. **Which warning fired.** Three distinct outcomes now print differently:
   - no bonding warning at all → the kept bond worked; `PER_SESSION` was never needed here
   - `...was rejected as a stale bond... — removing it` followed by `...bonding again after removing it was refused too...` → the cuff discards its key **and** will not accept a new one outside pairing mode → per-session button press is mandatory, and polling has to move to an advertisement-triggered design
   - `Could not remove the bond ... no BlueZ DBus path` → proxy backend; this run cannot distinguish the two hypotheses, rerun on a local adapter

Refs #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)

