### PR TITLE
fix: poll PER_SESSION cuffs when they signal, not when the clock says so

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -132,15 +132,36 @@ def process_service_info(
     data = coordinator.device_data
     update = data.update(service_info)
 
-    # 1. Only attempt active sessions when the device is connectable
-    if not service_info.connectable:
-        return update
-
     entry_data = coordinator.hass.data[DOMAIN][entry.entry_id]
 
     is_pairing = getattr(data, "pairing_mode", False)
     is_invalid_time = getattr(data, "invalid_time", False)
     is_forced_transfer = getattr(data, "forced_transfer", False)
+
+    # Logged before the returns below, and on every transition rather than only
+    # when we act. Both early returns used to swallow the flags silently, so a
+    # missing log line could equally mean "the cuff raised nothing", "it raised
+    # something on a non-connectable advertisement", or "it raised a flag we
+    # don't trigger on" — three very different answers to whether automatic
+    # collection is possible, and no way to tell them apart from a debug log
+    # (issue #92). Only transitions are logged: these cuffs advertise about
+    # once a second, and a line per advertisement would bury what it is for.
+    flags = (is_pairing, is_invalid_time, is_forced_transfer, service_info.connectable)
+    if entry_data.get("last_advert_flags") != flags:
+        entry_data["last_advert_flags"] = flags
+        _LOGGER.debug(
+            "Advertisement flags for %s: pairing_mode=%s invalid_time=%s "
+            "forced_transfer=%s connectable=%s",
+            service_info.address,
+            is_pairing,
+            is_invalid_time,
+            is_forced_transfer,
+            service_info.connectable,
+        )
+
+    # 1. Only attempt active sessions when the device is connectable
+    if not service_info.connectable:
+        return update
 
     # Trigger sync only for explicit device flags. A poll coordinator being present
     # is not itself a reason to connect on every advertisement.
@@ -151,14 +172,6 @@ def process_service_info(
     )
     if not is_sync_needed:
         return update
-
-    _LOGGER.debug(
-        "Advertisement flags for %s: pairing_mode=%s invalid_time=%s forced_transfer=%s",
-        service_info.address,
-        is_pairing,
-        is_invalid_time,
-        is_forced_transfer,
-    )
 
     # 2. Fail fast if a GATT session is already running — try-acquire only, no queueing.
     # The device rejects a second concurrent BLE connection with SMP auth fail

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -14,6 +14,9 @@ from .ble_session import (
     adopt_handoff_session,
     discard_handoff_session,
     has_handoff_session,
+    request_poll,
+    should_skip_scheduled_poll,
+    take_poll_request,
     omron_poll_ble_telemetry,
     poll_parked_session,
     run_post_pairing_poll,
@@ -47,6 +50,11 @@ PLATFORMS: list[Platform] = [
 ]
 
 _LOGGER = logging.getLogger(__name__)
+
+# Minimum gap between advertisement log lines when only the raw MSD changed.
+# Flag and connectability changes ignore this — they are the events the log
+# exists for; a rolling byte in the payload is not.
+_ADVERT_MSD_LOG_INTERVAL_SEC = 5.0
 
 # BLE advertisement trigger control constants
 POLL_COOLDOWN_SECONDS = 60
@@ -158,16 +166,25 @@ def process_service_info(
 
     # Keyed on the MSD too, so a payload that changes while the decoded flags
     # stay False is still visible — which is exactly what a measurement that
-    # we are failing to recognise would look like.
-    flags = (
-        is_pairing,
-        is_invalid_time,
-        is_forced_transfer,
-        service_info.connectable,
-        msd_hex,
+    # we are failing to recognise would look like. A per-advertisement field
+    # in the payload (a sequence byte, say) would otherwise put this back to a
+    # line a second, so MSD-only changes are throttled; a change in the
+    # decoded flags or in connectability always prints.
+    decoded_key = (
+        is_pairing, is_invalid_time, is_forced_transfer, service_info.connectable
     )
-    if entry_data.get("last_advert_flags") != flags:
+    flags = decoded_key + (msd_hex,)
+    previous = entry_data.get("last_advert_flags")
+    changed = previous != flags
+    decoded_changed = previous is None or previous[:4] != decoded_key
+    now = time.monotonic()
+    throttled = (
+        not decoded_changed
+        and now - entry_data.get("last_advert_log", 0.0) < _ADVERT_MSD_LOG_INTERVAL_SEC
+    )
+    if changed and not throttled:
         entry_data["last_advert_flags"] = flags
+        entry_data["last_advert_log"] = now
         _LOGGER.debug(
             "Advertisement flags for %s: pairing_mode=%s invalid_time=%s "
             "forced_transfer=%s connectable=%s msd=%s (format=%s decoded=%s)",
@@ -226,6 +243,11 @@ def process_service_info(
         # otherwise the child poll would see lock locked and return cached data.
         if is_forced_transfer and not is_pairing and not is_invalid_time:
             entry_data["last_attempt_time"] = time.time()
+            # Latched before the refresh, because that call is debounced: the
+            # poll it schedules runs seconds later and re-reads the flags,
+            # and a cuff that has since lowered the bit would have this
+            # request dropped by the gate.
+            request_poll(entry_data, "forced-transfer advertisement")
             _LOGGER.debug(
                 "Triggering scheduled poll via forced-transfer flag for %s",
                 service_info.address,
@@ -411,16 +433,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
             # A parked pairing session is exempt: that link is already open
             # and bonded, and skipping would strand it.
             device_data = coordinator.device_data
-            # Consumed unconditionally: a request that ends up skipped for some
-            # other reason must not leave the flag armed for a later scheduled
-            # poll that nobody asked for.
-            user_requested = entry_data.pop("user_requested_poll", False)
-            if (
-                not user_requested
-                and device_data.device_config.poll_requires_pairing_window
-                and not device_data.pairing_mode
-                and not device_data.forced_transfer
-                and not has_handoff_session(hass, address)
+            # Peeked, not consumed: a request must survive every path that
+            # bails out before a connect is actually attempted, or pressing
+            # the button while a session is in flight throws the press away.
+            poll_request = take_poll_request(entry_data)
+            flags_at = getattr(device_data, "last_msd_monotonic", None)
+            if should_skip_scheduled_poll(
+                device_data.device_config,
+                pairing_mode=device_data.pairing_mode,
+                forced_transfer=device_data.forced_transfer,
+                flags_age=None if flags_at is None else time.monotonic() - flags_at,
+                poll_request=poll_request,
+                handoff_parked=has_handoff_session(hass, address),
             ):
                 _LOGGER.debug(
                     "Skipping scheduled poll for %s (%s): the cuff is not "
@@ -449,6 +473,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 return entry.runtime_data.device_data._finish_update()
 
             async with session_lock:
+                # Committed to connecting, so the request has now been served.
+                # Consuming any earlier would discard it on a path that never
+                # touched the radio — the session-lock skip above being the
+                # one a user hits by pressing the button twice.
+                if poll_request is not None:
+                    entry_data.pop("poll_request", None)
+                    _LOGGER.debug(
+                        "Polling %s on a %s request", address, poll_request
+                    )
                 # Adopt a parked pairing/setup session (memory readout still
                 # open) so pairing, time sync, and the first EEPROM read share
                 # one connection. Taken here rather than at the top of the

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -146,17 +146,39 @@ def process_service_info(
     # collection is possible, and no way to tell them apart from a debug log
     # (issue #92). Only transitions are logged: these cuffs advertise about
     # once a second, and a line per advertisement would bury what it is for.
-    flags = (is_pairing, is_invalid_time, is_forced_transfer, service_info.connectable)
+    # The raw MSD rides along because the decoded flags cannot answer the
+    # question on their own: forced_transfer=False means "the cuff did not
+    # raise it", "this MSD format has no bit for it" (0x03 carries none), or
+    # "the payload failed its length contract and was dropped" — and only the
+    # first is a hardware limit. The format byte separates them.
+    msd = getattr(data, "last_msd", None)
+    msd_hex = msd.hex() if msd else "none"
+    msd_format = f"0x{msd[0]:02X}" if msd else "-"
+    msd_decoded = getattr(data, "last_msd_decoded", False)
+
+    # Keyed on the MSD too, so a payload that changes while the decoded flags
+    # stay False is still visible — which is exactly what a measurement that
+    # we are failing to recognise would look like.
+    flags = (
+        is_pairing,
+        is_invalid_time,
+        is_forced_transfer,
+        service_info.connectable,
+        msd_hex,
+    )
     if entry_data.get("last_advert_flags") != flags:
         entry_data["last_advert_flags"] = flags
         _LOGGER.debug(
             "Advertisement flags for %s: pairing_mode=%s invalid_time=%s "
-            "forced_transfer=%s connectable=%s",
+            "forced_transfer=%s connectable=%s msd=%s (format=%s decoded=%s)",
             service_info.address,
             is_pairing,
             is_invalid_time,
             is_forced_transfer,
             service_info.connectable,
+            msd_hex,
+            msd_format,
+            msd_decoded,
         )
 
     # 1. Only attempt active sessions when the device is connectable

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -13,6 +13,7 @@ from sensor_state_data import SensorDeviceClass as SSDSensorDeviceClass
 from .ble_session import (
     adopt_handoff_session,
     discard_handoff_session,
+    has_handoff_session,
     omron_poll_ble_telemetry,
     poll_parked_session,
     run_post_pairing_poll,
@@ -363,6 +364,36 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 )
                 return entry.runtime_data.device_data._finish_update()
             coordinator = entry.runtime_data
+
+            # Profiles that drop their bond every session cannot read on a timer:
+            # the cuff refuses a new bond once it leaves pairing mode, so a
+            # poll fired only because the interval elapsed spends a connect,
+            # a bond attempt and the session lock to reach a failure that was
+            # certain before it started. Let the device say when a read can
+            # work — pairing_mode (a bond can be made now) or forced_transfer
+            # (a measurement is waiting) — instead of guessing on the clock.
+            #
+            # A parked pairing session is exempt: that link is already open
+            # and bonded, and skipping would strand it.
+            device_data = coordinator.device_data
+            if (
+                device_data.device_config.poll_requires_pairing_window
+                and not device_data.pairing_mode
+                and not device_data.forced_transfer
+                and not has_handoff_session(hass, address)
+            ):
+                _LOGGER.debug(
+                    "Skipping scheduled poll for %s (%s): the cuff is not "
+                    "advertising pairing mode or pending data, and this "
+                    "profile needs a fresh bond for every session. Put it in "
+                    "pairing mode (blinking -P-) to read now",
+                    address,
+                    device_data.device_config.model,
+                )
+                if poll_coordinator.data is not None:
+                    return poll_coordinator.data
+                return entry.runtime_data.device_data._finish_update()
+
             session_lock: asyncio.Lock = entry_data["session_lock"]
 
             # Try-acquire only — if another BLE session is in flight (e.g. an

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -376,8 +376,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
             # A parked pairing session is exempt: that link is already open
             # and bonded, and skipping would strand it.
             device_data = coordinator.device_data
+            # Consumed unconditionally: a request that ends up skipped for some
+            # other reason must not leave the flag armed for a later scheduled
+            # poll that nobody asked for.
+            user_requested = entry_data.pop("user_requested_poll", False)
             if (
-                device_data.device_config.poll_requires_pairing_window
+                not user_requested
+                and device_data.device_config.poll_requires_pairing_window
                 and not device_data.pairing_mode
                 and not device_data.forced_transfer
                 and not has_handoff_session(hass, address)

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -133,17 +133,38 @@ def _register_advertisement_observer(
         if decoded is None:
             summary = "undecodable" if payload else "no Omron MSD"
         else:
-            summary = (
-                f"pairing_mode={decoded['pairing_mode']} "
-                f"invalid_time={decoded['invalid_time']} "
-                f"forced_transfer={decoded['forced_transfer']}"
+            # Every decoded field, not just the three we act on. The field that
+            # broke this open — a cuff advertising user_register_count=0 while
+            # a paired one shows 1 — was already being parsed and simply never
+            # printed, so it had to be found by decoding a pasted payload by
+            # hand. A diagnostic that shows only what we already suspected is
+            # not much of a diagnostic.
+            summary = " ".join(
+                f"{name}={decoded[name]}"
+                for name in (
+                    "user_register_count",
+                    "pairing_mode",
+                    "invalid_time",
+                    "forced_transfer",
+                    "streaming_mode",
+                    "service_uuid_mode",
+                    "guidance_mode",
+                    "result_identifier_num",
+                )
             )
+        # The flags byte is printed raw as well: the decoder only reads two
+        # bytes of the payload, so a signal living in the rest would otherwise
+        # be invisible even with the full MSD on the line.
+        flags_byte = f"0x{payload[1]:02X}" if payload and len(payload) > 1 else "-"
         _LOGGER.debug(
-            "Observed advertisement from %s: connectable=%s rssi=%s msd=%s (%s)",
+            "Observed advertisement from %s: connectable=%s rssi=%s msd=%s "
+            "(format=%s flags=%s %s)",
             service_info.address,
             service_info.connectable,
             getattr(service_info, "rssi", "?"),
             msd_hex,
+            f"0x{payload[0]:02X}" if payload else "-",
+            flags_byte,
             summary,
         )
 

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -6,6 +6,7 @@ from functools import partial
 import asyncio
 import logging
 import time
+from typing import Any
 
 from sensor_state_data import BinarySensorDeviceClass as SSDBinarySensorDeviceClass
 from sensor_state_data import SensorDeviceClass as SSDSensorDeviceClass
@@ -16,20 +17,23 @@ from .ble_session import (
     has_handoff_session,
     request_poll,
     should_skip_scheduled_poll,
-    take_poll_request,
+    peek_poll_request,
     omron_poll_ble_telemetry,
     poll_parked_session,
     run_post_pairing_poll,
 )
 from .omron_ble import OmronBluetoothDeviceData, SensorUpdate
-from .omron_ble.const import DEFAULT_DEVICE_MODEL
+from .omron_ble.const import DEFAULT_DEVICE_MODEL, OMRON_MANUFACTURER_ID
 from homeassistant.components.bluetooth import (
+    BluetoothCallbackMatcher,
+    BluetoothChange,
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
     async_ble_device_from_address,
+    async_register_callback,
 )
 from homeassistant.const import Platform, CONF_SCAN_INTERVAL
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from datetime import timedelta
@@ -79,6 +83,78 @@ _STALE_DROP_SENSOR_DEVICE_CLASSES: frozenset = frozenset({
 _STALE_DROP_BINARY_DEVICE_CLASSES: frozenset = frozenset({
     SSDBinarySensorDeviceClass.BATTERY,
 })
+
+
+def _register_advertisement_observer(
+    hass: HomeAssistant, entry: OmronConfigEntry, address: str
+) -> None:
+    """Log every advertisement from this cuff, connectable or not.
+
+    The processor coordinator registers with ``connectable=True``, so Home
+    Assistant only ever hands it advertisements it could connect on. A cuff
+    that announces "measurement waiting" in a non-connectable advertisement is
+    therefore invisible to ``process_service_info`` — not because of the
+    connectable check inside it, but because the advertisement was filtered
+    one level up, before any of our code ran.
+
+    That is the difference between "this hardware cannot do buttonless
+    collection" and "we are not listening on the channel it uses", and issue
+    #92 currently cannot tell them apart: two real measurements produced no
+    trace at all. This observer registers with ``connectable=False``, which in
+    Home Assistant means "give me everything", purely to find out.
+
+    Diagnostic only — it never touches device state or starts a session.
+    """
+
+    @callback
+    def _observe(
+        service_info: BluetoothServiceInfoBleak, change: BluetoothChange
+    ) -> None:
+        md = getattr(service_info, "manufacturer_data", None) or {}
+        payload = md.get(OMRON_MANUFACTURER_ID)
+        msd_hex = payload.hex() if payload else "none"
+
+        entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+        if entry_data is None:
+            return
+        seen = (msd_hex, service_info.connectable)
+        if entry_data.get("last_observed_advert") == seen:
+            return
+        entry_data["last_observed_advert"] = seen
+
+        decoded: Any = None
+        if payload:
+            try:
+                decoded = OmronBluetoothDeviceData._decode_omron_msd_fields(
+                    bytes(payload)
+                )
+            except Exception:  # noqa: BLE001 - diagnostic must never raise
+                decoded = None
+        if decoded is None:
+            summary = "undecodable" if payload else "no Omron MSD"
+        else:
+            summary = (
+                f"pairing_mode={decoded['pairing_mode']} "
+                f"invalid_time={decoded['invalid_time']} "
+                f"forced_transfer={decoded['forced_transfer']}"
+            )
+        _LOGGER.debug(
+            "Observed advertisement from %s: connectable=%s rssi=%s msd=%s (%s)",
+            service_info.address,
+            service_info.connectable,
+            getattr(service_info, "rssi", "?"),
+            msd_hex,
+            summary,
+        )
+
+    entry.async_on_unload(
+        async_register_callback(
+            hass,
+            _observe,
+            BluetoothCallbackMatcher(address=address, connectable=False),
+            BluetoothScanningMode.PASSIVE,
+        )
+    )
 
 
 def _merge_poll_sensor_update(prev: SensorUpdate, new: SensorUpdate) -> SensorUpdate:
@@ -202,6 +278,17 @@ def process_service_info(
     if not service_info.connectable:
         return update
 
+    # Latched here, before the session-lock and cooldown returns below, because
+    # those drop the advertisement entirely. A cuff that announced a waiting
+    # measurement while another session held the lock would otherwise be
+    # forgotten: the next scheduled poll is up to a scan interval away, by
+    # which time the flag has aged past ADVERT_FLAG_FRESHNESS_SECONDS and the
+    # gate skips it. The measurement then sits unread with nothing left that
+    # knows to go and get it. Re-latching while the flag stays up just
+    # refreshes the request's TTL, which is what we want.
+    if is_forced_transfer:
+        request_poll(entry_data, "forced-transfer advertisement")
+
     # Trigger sync only for explicit device flags. A poll coordinator being present
     # is not itself a reason to connect on every advertisement.
     is_sync_needed = (
@@ -243,11 +330,6 @@ def process_service_info(
         # otherwise the child poll would see lock locked and return cached data.
         if is_forced_transfer and not is_pairing and not is_invalid_time:
             entry_data["last_attempt_time"] = time.time()
-            # Latched before the refresh, because that call is debounced: the
-            # poll it schedules runs seconds later and re-reads the flags,
-            # and a cuff that has since lowered the bit would have this
-            # request dropped by the gate.
-            request_poll(entry_data, "forced-transfer advertisement")
             _LOGGER.debug(
                 "Triggering scheduled poll via forced-transfer flag for %s",
                 service_info.address,
@@ -436,7 +518,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
             # Peeked, not consumed: a request must survive every path that
             # bails out before a connect is actually attempted, or pressing
             # the button while a session is in flight throws the press away.
-            poll_request = take_poll_request(entry_data)
+            poll_request = peek_poll_request(entry_data)
             flags_at = getattr(device_data, "last_msd_monotonic", None)
             if should_skip_scheduled_poll(
                 device_data.device_config,
@@ -446,7 +528,18 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 poll_request=poll_request,
                 handoff_parked=has_handoff_session(hass, address),
             ):
-                _LOGGER.debug(
+                # First skip of a run says so at INFO: from the outside this
+                # looks like a sensor that quietly stopped updating, and at
+                # DEBUG the reason is invisible in a default log. Subsequent
+                # skips stay at DEBUG so a cuff left idle does not repeat it
+                # every scan interval.
+                log = (
+                    _LOGGER.debug
+                    if entry_data.get("poll_gate_waiting")
+                    else _LOGGER.info
+                )
+                entry_data["poll_gate_waiting"] = True
+                log(
                     "Skipping scheduled poll for %s (%s): the cuff is not "
                     "advertising pairing mode or pending data, and this "
                     "profile needs a fresh bond for every session. Put it in "
@@ -457,6 +550,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 if poll_coordinator.data is not None:
                     return poll_coordinator.data
                 return entry.runtime_data.device_data._finish_update()
+
+            if entry_data.pop("poll_gate_waiting", False):
+                _LOGGER.info(
+                    "Polling %s again: the cuff is offering a window", address
+                )
 
             session_lock: asyncio.Lock = entry_data["session_lock"]
 
@@ -558,6 +656,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     # only start after all platforms have had a chance to subscribe
+    _register_advertisement_observer(hass, entry, address)
     entry.async_on_unload(bt_coordinator.async_start())
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True

--- a/custom_components/omron/ble_session.py
+++ b/custom_components/omron/ble_session.py
@@ -48,10 +48,17 @@ def request_poll(entry_data: dict, source: str, *, now: float | None = None) -> 
     entry_data["poll_request"] = (source, time.monotonic() if now is None else now)
 
 
-def take_poll_request(
+def peek_poll_request(
     entry_data: dict, *, now: float | None = None
 ) -> str | None:
-    """Return the pending poll request's source, dropping it if it went stale."""
+    """Return the pending poll request's source without consuming it.
+
+    Named for the peek because that is the part callers get wrong: the request
+    is only cleared once a connect is actually committed, so that a press or
+    an advertisement blocked by the session lock is served by the retry
+    instead of vanishing. The one thing this does remove is a request that
+    aged out — an expired one is not a request any more.
+    """
     request = entry_data.get("poll_request")
     if request is None:
         return None

--- a/custom_components/omron/ble_session.py
+++ b/custom_components/omron/ble_session.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from time import perf_counter
@@ -18,6 +19,81 @@ if TYPE_CHECKING:
     from .omron_ble.omron_driver import OmronDeviceSession
 
 _LOGGER = logging.getLogger(__name__)
+
+
+# A poll someone actually asked for stays valid this long. Requests are not
+# consumed until a connect is committed, so without a bound a request that
+# never got its chance would sit armed and later open an unrelated scheduled
+# poll long after the moment that justified it had passed.
+POLL_REQUEST_TTL_SECONDS = 300
+
+# Advertisement flags are only refreshed when an MSD decodes. A packet that
+# fails its length contract, or a cuff that stops advertising, leaves the last
+# values frozen — and a frozen True would reopen exactly the doomed connects
+# the gate exists to stop. Past this age the flags are treated as unknown.
+ADVERT_FLAG_FRESHNESS_SECONDS = 60
+
+
+def request_poll(entry_data: dict, source: str, *, now: float | None = None) -> None:
+    """Record that something asked for a poll, for the gate to honour.
+
+    ``async_request_refresh`` is debounced by roughly ten seconds, so the poll
+    it schedules reads the advertisement flags well after the advertisement
+    that prompted it. A cuff that lowered the bit in between would have its
+    request silently dropped by the gate — the buttonless-collection path
+    being the one most likely to lose that race. Latching the request means
+    the gate honours the moment the flag was seen, not the moment the poll
+    happened to run.
+    """
+    entry_data["poll_request"] = (source, time.monotonic() if now is None else now)
+
+
+def take_poll_request(
+    entry_data: dict, *, now: float | None = None
+) -> str | None:
+    """Return the pending poll request's source, dropping it if it went stale."""
+    request = entry_data.get("poll_request")
+    if request is None:
+        return None
+    source, requested_at = request
+    if (time.monotonic() if now is None else now) - requested_at > POLL_REQUEST_TTL_SECONDS:
+        entry_data.pop("poll_request", None)
+        return None
+    return source
+
+
+def should_skip_scheduled_poll(
+    config: Any,
+    *,
+    pairing_mode: bool,
+    forced_transfer: bool,
+    flags_age: float | None,
+    poll_request: str | None,
+    handoff_parked: bool,
+) -> bool:
+    """Whether a poll would be spending a connect on a certain failure.
+
+    Split out of ``_async_poll_data`` so it can be called directly: the
+    conditions here are the whole behaviour of the gate, and a test that
+    restates them in its own words checks only that someone typed the same
+    thing twice.
+
+    ``flags_age`` is seconds since the advertisement flags were last refreshed
+    from a decoded MSD, or None if they never were.
+    """
+    if not config.poll_requires_pairing_window:
+        return False
+    # Someone asked for this connect — a person, or an advertisement that said
+    # a read could work. Either way it is not the clock talking.
+    if poll_request is not None:
+        return False
+    # A parked link is already open and bonded; skipping strands it and loses
+    # the reading it was opened for.
+    if handoff_parked:
+        return False
+    if flags_age is None or flags_age > ADVERT_FLAG_FRESHNESS_SECONDS:
+        return True
+    return not (pairing_mode or forced_transfer)
 
 
 async def stash_handoff_session(

--- a/custom_components/omron/ble_session.py
+++ b/custom_components/omron/ble_session.py
@@ -79,6 +79,17 @@ async def poll_parked_session(
     return True
 
 
+def has_handoff_session(hass: HomeAssistant, address: str) -> bool:
+    """Whether a pairing session is parked for ``address``, without taking it.
+
+    The poll gate needs to know this before deciding to skip: a parked link is
+    the one connect that is guaranteed to work, so a skip there would strand
+    it and throw away the read it was opened for. ``adopt_handoff_session``
+    pops, which is exactly what a gate must not do.
+    """
+    return address in hass.data.get(DOMAIN, {}).get("_setup_sessions", {})
+
+
 def adopt_handoff_session(
     hass: HomeAssistant, address: str
 ) -> OmronDeviceSession | None:

--- a/custom_components/omron/button.py
+++ b/custom_components/omron/button.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .ble_session import (
     omron_poll_ble_telemetry,
     poll_parked_session,
+    request_poll,
     run_post_pairing_poll,
 )
 from .const import DOMAIN
@@ -85,9 +86,10 @@ class OmronRefreshDataButtonEntity(ButtonEntity):
         # advertising that a read can work. A person pressing this button is
         # not the clock: they asked for this connect, so it happens even when
         # the gate would have skipped it, and they see the real error instead
-        # of a button that silently does nothing. One-shot — the next
-        # scheduled poll is gated again.
-        self.hass.data[DOMAIN][self._entry_id]["user_requested_poll"] = True
+        # of a button that silently does nothing. The request is consumed when
+        # a connect is actually attempted, so a press that lands while another
+        # session holds the lock is honoured by the retry rather than lost.
+        request_poll(self.hass.data[DOMAIN][self._entry_id], "button press")
         try:
             await poll_coordinator.async_request_refresh()
         except Exception as err:

--- a/custom_components/omron/button.py
+++ b/custom_components/omron/button.py
@@ -81,6 +81,13 @@ class OmronRefreshDataButtonEntity(ButtonEntity):
     async def async_press(self) -> None:
         """Handle button press to poll device and refresh sensor data."""
         poll_coordinator = self._entry.runtime_data.poll_coordinator
+        # Scheduled polls for bond-per-session profiles are gated on the cuff
+        # advertising that a read can work. A person pressing this button is
+        # not the clock: they asked for this connect, so it happens even when
+        # the gate would have skipped it, and they see the real error instead
+        # of a button that silently does nothing. One-shot — the next
+        # scheduled poll is gated again.
+        self.hass.data[DOMAIN][self._entry_id]["user_requested_poll"] = True
         try:
             await poll_coordinator.async_request_refresh()
         except Exception as err:

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.2"
+  "version": "2.7.8-beta.3"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.4"
+  "version": "2.7.8-beta.5"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.7"
+  "version": "2.7.8-beta.1"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.3"
+  "version": "2.7.8-beta.4"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.1"
+  "version": "2.7.8-beta.2"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.5"
+  "version": "2.7.8-beta.6"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -25,23 +25,22 @@ _WLD3_BOND_POLICY = BondPolicy.PER_SESSION
 
 # Bond strategy for the WLD4.0 family (HEM-7188T1 / 7191T1 / 7196T1).
 #
-# These profiles used to share _WLD3_BOND_POLICY, but only because they were
-# classified WLD3.0 at the time (#109); #112 reclassified HEM-7188T1 as
-# WLD4.0 without revisiting the bond policy it had inherited. No WLD4.0 cuff
-# ever supplied the evidence PER_SESSION was derived from.
+# Kept separate from _WLD3_BOND_POLICY because these profiles only ever
+# shared it by accident: they were classified WLD3.0 when #109 landed, and
+# #112 reclassified HEM-7188T1 as WLD4.0 without revisiting the policy.
 #
-# Field reports (issue #92, HEM-7188T1-LEO) show the premise PER_SESSION
-# rests on does not hold here: dropping the bond assumes the next connect can
-# bond again, but this cuff answers a fresh bond request with
-# AuthenticationCanceled / error 102 once it has left pairing mode. Dropping
-# the bond therefore guarantees the next connect fails rather than recovering.
+# REUSE was tested here and the answer was no. 2.7.8-beta.1 kept the bond on
+# a real HEM-7188T1-LEO (issue #92): the pairing-mode session read fine and
+# the integration never removed the bond, yet the next scheduled poll still
+# had to bond again and was refused. Whatever the cuff does with its side of
+# the bond, a kept host bond does not carry a later connect, so PER_SESSION
+# describes this hardware at least as well as REUSE does — with the same
+# consequence either way: a read needs a bond, and a bond needs pairing mode.
 #
-# Note what has actually shipped for these profiles: a kept bond went out
-# only in builds that still used unlock_mode=SECURE_SESSION, which the device
-# rejects outright (error frame 0xff26), and pair_on_connect did not exist
-# yet. "Kept bond + TOKEN_KEY + security up before GATT" has never been in a
-# release, so REUSE here is an untested combination, not a revisited one.
-_WLD4_BOND_POLICY = BondPolicy.REUSE
+# That is why the fix is not a bond-policy tweak. See
+# ``poll_requires_pairing_window``: a background poll cannot manufacture the
+# window a read needs, so it no longer tries.
+_WLD4_BOND_POLICY = BondPolicy.PER_SESSION
 
 _MODERN_OS_BONDING_BASE = {
     "parent_service_uuid": MODERN_STACK_PARENT_SERVICE_UUID,

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -13,8 +13,8 @@ from .devices import (
     UnlockMode,
 )
 
-# Bond strategy for the whole WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
-# 7188T1 / 7155T-MW3). These cuffs serve data during the pairing session and
+# Bond strategy for the WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
+# 7155T-MW3). These cuffs serve data during the pairing session and
 # then reject later connections, which fits a device that does not keep its
 # side of the bond; PER_SESSION drops ours to match, so every connection
 # bonds from scratch instead of offering a key the device has forgotten.
@@ -22,6 +22,26 @@ from .devices import (
 # Set this to BondPolicy.REUSE to put the family back on a kept bond — that
 # is the only change needed, every dependent behaviour is derived from it.
 _WLD3_BOND_POLICY = BondPolicy.PER_SESSION
+
+# Bond strategy for the WLD4.0 family (HEM-7188T1 / 7191T1 / 7196T1).
+#
+# These profiles used to share _WLD3_BOND_POLICY, but only because they were
+# classified WLD3.0 at the time (#109); #112 reclassified HEM-7188T1 as
+# WLD4.0 without revisiting the bond policy it had inherited. No WLD4.0 cuff
+# ever supplied the evidence PER_SESSION was derived from.
+#
+# Field reports (issue #92, HEM-7188T1-LEO) show the premise PER_SESSION
+# rests on does not hold here: dropping the bond assumes the next connect can
+# bond again, but this cuff answers a fresh bond request with
+# AuthenticationCanceled / error 102 once it has left pairing mode. Dropping
+# the bond therefore guarantees the next connect fails rather than recovering.
+#
+# Note what has actually shipped for these profiles: a kept bond went out
+# only in builds that still used unlock_mode=SECURE_SESSION, which the device
+# rejects outright (error frame 0xff26), and pair_on_connect did not exist
+# yet. "Kept bond + TOKEN_KEY + security up before GATT" has never been in a
+# release, so REUSE here is an untested combination, not a revisited one.
+_WLD4_BOND_POLICY = BondPolicy.REUSE
 
 _MODERN_OS_BONDING_BASE = {
     "parent_service_uuid": MODERN_STACK_PARENT_SERVICE_UUID,
@@ -1015,7 +1035,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7191T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[60],
@@ -1046,7 +1066,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7196T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0584],
         per_user_records_count=[60, 60],
@@ -1223,7 +1243,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         model="HEM-7188T1",
         connect_type=ConnectType.WLD4_0,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        bond_policy=_WLD4_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[30],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -288,9 +288,9 @@ class DeviceConfig:
     def poll_requires_pairing_window(self) -> bool:
         """Whether a read needs the device to be signalling, not just a timer.
 
-        A profile that drops its bond every session (``BondPolicy.PER_SESSION``)
-        has nothing to reconnect with, and these cuffs refuse to make a new
-        bond once they leave pairing mode — HEM-7188T1 answers the attempt with
+        A profile that drops its bond every session has nothing to reconnect
+        with, and these cuffs refuse to make a new bond once they leave
+        pairing mode — HEM-7188T1 answers the attempt with
         AuthenticationCanceled / error 102. A poll fired purely because the
         scan interval elapsed therefore cannot succeed: it spends a connect, a
         bond attempt and the session lock to arrive at a failure that was
@@ -298,15 +298,19 @@ class DeviceConfig:
 
         The device itself says when a read can work, via the advertisement
         flags: ``pairing_mode`` (a bond can be made now) and
-        ``forced_transfer`` (a measurement is waiting). Polls are gated on
-        those in ``_async_poll_data`` rather than on the clock.
+        ``forced_transfer`` (a measurement is waiting).
 
-        Deliberately derived from the same condition as
-        ``unpair_after_session`` — "we drop the bond" and "we need the device
-        to offer us a new one" are the same fact, and a profile that could set
-        them apart would be describing something incoherent.
+        Restricted to WLD4.0 on purpose. PER_SESSION alone would sweep in the
+        WLD3.0 family (HEM-7380T1 / 7376T1 / 7377T1 / 7386T1 / 7155T-MW3),
+        and the evidence for this gate is one WLD4.0 cuff. The costs are not
+        symmetric: gating a family whose timer polls do work stops their
+        readings silently, while leaving one ungated only wastes connects that
+        were already being wasted. Widen this once a WLD3.0 device has been
+        checked, not before.
         """
-        return self.unpair_after_session
+        return (
+            self.unpair_after_session and self.connect_type == ConnectType.WLD4_0
+        )
 
     @property
     def pair_on_connect(self) -> bool:

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -285,6 +285,30 @@ class DeviceConfig:
         )
 
     @property
+    def poll_requires_pairing_window(self) -> bool:
+        """Whether a read needs the device to be signalling, not just a timer.
+
+        A profile that drops its bond every session (``BondPolicy.PER_SESSION``)
+        has nothing to reconnect with, and these cuffs refuse to make a new
+        bond once they leave pairing mode — HEM-7188T1 answers the attempt with
+        AuthenticationCanceled / error 102. A poll fired purely because the
+        scan interval elapsed therefore cannot succeed: it spends a connect, a
+        bond attempt and the session lock to arrive at a failure that was
+        certain before it started.
+
+        The device itself says when a read can work, via the advertisement
+        flags: ``pairing_mode`` (a bond can be made now) and
+        ``forced_transfer`` (a measurement is waiting). Polls are gated on
+        those in ``_async_poll_data`` rather than on the clock.
+
+        Deliberately derived from the same condition as
+        ``unpair_after_session`` — "we drop the bond" and "we need the device
+        to offer us a new one" are the same fact, and a profile that could set
+        them apart would be describing something incoherent.
+        """
+        return self.unpair_after_session
+
+    @property
     def pair_on_connect(self) -> bool:
         """Bond during connect, before GATT discovery.
 

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -45,6 +45,9 @@ _POST_CONNECT_BOND_SETTLE_SEC: float = 1.5
 # of waiting out the full settle before retrying.
 _CONNECT_SETTLE_ATTEMPTS: int = 3
 _SETTLE_POLL_STEP_SEC: float = 0.25
+# Give BlueZ a moment to tear the device object down after RemoveDevice;
+# pairing again while it is still going away draws the same rejection.
+_BOND_REMOVE_SETTLE_SEC: float = 0.5
 _UNLOCK_PROBE_WAIT_TIMEOUT_SEC: float = 2.0
 _UNLOCK_AUTH_WAIT_TIMEOUT_SEC: float = 5.0
 _PAIRING_SETTLE_AGGRESSIVE_SEC: float = 0.25
@@ -167,6 +170,8 @@ async def establish_connection_with_bond_settle(
         except BleakError as exc:
             if pair_this_attempt:
                 client = None
+                rebond_exc: BaseException | None = None
+                bond_removed = False
                 if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
                     # Not "this cuff won't bond" but "the bond we hold is not
                     # one it still honours": BlueZ offered the stored LTK and
@@ -187,40 +192,68 @@ async def establish_connection_with_bond_settle(
                         source,
                         exc,
                     )
-                    if not await _bluez_remove_device(ble_device):
-                        _LOGGER.debug(
-                            "No DBus path to remove the stale bond for %s; "
-                            "retrying the bond anyway",
+                    bond_removed = await _bluez_remove_device(ble_device)
+                    if not bond_removed:
+                        # Proxy backends have no DBus path to remove through, so
+                        # the bond the proxy holds stays and the retry below
+                        # re-offers the same key. Say so rather than letting the
+                        # retry look like a cleared-bond attempt.
+                        _LOGGER.warning(
+                            "Could not remove the bond for %s on this backend "
+                            "(no BlueZ DBus path — ESPHome proxy links keep "
+                            "their bond); the retry re-offers the same key",
                             name,
                         )
+                    else:
+                        await asyncio.sleep(_BOND_REMOVE_SETTLE_SEC)
                     try:
                         client = await _connect_once(ble_device, name, pair=True)
                     except BleakError as retry_exc:
-                        _LOGGER.debug(
-                            "Re-bonding %s after clearing the stale bond failed "
-                            "(%s); falling back to connect without pair",
-                            name,
-                            retry_exc,
-                        )
+                        rebond_exc = retry_exc
                 if client is None:
-                    # The device refused to bond (e.g. error 102 when the cuff is
-                    # in normal transfer mode instead of pairing mode). Fall back to
-                    # connecting without pair so stateless/token-key transfers succeed.
-                    _LOGGER.warning(
-                        "Bonding %s [%s] during connect via source=%s failed "
-                        "(attempt %d/%d): %s; falling back to connect without pair",
-                        name,
-                        model or "?",
-                        source,
-                        attempt,
-                        _CONNECT_SETTLE_ATTEMPTS,
-                        exc,
-                    )
+                    if rebond_exc is not None:
+                        # Both halves belong in the WARNING: a field report that
+                        # only shows warnings must be able to tell "the cuff
+                        # discarded its key" from "we removed the bond and were
+                        # then refused a new one", which read identically if the
+                        # second error is left at debug level.
+                        _LOGGER.warning(
+                            "Bonding %s [%s] during connect via source=%s failed "
+                            "(attempt %d/%d): the stored bond was rejected (%s), "
+                            "and bonding again after %s was refused too (%s) — "
+                            "falling back to connect without pair. The cuff has "
+                            "to be in pairing mode to accept a new bond.",
+                            name,
+                            model or "?",
+                            source,
+                            attempt,
+                            _CONNECT_SETTLE_ATTEMPTS,
+                            exc,
+                            "removing it" if bond_removed else "failing to remove it",
+                            rebond_exc,
+                        )
+                    else:
+                        # The device refused to bond (e.g. error 102 when the cuff is
+                        # in normal transfer mode instead of pairing mode). Fall back to
+                        # connecting without pair so stateless/token-key transfers succeed.
+                        _LOGGER.warning(
+                            "Bonding %s [%s] during connect via source=%s failed "
+                            "(attempt %d/%d): %s; falling back to connect without pair",
+                            name,
+                            model or "?",
+                            source,
+                            attempt,
+                            _CONNECT_SETTLE_ATTEMPTS,
+                            exc,
+                        )
                     pair_this_attempt = False
                     try:
                         client = await _connect_once(ble_device, name, pair=False)
-                    except Exception:
-                        raise exc
+                    except Exception as fallback_exc:
+                        # Surface the bonding failure as the cause, but keep the
+                        # unpaired attempt's error in the chain instead of
+                        # dropping it on the floor.
+                        raise exc from fallback_exc
             else:
                 raise
         if pair_this_attempt:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -139,6 +139,10 @@ async def establish_connection_with_bond_settle(
     # Cleared if the backend reports it cannot pair at connect time, so the
     # remaining attempts fall back instead of failing repeatedly.
     pair_this_attempt = pair_on_connect
+    # A stale bond is worth clearing exactly once per call: after that a
+    # repeated auth failure is the device refusing to bond, not a key
+    # mismatch, and removing the bond again would just churn it.
+    stale_bond_cleared = False
     for attempt in range(1, _CONNECT_SETTLE_ATTEMPTS + 1):
         source = _connection_source(ble_device)
         last_source = source
@@ -162,24 +166,61 @@ async def establish_connection_with_bond_settle(
             client = await _connect_once(ble_device, name, pair=False)
         except BleakError as exc:
             if pair_this_attempt:
-                # The device refused to bond (e.g. error 102 when the cuff is
-                # in normal transfer mode instead of pairing mode). Fall back to
-                # connecting without pair so stateless/token-key transfers succeed.
-                _LOGGER.warning(
-                    "Bonding %s [%s] during connect via source=%s failed "
-                    "(attempt %d/%d): %s; falling back to connect without pair",
-                    name,
-                    model or "?",
-                    source,
-                    attempt,
-                    _CONNECT_SETTLE_ATTEMPTS,
-                    exc,
-                )
-                pair_this_attempt = False
-                try:
-                    client = await _connect_once(ble_device, name, pair=False)
-                except Exception:
-                    raise exc
+                client = None
+                if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
+                    # Not "this cuff won't bond" but "the bond we hold is not
+                    # one it still honours": BlueZ offered the stored LTK and
+                    # the device rejected it. bleak skips Pair() while BlueZ
+                    # still lists the device as paired, so the bond has to go
+                    # before a retry can be a real bond rather than the same
+                    # rejected key again. Without this a kept-bond (REUSE)
+                    # profile has no way back from a rotated key short of the
+                    # user deleting and re-adding the device.
+                    stale_bond_cleared = True
+                    _LOGGER.warning(
+                        "Bonding %s [%s] via source=%s was rejected as a stale "
+                        "bond (%s) — removing it so this attempt can bond from "
+                        "scratch instead of re-offering a key the cuff has "
+                        "forgotten",
+                        name,
+                        model or "?",
+                        source,
+                        exc,
+                    )
+                    if not await _bluez_remove_device(ble_device):
+                        _LOGGER.debug(
+                            "No DBus path to remove the stale bond for %s; "
+                            "retrying the bond anyway",
+                            name,
+                        )
+                    try:
+                        client = await _connect_once(ble_device, name, pair=True)
+                    except BleakError as retry_exc:
+                        _LOGGER.debug(
+                            "Re-bonding %s after clearing the stale bond failed "
+                            "(%s); falling back to connect without pair",
+                            name,
+                            retry_exc,
+                        )
+                if client is None:
+                    # The device refused to bond (e.g. error 102 when the cuff is
+                    # in normal transfer mode instead of pairing mode). Fall back to
+                    # connecting without pair so stateless/token-key transfers succeed.
+                    _LOGGER.warning(
+                        "Bonding %s [%s] during connect via source=%s failed "
+                        "(attempt %d/%d): %s; falling back to connect without pair",
+                        name,
+                        model or "?",
+                        source,
+                        attempt,
+                        _CONNECT_SETTLE_ATTEMPTS,
+                        exc,
+                    )
+                    pair_this_attempt = False
+                    try:
+                        client = await _connect_once(ble_device, name, pair=False)
+                    except Exception:
+                        raise exc
             else:
                 raise
         if pair_this_attempt:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -101,6 +101,34 @@ def _connection_source(ble_device: BLEDevice) -> str:
     return "unknown"
 
 
+def _connected_path(client: BleakClient, ble_device: BLEDevice) -> str:
+    """Best-effort identity of the link we actually connected over.
+
+    ``_connection_source`` reads the BLEDevice, which names the scanner that
+    saw the *advertisement* — not necessarily the path the connection took.
+    habluetooth picks that at connect time from whichever proxy scores best,
+    so on a multi-proxy setup the bond attempt and the fallback can land on
+    different ESP32s. Each proxy keeps its own bond table, which makes "where
+    did this actually connect" a question the log has to be able to answer
+    (issue #91: an attempt through one proxy, a fallback reported on another,
+    and a pairing the cuff then terminated).
+
+    Probes the backend because that is the only place the answer exists, and
+    falls back to the advertised source when it does not — the shapes here are
+    private to bleak/bleak-esphome and may change.
+    """
+    backend = getattr(client, "_backend", None)
+    if backend is not None:
+        # ESPHome proxy backends carry the proxy's own name.
+        for attr in ("_source", "source"):
+            if value := getattr(backend, attr, None):
+                return str(value)
+        # BlueZ backends carry the adapter in the object path.
+        if path := getattr(backend, "_device_path", None):
+            return str(path)
+    return _connection_source(ble_device)
+
+
 async def _connect_once(
     ble_device: BLEDevice, name: str, *, pair: bool
 ) -> BleakClient:
@@ -254,17 +282,35 @@ async def establish_connection_with_bond_settle(
                         # unpaired attempt's error in the chain instead of
                         # dropping it on the floor.
                         raise exc from fallback_exc
+                    fallback_via = _connected_path(client, ble_device)
+                    if fallback_via != source:
+                        # Worth its own line: the bond that just failed and the
+                        # link we now hold are not necessarily the same proxy,
+                        # and each ESP32 keeps its own bond table. A cuff that
+                        # terminates the next pairing may be answering state
+                        # left on a proxy nobody is looking at.
+                        _LOGGER.warning(
+                            "Unpaired fallback for %s connected via %s, not the "
+                            "%s that advertised it — on multi-proxy setups the "
+                            "bond state these two hold can differ",
+                            name,
+                            fallback_via,
+                            source,
+                        )
             else:
                 raise
         if pair_this_attempt:
             _LOGGER.debug(
                 "Bonded %s via source=%s before service discovery", name, source
             )
+        connected_via = _connected_path(client, ble_device)
         _LOGGER.debug(
-            "BLE link established to %s via source=%s (is_connected=%s); settling "
-            "up to %.1fs for bonding/encryption before first GATT op",
+            "BLE link established to %s (advertised by source=%s, connected via "
+            "%s, is_connected=%s); settling up to %.1fs for bonding/encryption "
+            "before first GATT op",
             name,
             source,
+            connected_via,
             getattr(client, "is_connected", "?"),
             _POST_CONNECT_BOND_SETTLE_SEC,
         )

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import datetime as dt
 import logging
+import time
 from typing import Any
 
 from bleak import BleakClient
@@ -95,6 +96,11 @@ class OmronBluetoothDeviceData(BluetoothData):
         # three different answers that look identical in the decoded flags.
         self.last_msd: bytes | None = None
         self.last_msd_decoded: bool = False
+        # When the flags above were last refreshed from a decoded MSD. The
+        # gate needs this: a dropped packet or a cuff that stopped advertising
+        # freezes the last values, and a frozen True reopens the connects the
+        # gate exists to stop.
+        self.last_msd_monotonic: float | None = None
         # Additional fields parsed from MSD. Kept as
         # informational attributes; not exposed as sensors today.
         self.streaming_mode: bool = False
@@ -273,6 +279,7 @@ class OmronBluetoothDeviceData(BluetoothData):
 
         # Update instance attributes referenced externally (poll triggers in
         # custom_components/omron/__init__.py).
+        self.last_msd_monotonic = time.monotonic()
         self.invalid_time = fields["invalid_time"]
         self.pairing_mode = fields["pairing_mode"]
         self.forced_transfer = fields["forced_transfer"]

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1226,9 +1226,13 @@ class OmronBluetoothDeviceData(BluetoothData):
                                 ):
                                     _LOGGER.warning(
                                         "Memory session failed for OS-bonding device %s "
-                                        "(model=%s): %s. Ensure OS-level BLE bonding is "
-                                        "complete — remove and re-add the device if this "
-                                        "error persists.",
+                                        "(model=%s): %s. This usually means the link came "
+                                        "up without encryption — these cuffs only serve "
+                                        "the memory characteristics over a bonded link. "
+                                        "Put the cuff back in pairing mode (blinking -P-) "
+                                        "and press Retry Pairing. Removing and re-adding "
+                                        "the integration pairs it once and then hits this "
+                                        "same error on the next poll, so it is not a fix.",
                                         ble_device.address,
                                         self._device_config.model,
                                         last_session_exc,

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -99,6 +99,16 @@ class OmronBluetoothDeviceData(BluetoothData):
         self._seed_measurement_entities()
 
     @property
+    def device_config(self) -> DeviceConfig:
+        """Profile in force for this device.
+
+        Public because the poll gate in ``__init__.py`` has to ask whether
+        this profile can read on a timer at all. Reassigned when the model
+        changes, so read it through here rather than caching it.
+        """
+        return self._device_config
+
+    @property
     def device_model(self) -> str:
         """Return the configured device model."""
         return self._device_model

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -88,6 +88,13 @@ class OmronBluetoothDeviceData(BluetoothData):
         self.forced_transfer: bool = False
         self.invalid_time: bool = False
         self.pairing_mode: bool = False
+        # Raw MSD of the last advertisement carrying one, and whether it
+        # decoded. Diagnostic only: a False flag can mean the cuff did not
+        # raise it, that this MSD format has no bit for it (0x03 has none),
+        # or that the payload failed its length contract and was dropped —
+        # three different answers that look identical in the decoded flags.
+        self.last_msd: bytes | None = None
+        self.last_msd_decoded: bool = False
         # Additional fields parsed from MSD. Kept as
         # informational attributes; not exposed as sensors today.
         self.streaming_mode: bool = False
@@ -253,7 +260,9 @@ class OmronBluetoothDeviceData(BluetoothData):
         if not payload or len(payload) < 2:
             return
 
+        self.last_msd = bytes(payload)
         fields = self._decode_omron_msd_fields(payload)
+        self.last_msd_decoded = fields is not None
         if fields is None:
             _LOGGER.debug(
                 "Ignoring Omron MSD: format=0x%02X len=%d (length contract mismatch)",

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -219,3 +219,76 @@ def test_no_bond_recovery_when_not_pairing_on_connect(
 
     assert remove_device_recorder == []
     assert connect.pair_args == [False]
+
+
+def test_proxy_backend_says_the_bond_could_not_be_removed(
+    monkeypatch, settle_free, caplog
+):
+    """프록시 링크: 본드를 못 지웠다는 사실이 WARNING 으로 드러나야 한다.
+
+    ``_bluez_remove_device`` 는 로컬 BlueZ DBus path 가 필요하다. 프록시에서는
+    제거가 실패하고 재시도가 **같은 키를 다시 내미는** 것이 되는데, 이게 조용히
+    지나가면 로그만 보고 "본드를 지우고 재본딩했는데도 거부당했다" 로 잘못
+    읽힌다.
+    """
+    async def _fail_remove(obj):
+        return False
+
+    monkeypatch.setattr(omron_driver, "_bluez_remove_device", _fail_remove)
+    connect = ConnectRecorder([_stale_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with caplog.at_level("WARNING", logger="custom_components.omron.omron_ble.omron_driver"):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+            )
+        )
+
+    assert any("Could not remove the bond" in r.getMessage() for r in caplog.records)
+    assert connect.pair_args == [True, True]
+
+
+def test_failed_rebond_reports_both_errors_at_warning(
+    monkeypatch, settle_free, remove_device_recorder, caplog
+):
+    """복구 후 재본딩까지 실패하면 두 에러가 모두 WARNING 에 남아야 한다.
+
+    재본딩 오류가 DEBUG 에만 있으면, WARNING 만 수집하는 필드 리포트에서
+    "커프가 키를 버렸다" 와 "본드를 지운 뒤 새 본드를 거부당했다" 가 구분되지
+    않는다 — 이 실험의 판정이 정확히 그 구분에 달려 있다.
+    """
+    connect = ConnectRecorder(
+        [_stale_bond_error(), _refused_bond_error(), None]
+    )
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with caplog.at_level("WARNING", logger="custom_components.omron.omron_ble.omron_driver"):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+            )
+        )
+
+    warnings = " | ".join(r.getMessage() for r in caplog.records)
+    assert "AuthenticationFailed" in warnings, "원래 stale-bond 에러"
+    assert "AuthenticationCanceled" in warnings, "재본딩 거부 에러(retry_exc)"
+    assert "removing it" in warnings, "본드를 실제로 지웠는지 여부"
+    assert connect.pair_args == [True, True, False]
+
+
+@pytest.mark.parametrize(
+    "variant", ("HEM-7188T1-LE", "HEM-7188T1-LEO")
+)
+def test_variants_inherit_the_wld4_bond_policy(variant):
+    """카탈로그 variant 도 canonical 과 같은 본드 정책을 써야 한다.
+
+    필드에서 실제로 선택되는 이름은 canonical 이 아니라 variant 다. variant 가
+    정책을 물려받지 못하면 실험 빌드가 제보자 기기에서 아무것도 바꾸지 않는다.
+    """
+    from custom_components.omron.omron_ble.devices import get_device_config
+
+    config = get_device_config(variant)
+    assert config.bond_policy == BondPolicy.REUSE
+    assert config.unpair_after_session is False
+    assert config.pair_on_connect is True

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -331,3 +331,64 @@ def test_memory_session_warning_does_not_advise_re_adding_the_device():
     assert "remove and re-add the device" not in message
     assert "pairing mode" in message
     assert "Retry Pairing" in message
+
+
+# ── 실제 연결 경로 기록 ────────────────────────────────────────────────────
+
+class _ESPHomeBackend:
+    def __init__(self, source):
+        self._source = source
+
+
+class _BlueZBackend:
+    def __init__(self, device_path):
+        self._device_path = device_path
+
+
+class _PathClient:
+    def __init__(self, backend=None):
+        self.is_connected = True
+        self._backend = backend
+
+
+def test_connected_path_reads_the_proxy_the_link_actually_used():
+    """광고를 본 스캐너와 실제 연결 경로는 다를 수 있다.
+
+    habluetooth 는 connect 시점에 점수로 프록시를 고르므로, 본딩 시도와
+    비암호화 폴백이 서로 다른 ESP32 에 안착할 수 있다. ESP32 는 각자 본드
+    테이블을 들고 있어서 "어디로 붙었나" 가 진단에 필요하다(이슈 #91).
+    """
+    ble_device = FakeBLEDevice()  # details["source"] = "hci0"
+
+    assert (
+        omron_driver._connected_path(_PathClient(_ESPHomeBackend("esp-mini")), ble_device)
+        == "esp-mini"
+    )
+    assert omron_driver._connected_path(
+        _PathClient(_BlueZBackend("/org/bluez/hci0/dev_D5_4F_40_C4_5A_E2")), ble_device
+    ) == "/org/bluez/hci0/dev_D5_4F_40_C4_5A_E2"
+
+
+def test_connected_path_falls_back_to_the_advertised_source():
+    """백엔드 내부 형태는 bleak/bleak-esphome 사유라 바뀔 수 있다.
+
+    못 읽으면 조용히 광고 소스로 떨어져야 한다 — 진단이 예외를 던지면 그건
+    더 이상 진단이 아니다.
+    """
+    ble_device = FakeBLEDevice()
+
+    assert omron_driver._connected_path(_PathClient(None), ble_device) == "hci0"
+    assert omron_driver._connected_path(_PathClient(object()), ble_device) == "hci0"
+
+
+def test_fallback_on_a_different_proxy_is_reported():
+    """폴백이 다른 프록시에 안착하면 그 사실이 로그에 남아야 한다."""
+    import pathlib
+
+    source = pathlib.Path(
+        "custom_components/omron/omron_ble/omron_driver.py"
+    ).read_text()
+
+    assert "Unpaired fallback for %s connected via %s, not the " in source
+    # 연결 성립 로그도 두 값을 구분해서 남긴다.
+    assert "advertised by source=%s, connected via " in source

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -1,22 +1,23 @@
-"""WLD4.0 본드 정책(REUSE) 및 stale-bond 복구 회귀 테스트.
+"""WLD4.0 본드 정책 및 stale-bond 복구 회귀 테스트.
 
-배경(이슈 #92, HEM-7188T1-LEO):
+배경(이슈 #92, HEM-7188T1-LEO/-LE):
 
-PER_SESSION 은 "본드를 버려도 다음 연결이 다시 본딩하니까 안전하다"는 전제
-위에 서 있는데, 이 커프는 페어링 모드를 벗어나면 새 본드를 AuthenticationCanceled
-/ error 102 로 거부한다. 전제가 깨지므로 본드를 버리는 순간 다음 연결은 확정
-실패다.
+PER_SESSION 은 "본드를 버려도 다음 연결이 다시 본딩하니까 안전하다"는 전제 위에
+서 있는데, 이 커프는 페어링 모드를 벗어나면 새 본드를 AuthenticationCanceled /
+error 102 로 거부한다. 전제가 깨진다.
 
-WLD4.0 프로필들이 PER_SESSION 이었던 건 #109 당시 WLD3.0 으로 분류돼 있었기
-때문이고, #112 가 WLD4.0 으로 정정하면서 본드 정책은 따라오지 않았다.
+REUSE 로 바꿔 실기기에서 확인한 결과는 **음성**이었다(2.7.8-beta.1): 통합은
+본드를 유지했는데도 다음 예약 폴이 다시 본딩을 시도했고 또 거부당했다. 즉 호스트
+쪽 본드를 들고 있어도 다음 연결로 이어지지 않는다. 그래서 정책은 PER_SESSION
+으로 되돌리고, 진짜 수정은 폴 트리거 쪽으로 옮겼다 —
+``poll_requires_pairing_window`` 참고.
 
-REUSE 로 되돌리는 것만으로는 실험이 성립하지 않는다: 커프가 자기 LTK 를 정말
-버린다면 저장된 키로 암호화가 거부되는데, stale-bond 복구는
-``_pair_os_bonding()`` 안에만 있고 ``pair()`` 는 ``pair_on_connect`` 면 조기
-반환하므로 그 경로에 도달하지 못한다. 그래서 복구를 connect 경로에도 연결한다.
+stale-bond 복구는 남긴다. 이 기기의 실패 모드(102)에서는 발동하지 않지만,
+발동해야 하는 경우(AuthenticationFailed)에 여전히 도달 불가였던 경로를 메운다.
 """
 import asyncio
 import pathlib
+from contextlib import asynccontextmanager
 
 import pytest
 
@@ -24,7 +25,11 @@ from custom_components.omron.omron_ble import omron_driver
 from custom_components.omron.omron_ble.device_catalog import (
     CANONICAL_DEVICE_PROFILES,
 )
-from custom_components.omron.omron_ble.devices import BondPolicy, ConnectType
+from custom_components.omron.omron_ble.devices import (
+    BondPolicy,
+    ConnectType,
+    get_device_config,
+)
 
 
 # ── 카탈로그 정책 ──────────────────────────────────────────────────────────
@@ -33,19 +38,21 @@ WLD4_PROFILES = ("HEM-7188T1", "HEM-7191T1", "HEM-7196T1")
 
 
 @pytest.mark.parametrize("profile", WLD4_PROFILES)
-def test_wld4_keeps_the_bond_but_still_brings_security_up_first(profile):
-    """WLD4.0 은 본드를 유지하되 pair_on_connect 는 그대로 True 여야 한다.
+def test_wld4_drops_the_bond_and_needs_a_pairing_window(profile):
+    """REUSE 실험이 음성으로 끝났으므로 WLD4.0 은 PER_SESSION 이다.
 
-    본드만 유지하고 pair_on_connect 를 잃으면 2.5.23 시절 구성으로 돌아간다 —
-    연결 후 GATT 를 건드리는 동안 보안이 올라와 있지 않아 커프가 링크를 끊던
-    바로 그 조합(#108). 두 조건이 동시에 성립해야 한다.
+    그리고 본드를 버린다는 것은 곧 "다음 읽기에 커프가 새 본드를 내줘야 한다"는
+    뜻이므로, 타이머만으로 도는 폴은 성립하지 않는다. 두 사실이 갈라지면
+    설명 불가능한 프로필이 되므로 같은 조건에서 유도한다.
     """
     config = CANONICAL_DEVICE_PROFILES[profile]
 
     assert config.connect_type == ConnectType.WLD4_0
-    assert config.bond_policy == BondPolicy.REUSE
-    assert config.unpair_after_session is False, "본드가 세션 종료 시 삭제되면 안 된다"
-    assert config.pair_on_connect is True, "보안은 GATT 디스커버리 전에 올라와야 한다"
+    assert config.bond_policy == BondPolicy.PER_SESSION
+    assert config.unpair_after_session is True
+    assert config.poll_requires_pairing_window is True
+    # 세션 시작 시 보안은 여전히 GATT 디스커버리보다 먼저 올라와야 한다(#108).
+    assert config.pair_on_connect is True
 
 
 def test_wld3_bond_policy_is_untouched():
@@ -59,6 +66,33 @@ def test_wld3_bond_policy_is_untouched():
     for name, cfg in wld3:
         assert cfg.bond_policy == BondPolicy.PER_SESSION, name
         assert cfg.unpair_after_session is True, name
+
+
+def test_reuse_profiles_never_require_a_pairing_window():
+    """본드를 유지하는 프로필은 타이머 폴이 계속 돌아야 한다.
+
+    게이트가 REUSE 프로필까지 번지면 정상 동작하는 기기들이 버튼을 눌러야만
+    읽히는 상태가 된다 — 이 변경에서 가장 비싼 회귀다.
+    """
+    reuse = [
+        (name, cfg)
+        for name, cfg in CANONICAL_DEVICE_PROFILES.items()
+        if cfg.bond_policy == BondPolicy.REUSE
+    ]
+    assert reuse
+    for name, cfg in reuse:
+        assert cfg.poll_requires_pairing_window is False, name
+
+
+@pytest.mark.parametrize("variant", ("HEM-7188T1-LE", "HEM-7188T1-LEO"))
+def test_variants_inherit_the_wld4_policy(variant):
+    """카탈로그 variant 도 canonical 과 같은 정책을 써야 한다.
+
+    필드에서 실제로 선택되는 이름은 canonical 이 아니라 variant 다.
+    """
+    config = get_device_config(variant)
+    assert config.bond_policy == BondPolicy.PER_SESSION
+    assert config.poll_requires_pairing_window is True
 
 
 # ── stale-bond 복구 ────────────────────────────────────────────────────────
@@ -278,21 +312,6 @@ def test_failed_rebond_reports_both_errors_at_warning(
     assert connect.pair_args == [True, True, False]
 
 
-@pytest.mark.parametrize(
-    "variant", ("HEM-7188T1-LE", "HEM-7188T1-LEO")
-)
-def test_variants_inherit_the_wld4_bond_policy(variant):
-    """카탈로그 variant 도 canonical 과 같은 본드 정책을 써야 한다.
-
-    필드에서 실제로 선택되는 이름은 canonical 이 아니라 variant 다. variant 가
-    정책을 물려받지 못하면 실험 빌드가 제보자 기기에서 아무것도 바꾸지 않는다.
-    """
-    from custom_components.omron.omron_ble.devices import get_device_config
-
-    config = get_device_config(variant)
-    assert config.bond_policy == BondPolicy.REUSE
-    assert config.unpair_after_session is False
-    assert config.pair_on_connect is True
 
 
 def test_memory_session_warning_does_not_advise_re_adding_the_device():

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -1,0 +1,221 @@
+"""WLD4.0 본드 정책(REUSE) 및 stale-bond 복구 회귀 테스트.
+
+배경(이슈 #92, HEM-7188T1-LEO):
+
+PER_SESSION 은 "본드를 버려도 다음 연결이 다시 본딩하니까 안전하다"는 전제
+위에 서 있는데, 이 커프는 페어링 모드를 벗어나면 새 본드를 AuthenticationCanceled
+/ error 102 로 거부한다. 전제가 깨지므로 본드를 버리는 순간 다음 연결은 확정
+실패다.
+
+WLD4.0 프로필들이 PER_SESSION 이었던 건 #109 당시 WLD3.0 으로 분류돼 있었기
+때문이고, #112 가 WLD4.0 으로 정정하면서 본드 정책은 따라오지 않았다.
+
+REUSE 로 되돌리는 것만으로는 실험이 성립하지 않는다: 커프가 자기 LTK 를 정말
+버린다면 저장된 키로 암호화가 거부되는데, stale-bond 복구는
+``_pair_os_bonding()`` 안에만 있고 ``pair()`` 는 ``pair_on_connect`` 면 조기
+반환하므로 그 경로에 도달하지 못한다. 그래서 복구를 connect 경로에도 연결한다.
+"""
+import asyncio
+
+import pytest
+
+from custom_components.omron.omron_ble import omron_driver
+from custom_components.omron.omron_ble.device_catalog import (
+    CANONICAL_DEVICE_PROFILES,
+)
+from custom_components.omron.omron_ble.devices import BondPolicy, ConnectType
+
+
+# ── 카탈로그 정책 ──────────────────────────────────────────────────────────
+
+WLD4_PROFILES = ("HEM-7188T1", "HEM-7191T1", "HEM-7196T1")
+
+
+@pytest.mark.parametrize("profile", WLD4_PROFILES)
+def test_wld4_keeps_the_bond_but_still_brings_security_up_first(profile):
+    """WLD4.0 은 본드를 유지하되 pair_on_connect 는 그대로 True 여야 한다.
+
+    본드만 유지하고 pair_on_connect 를 잃으면 2.5.23 시절 구성으로 돌아간다 —
+    연결 후 GATT 를 건드리는 동안 보안이 올라와 있지 않아 커프가 링크를 끊던
+    바로 그 조합(#108). 두 조건이 동시에 성립해야 한다.
+    """
+    config = CANONICAL_DEVICE_PROFILES[profile]
+
+    assert config.connect_type == ConnectType.WLD4_0
+    assert config.bond_policy == BondPolicy.REUSE
+    assert config.unpair_after_session is False, "본드가 세션 종료 시 삭제되면 안 된다"
+    assert config.pair_on_connect is True, "보안은 GATT 디스커버리 전에 올라와야 한다"
+
+
+def test_wld3_bond_policy_is_untouched():
+    """WLD3.0 패밀리는 검증된 PER_SESSION 동작을 그대로 유지한다."""
+    wld3 = [
+        (name, cfg)
+        for name, cfg in CANONICAL_DEVICE_PROFILES.items()
+        if cfg.connect_type == ConnectType.WLD3_0
+    ]
+    assert wld3, "WLD3.0 프로필이 하나도 없다면 이 가드는 의미가 없다"
+    for name, cfg in wld3:
+        assert cfg.bond_policy == BondPolicy.PER_SESSION, name
+        assert cfg.unpair_after_session is True, name
+
+
+# ── stale-bond 복구 ────────────────────────────────────────────────────────
+
+class FakeBLEDevice:
+    def __init__(self):
+        self.address = "D5:4F:40:C4:5A:E2"
+        self.details = {
+            "path": "/org/bluez/hci0/dev_D5_4F_40_C4_5A_E2",
+            "props": {},
+            "source": "hci0",
+        }
+
+
+class FakeClient:
+    def __init__(self):
+        self.is_connected = True
+
+
+class ConnectRecorder:
+    """``_connect_once`` 대역 — pair 인자 시퀀스를 기록한다."""
+
+    def __init__(self, errors):
+        self.errors = list(errors)
+        self.pair_args: list[bool] = []
+
+    async def __call__(self, ble_device, name, *, pair):
+        self.pair_args.append(pair)
+        if self.errors:
+            exc = self.errors.pop(0)
+            if exc is not None:
+                raise exc
+        return FakeClient()
+
+
+@pytest.fixture
+def settle_free(monkeypatch):
+    """post-connect settle 의 실제 대기/GATT 갱신을 제거한다."""
+    async def _noop_sleep(delay, *args, **kwargs):
+        return None
+
+    async def _noop_refresh(client):
+        return None
+
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+    monkeypatch.setattr(omron_driver, "_bleak_refresh_services", _noop_refresh)
+
+
+@pytest.fixture
+def remove_device_recorder(monkeypatch):
+    calls: list[str] = []
+
+    async def _fake_remove(obj):
+        calls.append(getattr(obj, "address", "?"))
+        return True
+
+    monkeypatch.setattr(omron_driver, "_bluez_remove_device", _fake_remove)
+    return calls
+
+
+class FakeBleakError(Exception):
+    """conftest 가 bleak 을 MagicMock 으로 대체하므로 실제 예외 클래스가 없다.
+
+    드라이버가 ``except BleakError`` 로 잡을 수 있도록 진짜 예외 클래스를
+    심어 준다.
+    """
+
+
+@pytest.fixture(autouse=True)
+def real_bleak_error(monkeypatch):
+    monkeypatch.setattr(omron_driver, "BleakError", FakeBleakError)
+
+
+def _stale_bond_error():
+    return FakeBleakError(
+        "[org.bluez.Error.AuthenticationFailed] Authentication Failed"
+    )
+
+
+def _refused_bond_error():
+    return FakeBleakError(
+        "[org.bluez.Error.AuthenticationCanceled] Authentication Canceled"
+    )
+
+
+def test_stale_bond_is_cleared_and_rebonded_not_downgraded(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """AuthenticationFailed 면 본드를 지우고 pair=True 로 다시 시도한다.
+
+    바로 pair=False 로 내려가면 비암호화 링크가 되고, 그 위에서 토큰 언락과
+    메모리 세션이 실패한다 — 이슈 #92 에서 보고된 그 경로다.
+    """
+    connect = ConnectRecorder([_stale_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    client = asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert isinstance(client, FakeClient)
+    assert remove_device_recorder == ["D5:4F:40:C4:5A:E2"], "본드를 지워야 한다"
+    # 두 번째 시도도 pair=True — 비암호화 폴백으로 내려가지 않았다.
+    assert connect.pair_args == [True, True]
+
+
+def test_refused_bond_still_falls_back_to_unpaired_connect(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """stale-bond 가 아닌 거부(error 102 등)는 기존 pair=False 폴백 그대로."""
+    connect = ConnectRecorder([_refused_bond_error(), None])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert remove_device_recorder == [], "멀쩡한 본드를 지우면 안 된다"
+    assert connect.pair_args == [True, False]
+
+
+def test_stale_bond_recovery_runs_at_most_once(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """복구 후에도 같은 인증 실패가 나면 본드 문제가 아니다 — 다시 지우지 않는다."""
+    connect = ConnectRecorder(
+        [_stale_bond_error(), _stale_bond_error(), None]
+    )
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    asyncio.run(
+        omron_driver.establish_connection_with_bond_settle(
+            FakeBLEDevice(), "cuff", pair_on_connect=True, model="HEM-7188T1"
+        )
+    )
+
+    assert len(remove_device_recorder) == 1
+    # 지우고 재본딩(True) → 또 실패 → 비암호화 폴백(False).
+    assert connect.pair_args == [True, True, False]
+
+
+def test_no_bond_recovery_when_not_pairing_on_connect(
+    monkeypatch, settle_free, remove_device_recorder
+):
+    """pair_on_connect=False 프로필에서는 이 경로가 아예 열리지 않는다."""
+    connect = ConnectRecorder([_stale_bond_error()])
+    monkeypatch.setattr(omron_driver, "_connect_once", connect)
+
+    with pytest.raises(Exception):
+        asyncio.run(
+            omron_driver.establish_connection_with_bond_settle(
+                FakeBLEDevice(), "cuff", pair_on_connect=False, model="HEM-7142T2"
+            )
+        )
+
+    assert remove_device_recorder == []
+    assert connect.pair_args == [False]

--- a/tests/test_bond_policy_recovery.py
+++ b/tests/test_bond_policy_recovery.py
@@ -16,6 +16,7 @@ REUSE 로 되돌리는 것만으로는 실험이 성립하지 않는다: 커프�
 반환하므로 그 경로에 도달하지 못한다. 그래서 복구를 connect 경로에도 연결한다.
 """
 import asyncio
+import pathlib
 
 import pytest
 
@@ -292,3 +293,22 @@ def test_variants_inherit_the_wld4_bond_policy(variant):
     assert config.bond_policy == BondPolicy.REUSE
     assert config.unpair_after_session is False
     assert config.pair_on_connect is True
+
+
+def test_memory_session_warning_does_not_advise_re_adding_the_device():
+    """실패 안내가 "제거 후 재추가"로 유도하면 안 된다.
+
+    재추가는 커프가 페어링 모드일 때 한 번 성공하고 다음 폴에서 같은 에러로
+    돌아온다(discussions#119, 2.7.7 로그). 이슈 #125 의 "clear Bluetooth cache"
+    와 같은 오도 패턴이라, 실제로 통하는 동작(페어링 모드 + Retry Pairing)을
+    가리켜야 한다.
+    """
+    source = pathlib.Path(
+        "custom_components/omron/omron_ble/parser.py"
+    ).read_text()
+    start = source.index("Memory session failed for OS-bonding device")
+    message = source[start : start + 800]
+
+    assert "remove and re-add the device" not in message
+    assert "pairing mode" in message
+    assert "Retry Pairing" in message

--- a/tests/test_pairing_session_handoff.py
+++ b/tests/test_pairing_session_handoff.py
@@ -1,9 +1,13 @@
 """Pairing-session handoff regression tests (discussions#119).
 
-WLD3.0 cuffs (HEM-7380T1 / 7188T1 and friends) serve data during the pairing
+WLD3.0 cuffs (HEM-7380T1 and friends) serve data during the pairing
 session and reject later connections — see the _WLD3_BOND_POLICY comment in
-device_catalog.py. Closing the link after pairing and letting the follow-up
-poll reconnect is therefore what makes that poll time out.
+device_catalog.py. HEM-7188T1 shows the same handoff symptom but is WLD4.0
+and no longer shares that bond policy (see _WLD4_BOND_POLICY); the handoff
+below is what it has in common with them, not the bond lifetime.
+
+Closing the link after pairing and letting the follow-up poll reconnect is
+therefore what makes that poll time out.
 
 The config flow already parked its session in _setup_sessions so the first
 poll reuses the same link, but the advertisement-triggered auto-pairing

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -1,0 +1,104 @@
+"""예약 폴을 커프의 신호에 묶는 게이트 회귀 테스트.
+
+실기기 결과(이슈 #92, HEM-7188T1-LEO on 2.7.8-beta.1): 본드를 유지해도 다음
+연결은 다시 본딩을 요구받고 거부당한다. 즉 읽기에는 본드가 필요하고 본드에는
+페어링 모드가 필요하므로, 스캔 간격이 지났다는 이유만으로 도는 폴은 시작 전에
+이미 실패가 확정돼 있다 — connect 와 세션 락을 10초쯤 태우고 경고를 남긴 뒤.
+
+그래서 커프가 스스로 말할 때만 폴한다:
+  * ``pairing_mode``   — 지금이면 본드를 만들 수 있다
+  * ``forced_transfer`` — 측정값이 대기 중이다
+
+게이트가 REUSE 프로필까지 번지면 멀쩡한 기기가 버튼을 눌러야만 읽히게 되므로,
+그 경계도 함께 고정한다.
+"""
+import pytest
+
+from custom_components.omron.omron_ble.device_catalog import (
+    CANONICAL_DEVICE_PROFILES,
+)
+
+
+def _should_poll(config, *, pairing_mode, forced_transfer, handoff_parked):
+    """__init__.py `_async_poll_data` 게이트 조건의 거울.
+
+    조건식을 테스트에 복제하는 것은 보통 피하지만, 여기서는 HA 런타임 전체를
+    띄우지 않고 경계를 고정하기 위한 의도적 선택이다. 실제 게이트가 바뀌면
+    아래 test_gate_condition_matches_the_source 가 어긋난 것을 잡는다.
+    """
+    if not config.poll_requires_pairing_window:
+        return True
+    if handoff_parked:
+        return True
+    return pairing_mode or forced_transfer
+
+
+PER_SESSION_PROFILE = CANONICAL_DEVICE_PROFILES["HEM-7188T1"]
+REUSE_PROFILE = CANONICAL_DEVICE_PROFILES["HEM-7142T2"]
+
+
+@pytest.mark.parametrize(
+    "pairing_mode,forced_transfer,expected",
+    [
+        (False, False, False),  # 타이머만으로 도는 폴 — 실패가 확정된 경우
+        (True, False, True),    # 페어링 모드: 본드를 만들 수 있다
+        (False, True, True),    # 측정값 대기: 가져올 것이 있다
+        (True, True, True),
+    ],
+)
+def test_per_session_profile_polls_only_when_the_cuff_signals(
+    pairing_mode, forced_transfer, expected
+):
+    assert (
+        _should_poll(
+            PER_SESSION_PROFILE,
+            pairing_mode=pairing_mode,
+            forced_transfer=forced_transfer,
+            handoff_parked=False,
+        )
+        is expected
+    )
+
+
+def test_parked_pairing_session_is_never_skipped():
+    """주차된 링크는 이미 열려 있고 본딩돼 있다 — 건너뛰면 그대로 방치된다.
+
+    페어링 직후 폴이 정확히 이 경로다. 게이트가 여기서 걸리면 페어링은 됐는데
+    첫 측정값이 안 들어오는, 이 이슈의 원래 증상으로 되돌아간다.
+    """
+    assert _should_poll(
+        PER_SESSION_PROFILE,
+        pairing_mode=False,
+        forced_transfer=False,
+        handoff_parked=True,
+    )
+
+
+@pytest.mark.parametrize(
+    "pairing_mode,forced_transfer", [(False, False), (True, False), (False, True)]
+)
+def test_reuse_profile_keeps_polling_on_the_timer(pairing_mode, forced_transfer):
+    """본드를 유지하는 기기는 종전대로 스캔 간격에 읽는다."""
+    assert _should_poll(
+        REUSE_PROFILE,
+        pairing_mode=pairing_mode,
+        forced_transfer=forced_transfer,
+        handoff_parked=False,
+    )
+
+
+def test_gate_condition_matches_the_source():
+    """위 거울 함수가 실제 게이트와 같은 신호를 보는지 확인한다.
+
+    조건식을 복제한 대가로, 원본이 바뀌었는데 테스트만 옛 규칙을 지키고 있는
+    상황을 막는다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    start = source.index("poll_requires_pairing_window")
+    gate = source[start - 200 : start + 400]
+
+    assert "not device_data.pairing_mode" in gate
+    assert "not device_data.forced_transfer" in gate
+    assert "not has_handoff_session(hass, address)" in gate

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -21,7 +21,7 @@ from custom_components.omron.ble_session import (
     POLL_REQUEST_TTL_SECONDS,
     request_poll,
     should_skip_scheduled_poll,
-    take_poll_request,
+    peek_poll_request,
 )
 from custom_components.omron.omron_ble.device_catalog import (
     CANONICAL_DEVICE_PROFILES,
@@ -124,16 +124,16 @@ def test_request_is_returned_until_taken():
 
     # peek 은 소비하지 않는다 — connect 를 실제로 시도하기 전에 사라지면
     # 세션 락에 막힌 버튼 누름이 통째로 없어진다.
-    assert take_poll_request(entry_data, now=1000.0) == "button press"
-    assert take_poll_request(entry_data, now=1001.0) == "button press"
+    assert peek_poll_request(entry_data, now=1000.0) == "button press"
+    assert peek_poll_request(entry_data, now=1001.0) == "button press"
 
 
 def test_request_expires_so_it_cannot_open_an_unrelated_poll_later():
     entry_data: dict = {}
     request_poll(entry_data, "forced-transfer advertisement", now=1000.0)
 
-    assert take_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS - 1)
-    assert take_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS + 1) is None
+    assert peek_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS - 1)
+    assert peek_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS + 1) is None
     assert "poll_request" not in entry_data
 
 
@@ -228,3 +228,83 @@ def test_parser_retains_the_raw_msd_its_freshness_and_whether_it_decoded():
     assert source.index("self.last_msd = bytes(payload)") < source.index(
         "fields = self._decode_omron_msd_fields(payload)"
     )
+
+
+def test_observer_listens_to_non_connectable_advertisements_too():
+    """진단 관찰자는 connectable=False 로 등록돼야 한다.
+
+    처리 코디네이터는 ``connectable=True`` 로 등록돼 있어서 HA 가 연결 가능한
+    광고만 넘겨준다. 커프가 "측정 대기" 를 non-connectable 광고로 알린다면
+    ``process_service_info`` 에는 **아예 도달하지 않는다** — 그 안의 connectable
+    체크 때문이 아니라, 우리 코드가 돌기 전에 한 단계 위에서 걸러지기 때문이다.
+
+    이슈 #92 는 지금 "이 하드웨어가 못 한다" 와 "우리가 그 채널을 안 듣고 있다"
+    를 구분하지 못한다. 관찰자가 이걸 가른다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    # 처리 코디네이터는 연결 가능한 광고만 받는다(연결 라우팅 때문에 유지).
+    assert "connectable=True," in source
+    # 관찰자는 전부 받는다.
+    assert "BluetoothCallbackMatcher(address=address, connectable=False)" in source
+    # 그리고 원문 MSD 와 connectable 을 같이 찍는다.
+    assert "Observed advertisement from %s: connectable=%s" in source
+
+
+def test_observer_never_touches_device_state():
+    """진단이 동작을 바꾸면 그건 더 이상 진단이 아니다."""
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("def _register_advertisement_observer") :]
+    body = body[: body.index("\ndef _merge_poll_sensor_update")]
+
+    for forbidden in (
+        "data.update(",
+        "request_poll(",
+        "async_request_refresh",
+        "async_retry_pairing",
+        "session_lock",
+    ):
+        assert forbidden not in body, f"관찰자가 {forbidden} 를 건드린다"
+
+
+def test_forced_transfer_is_latched_before_the_lock_and_cooldown_returns():
+    """락/쿨다운에 걸린 광고도 요청으로 남아야 한다.
+
+    트리거는 세션 락과 60초 쿨다운에서 그냥 return 한다. 래치가 그 뒤에 있으면
+    이런 순서로 측정값이 통째로 유실된다:
+
+      1. 다른 BLE 세션이 락을 잡고 있다 (최대 180초)
+      2. 측정 후 forced_transfer 광고가 온다
+      3. 트리거가 return 하고 래치도 안 한다
+      4. 세션이 끝난다
+      5. 다음 예약 폴은 기본 300초 뒤 — 플래그는 이미 60초 신선도를 넘겼다
+      6. 게이트가 skip 한다. 측정값이 커프에 남는다
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    latch = source.index('request_poll(entry_data, "forced-transfer advertisement")')
+    lock_return = source.index("if session_lock.locked():")
+    cooldown_return = source.index("if now - last_attempt < POLL_COOLDOWN_SECONDS:")
+
+    assert latch < lock_return, "락에 막힌 광고가 래치되지 않는다"
+    assert latch < cooldown_return, "쿨다운에 걸린 광고가 래치되지 않는다"
+    # 래치 지점은 하나여야 한다 — 여러 곳이면 어느 것이 유효한지 흐려진다.
+    assert source.count("request_poll(entry_data") == 1
+
+
+def test_entering_the_waiting_state_is_visible_at_info():
+    """DEBUG 만으로는 기본 로그에서 센서가 그냥 멈춘 것처럼 보인다."""
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    assert 'entry_data.get("poll_gate_waiting")' in source
+    assert "_LOGGER.info" in source
+    # 유휴 상태가 이어지는 동안 스캔 간격마다 INFO 를 반복하지는 않는다.
+    assert "_LOGGER.debug\n                    if entry_data.get" in source

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -19,13 +19,17 @@ from custom_components.omron.omron_ble.device_catalog import (
 )
 
 
-def _should_poll(config, *, pairing_mode, forced_transfer, handoff_parked):
+def _should_poll(
+    config, *, pairing_mode, forced_transfer, handoff_parked, user_requested=False
+):
     """__init__.py `_async_poll_data` 게이트 조건의 거울.
 
     조건식을 테스트에 복제하는 것은 보통 피하지만, 여기서는 HA 런타임 전체를
     띄우지 않고 경계를 고정하기 위한 의도적 선택이다. 실제 게이트가 바뀌면
     아래 test_gate_condition_matches_the_source 가 어긋난 것을 잡는다.
     """
+    if user_requested:
+        return True
     if not config.poll_requires_pairing_window:
         return True
     if handoff_parked:
@@ -99,6 +103,39 @@ def test_gate_condition_matches_the_source():
     start = source.index("poll_requires_pairing_window")
     gate = source[start - 200 : start + 400]
 
+    assert "not user_requested" in gate
     assert "not device_data.pairing_mode" in gate
     assert "not device_data.forced_transfer" in gate
     assert "not has_handoff_session(hass, address)" in gate
+
+
+def test_user_pressing_refresh_is_never_skipped():
+    """사람이 누른 요청은 시계가 아니다 — 게이트를 통과해야 한다.
+
+    조용히 건너뛰면 버튼이 아무 일도 안 하는 것처럼 보인다. 실패하더라도
+    사용자는 실제 에러를 봐야 한다.
+    """
+    assert _should_poll(
+        PER_SESSION_PROFILE,
+        pairing_mode=False,
+        forced_transfer=False,
+        handoff_parked=False,
+        user_requested=True,
+    )
+
+
+def test_refresh_button_arms_the_flag_and_the_poll_consumes_it():
+    """플래그는 일회성이어야 한다.
+
+    소비되지 않고 남으면, 다음 예약 폴이 아무도 요청하지 않았는데 게이트를
+    통과한다 — 이 변경이 없애려던 바로 그 폴이다.
+    """
+    import pathlib
+
+    button = pathlib.Path("custom_components/omron/button.py").read_text()
+    init = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    assert '["user_requested_poll"] = True' in button
+    # pop 이어야 한다: get 이면 플래그가 남아 다음 폴까지 열어 준다.
+    assert 'entry_data.pop("user_requested_poll", False)' in init
+    assert 'entry_data.get("user_requested_poll"' not in init

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -179,3 +179,36 @@ def test_advert_flags_log_is_transition_only():
 
     assert 'entry_data.get("last_advert_flags") != flags' in source
     assert 'entry_data["last_advert_flags"] = flags' in source
+
+
+def test_advert_log_carries_the_raw_msd_and_format():
+    """디코드된 플래그만으로는 네 경우가 구분되지 않는다.
+
+    ``forced_transfer=False`` 는 다음을 전부 뜻할 수 있다:
+      * 커프가 안 올렸다                     ← 유일한 하드웨어 한계
+      * MSD 포맷 0x03 이라 비트가 없다        ← 우리가 다른 신호를 찾아야 함
+      * length contract 불일치로 통째 무시    ← 포맷 지원을 넓히면 됨
+
+    앞의 둘만 놓고 "하드웨어가 못 한다"고 결론내면 고칠 수 있는 문제를 접는
+    것이므로, 포맷 바이트와 원문이 같은 줄에 있어야 한다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    assert "msd=%s (format=%s decoded=%s)" in source
+    # 플래그가 안 변해도 MSD 가 변하면 보여야 한다 — 인식 못 한 측정이 그 모습이다.
+    assert "msd_hex,\n    )" in source or "        msd_hex,\n    )" in source
+
+
+def test_parser_retains_the_raw_msd_and_whether_it_decoded():
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/omron_ble/parser.py").read_text()
+
+    assert "self.last_msd = bytes(payload)" in source
+    assert "self.last_msd_decoded = fields is not None" in source
+    # 원문은 디코드 시도 전에 잡아야 한다: 실패한 페이로드가 정확히 필요한 것이다.
+    assert source.index("self.last_msd = bytes(payload)") < source.index(
+        "fields = self._decode_omron_msd_fields(payload)"
+    )

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -1,159 +1,208 @@
 """예약 폴을 커프의 신호에 묶는 게이트 회귀 테스트.
 
 실기기 결과(이슈 #92, HEM-7188T1-LEO on 2.7.8-beta.1): 본드를 유지해도 다음
-연결은 다시 본딩을 요구받고 거부당한다. 즉 읽기에는 본드가 필요하고 본드에는
+연결은 다시 본딩을 요구받고 거부당한다. 읽기에는 본드가 필요하고 본드에는
 페어링 모드가 필요하므로, 스캔 간격이 지났다는 이유만으로 도는 폴은 시작 전에
-이미 실패가 확정돼 있다 — connect 와 세션 락을 10초쯤 태우고 경고를 남긴 뒤.
+실패가 확정돼 있다 — connect 와 세션 락을 태우고 경고를 남긴 뒤.
 
-그래서 커프가 스스로 말할 때만 폴한다:
-  * ``pairing_mode``   — 지금이면 본드를 만들 수 있다
-  * ``forced_transfer`` — 측정값이 대기 중이다
+게이트가 삼키면 안 되는 경로가 세 가지 있고, 전부 여기서 고정한다:
+  * 광고가 요청한 폴 (``async_request_refresh`` 는 ~10초 디바운스라, 폴이
+    실행될 때쯤 커프가 비트를 내렸을 수 있다)
+  * 사람이 누른 Refresh (세션 락에 막혀도 요청이 사라지면 안 된다)
+  * 주차된 페어링 세션 (이미 열려 있고 본딩된 링크)
 
-게이트가 REUSE 프로필까지 번지면 멀쩡한 기기가 버튼을 눌러야만 읽히게 되므로,
-그 경계도 함께 고정한다.
+그리고 반대 방향 — 오래된 True 가 얼어붙어 실패 연결을 다시 여는 것 — 도
+막는다.
 """
 import pytest
 
+from custom_components.omron.ble_session import (
+    ADVERT_FLAG_FRESHNESS_SECONDS,
+    POLL_REQUEST_TTL_SECONDS,
+    request_poll,
+    should_skip_scheduled_poll,
+    take_poll_request,
+)
 from custom_components.omron.omron_ble.device_catalog import (
     CANONICAL_DEVICE_PROFILES,
 )
+from custom_components.omron.omron_ble.devices import BondPolicy, ConnectType
+
+GATED = CANONICAL_DEVICE_PROFILES["HEM-7188T1"]       # WLD4.0, PER_SESSION
+UNGATED_REUSE = CANONICAL_DEVICE_PROFILES["HEM-7142T2"]   # 본드 유지
+UNGATED_WLD3 = CANONICAL_DEVICE_PROFILES["HEM-7380T1"]    # PER_SESSION 이지만 미검증
 
 
-def _should_poll(
-    config, *, pairing_mode, forced_transfer, handoff_parked, user_requested=False
-):
-    """__init__.py `_async_poll_data` 게이트 조건의 거울.
+def _skip(config, **kw):
+    """게이트를 실제로 호출한다 — 조건식을 테스트에 복제하지 않는다."""
+    args = dict(
+        pairing_mode=False,
+        forced_transfer=False,
+        flags_age=1.0,
+        poll_request=None,
+        handoff_parked=False,
+    )
+    args.update(kw)
+    return should_skip_scheduled_poll(config, **args)
 
-    조건식을 테스트에 복제하는 것은 보통 피하지만, 여기서는 HA 런타임 전체를
-    띄우지 않고 경계를 고정하기 위한 의도적 선택이다. 실제 게이트가 바뀌면
-    아래 test_gate_condition_matches_the_source 가 어긋난 것을 잡는다.
+
+# ── 기본 동작 ──────────────────────────────────────────────────────────────
+
+def test_timer_only_poll_is_skipped():
+    """아무 신호도 없으면 건너뛴다 — 실패가 확정된 연결이다."""
+    assert _skip(GATED) is True
+
+
+@pytest.mark.parametrize("flag", ["pairing_mode", "forced_transfer"])
+def test_cuff_signalling_lets_the_poll_through(flag):
+    assert _skip(GATED, **{flag: True}) is False
+
+
+def test_reuse_profile_is_never_gated():
+    """본드를 유지하는 기기는 종전대로 스캔 간격에 읽는다.
+
+    여기 번지면 멀쩡히 동작하던 기기가 버튼을 눌러야만 읽히게 된다 — 이
+    변경에서 가장 비싼 회귀다.
     """
-    if user_requested:
-        return True
-    if not config.poll_requires_pairing_window:
-        return True
-    if handoff_parked:
-        return True
-    return pairing_mode or forced_transfer
+    assert _skip(UNGATED_REUSE) is False
 
 
-PER_SESSION_PROFILE = CANONICAL_DEVICE_PROFILES["HEM-7188T1"]
-REUSE_PROFILE = CANONICAL_DEVICE_PROFILES["HEM-7142T2"]
-
+# ── 삼키면 안 되는 세 경로 ─────────────────────────────────────────────────
 
 @pytest.mark.parametrize(
-    "pairing_mode,forced_transfer,expected",
-    [
-        (False, False, False),  # 타이머만으로 도는 폴 — 실패가 확정된 경우
-        (True, False, True),    # 페어링 모드: 본드를 만들 수 있다
-        (False, True, True),    # 측정값 대기: 가져올 것이 있다
-        (True, True, True),
-    ],
+    "source", ["forced-transfer advertisement", "button press"]
 )
-def test_per_session_profile_polls_only_when_the_cuff_signals(
-    pairing_mode, forced_transfer, expected
-):
-    assert (
-        _should_poll(
-            PER_SESSION_PROFILE,
-            pairing_mode=pairing_mode,
-            forced_transfer=forced_transfer,
-            handoff_parked=False,
-        )
-        is expected
-    )
+def test_a_requested_poll_survives_the_flag_going_down(source):
+    """요청이 래치되지 않으면 디바운스 구간에서 통째로 사라진다.
+
+    광고 경로는 connect 를 직접 열지 않고 ``async_request_refresh()`` 만
+    부르는데 이 호출은 ~10초 디바운스다. 그 사이 커프가 비트를 내리면 폴은
+    플래그가 False 인 상태로 실행되고, 래치가 없으면 게이트가 삼킨다 —
+    버튼 없는 자동 수집이 정확히 이 경로다.
+    """
+    assert _skip(GATED, pairing_mode=False, forced_transfer=False, poll_request=source) is False
 
 
 def test_parked_pairing_session_is_never_skipped():
-    """주차된 링크는 이미 열려 있고 본딩돼 있다 — 건너뛰면 그대로 방치된다.
+    """주차된 링크는 이미 열려 있고 본딩돼 있다 — 건너뛰면 방치된다.
 
-    페어링 직후 폴이 정확히 이 경로다. 게이트가 여기서 걸리면 페어링은 됐는데
-    첫 측정값이 안 들어오는, 이 이슈의 원래 증상으로 되돌아간다.
+    페어링 직후 폴이 이 경로다. 여기서 걸리면 페어링은 됐는데 첫 측정값이
+    안 들어오는, 이 이슈의 원래 증상으로 되돌아간다.
     """
-    assert _should_poll(
-        PER_SESSION_PROFILE,
-        pairing_mode=False,
-        forced_transfer=False,
-        handoff_parked=True,
-    )
+    assert _skip(GATED, handoff_parked=True) is False
 
 
-@pytest.mark.parametrize(
-    "pairing_mode,forced_transfer", [(False, False), (True, False), (False, True)]
-)
-def test_reuse_profile_keeps_polling_on_the_timer(pairing_mode, forced_transfer):
-    """본드를 유지하는 기기는 종전대로 스캔 간격에 읽는다."""
-    assert _should_poll(
-        REUSE_PROFILE,
-        pairing_mode=pairing_mode,
-        forced_transfer=forced_transfer,
-        handoff_parked=False,
-    )
+# ── 반대 방향: 얼어붙은 플래그 ─────────────────────────────────────────────
 
+def test_stale_true_flag_does_not_reopen_doomed_connects():
+    """플래그는 MSD 디코드가 성공할 때만 갱신된다.
 
-def test_gate_condition_matches_the_source():
-    """위 거울 함수가 실제 게이트와 같은 신호를 보는지 확인한다.
-
-    조건식을 복제한 대가로, 원본이 바뀌었는데 테스트만 옛 규칙을 지키고 있는
-    상황을 막는다.
+    길이 불일치로 패킷을 버리거나 커프가 광고를 멈추면 이전 True 가 그대로
+    남고, 그 True 는 게이트가 없애려던 실패 연결을 다시 연다.
     """
+    fresh = _skip(GATED, forced_transfer=True, flags_age=1.0)
+    stale = _skip(GATED, forced_transfer=True, flags_age=ADVERT_FLAG_FRESHNESS_SECONDS + 1)
+
+    assert fresh is False
+    assert stale is True
+
+
+def test_flags_never_seen_are_not_treated_as_permission():
+    assert _skip(GATED, forced_transfer=True, flags_age=None) is True
+
+
+def test_a_request_overrides_even_stale_flags():
+    """명시적 요청은 플래그 신선도와 무관하다."""
+    assert _skip(GATED, flags_age=None, poll_request="button press") is False
+
+
+# ── 요청 래치의 수명 ───────────────────────────────────────────────────────
+
+def test_request_is_returned_until_taken():
+    entry_data: dict = {}
+    request_poll(entry_data, "button press", now=1000.0)
+
+    # peek 은 소비하지 않는다 — connect 를 실제로 시도하기 전에 사라지면
+    # 세션 락에 막힌 버튼 누름이 통째로 없어진다.
+    assert take_poll_request(entry_data, now=1000.0) == "button press"
+    assert take_poll_request(entry_data, now=1001.0) == "button press"
+
+
+def test_request_expires_so_it_cannot_open_an_unrelated_poll_later():
+    entry_data: dict = {}
+    request_poll(entry_data, "forced-transfer advertisement", now=1000.0)
+
+    assert take_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS - 1)
+    assert take_poll_request(entry_data, now=1000.0 + POLL_REQUEST_TTL_SECONDS + 1) is None
+    assert "poll_request" not in entry_data
+
+
+# ── 적용 범위 ──────────────────────────────────────────────────────────────
+
+@pytest.mark.parametrize("profile", ["HEM-7188T1", "HEM-7191T1", "HEM-7196T1"])
+def test_wld4_is_gated(profile):
+    config = CANONICAL_DEVICE_PROFILES[profile]
+    assert config.connect_type == ConnectType.WLD4_0
+    assert config.bond_policy == BondPolicy.PER_SESSION
+    assert config.poll_requires_pairing_window is True
+
+
+def test_wld3_is_not_gated_without_evidence():
+    """증거는 WLD4.0 한 대뿐이다.
+
+    비용이 비대칭이다: 타이머 폴이 실제로 동작하는 패밀리를 게이트하면 읽기가
+    조용히 멈추고, 게이트를 안 하면 이미 낭비되던 connect 가 계속 낭비될 뿐이다.
+    WLD3.0 실기기로 확인한 뒤에 넓힌다.
+    """
+    wld3 = [
+        (n, c) for n, c in CANONICAL_DEVICE_PROFILES.items()
+        if c.connect_type == ConnectType.WLD3_0
+    ]
+    assert wld3
+    for name, config in wld3:
+        assert config.unpair_after_session is True, name
+        assert config.poll_requires_pairing_window is False, name
+    assert _skip(UNGATED_WLD3) is False
+
+
+# ── 소스 배선 (함수 밖에서만 확인 가능한 것) ───────────────────────────────
+
+def test_advert_and_button_paths_latch_a_request():
+    """디바운스되는 refresh 를 부르기 전에 요청이 기록돼야 한다."""
     import pathlib
 
-    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
-    start = source.index("poll_requires_pairing_window")
-    gate = source[start - 200 : start + 400]
-
-    assert "not user_requested" in gate
-    assert "not device_data.pairing_mode" in gate
-    assert "not device_data.forced_transfer" in gate
-    assert "not has_handoff_session(hass, address)" in gate
-
-
-def test_user_pressing_refresh_is_never_skipped():
-    """사람이 누른 요청은 시계가 아니다 — 게이트를 통과해야 한다.
-
-    조용히 건너뛰면 버튼이 아무 일도 안 하는 것처럼 보인다. 실패하더라도
-    사용자는 실제 에러를 봐야 한다.
-    """
-    assert _should_poll(
-        PER_SESSION_PROFILE,
-        pairing_mode=False,
-        forced_transfer=False,
-        handoff_parked=False,
-        user_requested=True,
-    )
-
-
-def test_refresh_button_arms_the_flag_and_the_poll_consumes_it():
-    """플래그는 일회성이어야 한다.
-
-    소비되지 않고 남으면, 다음 예약 폴이 아무도 요청하지 않았는데 게이트를
-    통과한다 — 이 변경이 없애려던 바로 그 폴이다.
-    """
-    import pathlib
-
+    init = pathlib.Path("custom_components/omron/__init__.py").read_text()
     button = pathlib.Path("custom_components/omron/button.py").read_text()
+
+    advert = init.index('request_poll(entry_data, "forced-transfer advertisement")')
+    refresh = init.index("await coordinator.poll_coordinator.async_request_refresh()")
+    assert advert < refresh, "디바운스된 refresh 뒤에 래치하면 이미 늦다"
+
+    assert 'request_poll(self.hass.data[DOMAIN][self._entry_id], "button press")' in button
+
+
+def test_request_is_consumed_only_after_committing_to_connect():
+    """세션 락에 막혀 되돌아가는 경로에서 요청이 소비되면 안 된다."""
+    import pathlib
+
     init = pathlib.Path("custom_components/omron/__init__.py").read_text()
 
-    assert '["user_requested_poll"] = True' in button
-    # pop 이어야 한다: get 이면 플래그가 남아 다음 폴까지 열어 준다.
-    assert 'entry_data.pop("user_requested_poll", False)' in init
-    assert 'entry_data.get("user_requested_poll"' not in init
+    lock_skip = init.index('"Skipping scheduled poll: BLE session lock held for %s"')
+
+    # 「뒤에 소비가 하나 있다」가 아니라 「앞에 소비가 하나도 없다」를 본다.
+    # 앞의 것만 보면 소비를 하나 더 끼워 넣는 변경을 놓친다.
+    consumes = [
+        i for i in range(len(init))
+        if init.startswith('entry_data.pop("poll_request"', i)
+    ]
+    assert consumes, "요청을 소비하는 곳이 없다"
+    assert min(consumes) > lock_skip, (
+        "락 때문에 되돌아가는 경로보다 먼저 요청이 소비된다 — 버튼 누름이 사라진다"
+    )
 
 
 def test_advert_flags_are_logged_before_both_early_returns():
-    """플래그 로그가 두 early return 보다 앞에 있어야 한다.
-
-    이슈 #92 에서 진단이 막힌 지점이다. 로그가 뒤에 있으면 "Advertisement
-    flags" 줄이 없다는 사실이 세 가지를 동시에 뜻하게 된다:
-
-      * 커프가 아무 플래그도 안 올렸다
-      * 올렸는데 non-connectable 광고라 connectable 체크에서 버려졌다
-      * 우리가 트리거하지 않는 플래그만 올렸다
-
-    자동 수집이 가능한지에 대해 정반대 답이 나오는 세 경우인데, 로그로는
-    구분할 수 없었다. connectable 값도 같은 줄에 있어야 두 번째가 갈린다.
-    """
+    """플래그 로그가 두 early return 보다 앞에 있어야 한다(이슈 #92 진단)."""
     import pathlib
 
     source = pathlib.Path("custom_components/omron/__init__.py").read_text()
@@ -161,53 +210,20 @@ def test_advert_flags_are_logged_before_both_early_returns():
     body = body[: body.index("\nasync def ")]
 
     log_at = body.index('"Advertisement flags for %s')
-    connectable_return_at = body.index("if not service_info.connectable:")
-    sync_needed_return_at = body.index("if not is_sync_needed:")
-
-    assert log_at < connectable_return_at, (
-        "non-connectable 광고의 플래그가 로그 없이 버려진다"
-    )
-    assert log_at < sync_needed_return_at
+    assert log_at < body.index("if not service_info.connectable:")
+    assert log_at < body.index("if not is_sync_needed:")
     assert "connectable=%s" in body
+    assert "msd=%s (format=%s decoded=%s)" in body
 
 
-def test_advert_flags_log_is_transition_only():
-    """광고마다 찍으면(초당 1회 수준) 정작 볼 것이 묻힌다."""
-    import pathlib
-
-    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
-
-    assert 'entry_data.get("last_advert_flags") != flags' in source
-    assert 'entry_data["last_advert_flags"] = flags' in source
-
-
-def test_advert_log_carries_the_raw_msd_and_format():
-    """디코드된 플래그만으로는 네 경우가 구분되지 않는다.
-
-    ``forced_transfer=False`` 는 다음을 전부 뜻할 수 있다:
-      * 커프가 안 올렸다                     ← 유일한 하드웨어 한계
-      * MSD 포맷 0x03 이라 비트가 없다        ← 우리가 다른 신호를 찾아야 함
-      * length contract 불일치로 통째 무시    ← 포맷 지원을 넓히면 됨
-
-    앞의 둘만 놓고 "하드웨어가 못 한다"고 결론내면 고칠 수 있는 문제를 접는
-    것이므로, 포맷 바이트와 원문이 같은 줄에 있어야 한다.
-    """
-    import pathlib
-
-    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
-
-    assert "msd=%s (format=%s decoded=%s)" in source
-    # 플래그가 안 변해도 MSD 가 변하면 보여야 한다 — 인식 못 한 측정이 그 모습이다.
-    assert "msd_hex,\n    )" in source or "        msd_hex,\n    )" in source
-
-
-def test_parser_retains_the_raw_msd_and_whether_it_decoded():
+def test_parser_retains_the_raw_msd_its_freshness_and_whether_it_decoded():
     import pathlib
 
     source = pathlib.Path("custom_components/omron/omron_ble/parser.py").read_text()
 
     assert "self.last_msd = bytes(payload)" in source
     assert "self.last_msd_decoded = fields is not None" in source
+    assert "self.last_msd_monotonic = time.monotonic()" in source
     # 원문은 디코드 시도 전에 잡아야 한다: 실패한 페이로드가 정확히 필요한 것이다.
     assert source.index("self.last_msd = bytes(payload)") < source.index(
         "fields = self._decode_omron_msd_fields(payload)"

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -139,3 +139,43 @@ def test_refresh_button_arms_the_flag_and_the_poll_consumes_it():
     # pop 이어야 한다: get 이면 플래그가 남아 다음 폴까지 열어 준다.
     assert 'entry_data.pop("user_requested_poll", False)' in init
     assert 'entry_data.get("user_requested_poll"' not in init
+
+
+def test_advert_flags_are_logged_before_both_early_returns():
+    """플래그 로그가 두 early return 보다 앞에 있어야 한다.
+
+    이슈 #92 에서 진단이 막힌 지점이다. 로그가 뒤에 있으면 "Advertisement
+    flags" 줄이 없다는 사실이 세 가지를 동시에 뜻하게 된다:
+
+      * 커프가 아무 플래그도 안 올렸다
+      * 올렸는데 non-connectable 광고라 connectable 체크에서 버려졌다
+      * 우리가 트리거하지 않는 플래그만 올렸다
+
+    자동 수집이 가능한지에 대해 정반대 답이 나오는 세 경우인데, 로그로는
+    구분할 수 없었다. connectable 값도 같은 줄에 있어야 두 번째가 갈린다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("def process_service_info") :]
+    body = body[: body.index("\nasync def ")]
+
+    log_at = body.index('"Advertisement flags for %s')
+    connectable_return_at = body.index("if not service_info.connectable:")
+    sync_needed_return_at = body.index("if not is_sync_needed:")
+
+    assert log_at < connectable_return_at, (
+        "non-connectable 광고의 플래그가 로그 없이 버려진다"
+    )
+    assert log_at < sync_needed_return_at
+    assert "connectable=%s" in body
+
+
+def test_advert_flags_log_is_transition_only():
+    """광고마다 찍으면(초당 1회 수준) 정작 볼 것이 묻힌다."""
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+
+    assert 'entry_data.get("last_advert_flags") != flags' in source
+    assert 'entry_data["last_advert_flags"] = flags' in source

--- a/tests/test_pairing_window_poll_gate.py
+++ b/tests/test_pairing_window_poll_gate.py
@@ -308,3 +308,33 @@ def test_entering_the_waiting_state_is_visible_at_info():
     assert "_LOGGER.info" in source
     # 유휴 상태가 이어지는 동안 스캔 간격마다 INFO 를 반복하지는 않는다.
     assert "_LOGGER.debug\n                    if entry_data.get" in source
+
+
+def test_observer_prints_every_decoded_field():
+    """행동에 쓰는 세 개만 찍으면 진단이 아니다.
+
+    이 조사를 푼 단서(``user_register_count`` 가 페어링된 기기는 1, 침묵하는
+    기기는 0)는 이미 파싱되고 있었는데 로그에 없어서, 붙여넣은 페이로드를 손으로
+    디코드해서야 발견됐다. 이미 알고 있던 것만 보여주는 로그는 쓸모가 없다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("def _register_advertisement_observer") :]
+    body = body[: body.index("\ndef _merge_poll_sensor_update")]
+
+    for field in (
+        "user_register_count",
+        "pairing_mode",
+        "invalid_time",
+        "forced_transfer",
+        "streaming_mode",
+        "service_uuid_mode",
+        "guidance_mode",
+        "result_identifier_num",
+    ):
+        assert f'"{field}"' in body, f"{field} 가 관찰자 로그에 없다"
+
+    # 디코더는 페이로드의 2바이트만 읽는다 — 나머지에 신호가 있을 수 있으므로
+    # 포맷/플래그 바이트도 원문으로 남긴다.
+    assert "format=%s flags=%s" in body


### PR DESCRIPTION
> Supersedes #128. Draft until a second real-device run confirms the gate behaves as intended.

## The experiment in #128 came back negative

2.7.8-beta.1 kept the bond for the WLD4.0 profiles. Tested against a real HEM-7188T1-LEO ([#92](https://github.com/eigger/hass-omron/issues/92#issuecomment-5378953230)):

```
09:00:53  Advertisement flags: pairing_mode=True
09:00:55  Bonded ... before service discovery
09:00:59  Token unlock OK
09:01:00  slot=2 parsed: sys=113 dia=83 bpm=70
09:01:01  BLE link closed              <-- no "Removed OS bond": REUSE held
   ... 5 minutes, scheduled poll, cuff no longer in pairing mode ...
09:06:10  WARNING Bonding ... failed: Pairing failed due to error: 102
09:06:13  Memory session open attempt 1/3 failed
```

The integration kept the bond and the next connect still had to bond again, and was refused. Whatever the cuff does with its side, a host-side bond does not carry a later connect here. `_WLD4_BOND_POLICY` goes back to `PER_SESSION`, and its comment now records the result instead of the hypothesis.

## So the defect is the trigger, not the bond lifetime

A read needs a bond; a bond needs pairing mode. A poll fired because the scan interval elapsed can manufacture neither — it spends a connect, a bond attempt and the session lock to reach a failure that was certain before it started, and then warns about it.

The device already announces when a read can work, in its advertisement flags. This gates the scheduled poll on those — **for WLD4.0 only** (`HEM-7188T1` / `7191T1` / `7196T1`):

| Situation | WLD4.0 (gated) | WLD3.0 / REUSE |
|---|---|---|
| nothing — timer alone | **skip** | poll |
| `pairing_mode` seen recently | poll | poll |
| `forced_transfer` seen recently | poll | poll |
| a request latched by the button or an advertisement | poll | poll |
| pairing session parked | poll | poll |
| flags stale (> 60 s) or never seen | **skip** | poll |

**WLD3.0 is deliberately *not* gated**, though it is equally `PER_SESSION`. The evidence for this gate is one WLD4.0 cuff, and the costs are not symmetric: gating a family whose timer polls do work stops their readings silently, while leaving one ungated only wastes connects already being wasted. `HEM-7380T1` and friends can join once one has been checked. REUSE profiles are untouched for the same reason, more strongly — gating those would make currently-working devices need a button press.

### Requests are latched, not sampled

The advertisement path does not connect; it calls `async_request_refresh()`, which is debounced by ~10 s (the coordinator takes Home Assistant's default). The poll therefore re-reads the flags well after the advertisement that prompted it, and a cuff that lowered the bit in between would have its request silently skipped — with the 60 s trigger cooldown holding off a retry. That is the buttonless-collection path, so it gets a latch rather than a re-read:

- **latched the moment the flag is parsed**, ahead of the session-lock and cooldown returns, which otherwise drop the advertisement entirely
- **peeked** by the gate and **consumed only once a connect is committed**, so a press or an advertisement blocked by the session lock is served by the retry instead of vanishing
- **TTL-bounded** (5 min), so one that never got its chance cannot open an unrelated poll later

**A parked pairing session is exempt.** That link is already open and bonded; skipping it would strand it and lose the first reading — the original symptom of this issue. `has_handoff_session()` is a peek, since `adopt_handoff_session()` pops and a gate must not.

**Stale flags cannot open a connect.** The flags only refresh when an MSD decodes, so a dropped packet or a cuff that went quiet leaves the last values standing — and a frozen `True` would reopen exactly the connects this removes.

## Carried over from #128

The stale-bond recovery and the log work survive on their own merits. The recovery does not fire on this cuff's error 102 — correctly, since a bond refused for want of pairing mode is not a stale one — but it still fills a path that was unreachable for all eight `pair_on_connect` profiles.

## The untested window

It is tempting to read the negative result as "these cuffs need a button press for every reading". That does not follow from what was observed, and the gate is built so it does not depend on it.

| Advert state | Bonding observed? |
|---|---|
| idle — no flags | refused, error 102 / `AuthenticationCanceled` (2 reports) |
| `pairing_mode` | bonds and reads cleanly (2 reports) |
| **`forced_transfer`** | **never tested** |

`forced_transfer` is a real MSD bit (`b13 & 0x40`, "Data Pending") that the cuff raises **on its own after a measurement** — no button involved. It is how the official app collects readings without user action, and this integration already treats it as a poll trigger. Neither field log contains a post-measurement window: both show `forced_transfer=False` throughout.

So the honest state is that the idle failure has been generalised to a window nobody has looked at. Circumstantial evidence leans slightly toward that window also failing — the readings finally collected were 9 hours old in one report and 2 days old in the other, so automatic collection had not been happening — but both reporters were mid-debugging, which is exactly the confound that makes it circumstantial.

**The gate is correct under either answer**, which is why it does not wait on this: `forced_transfer` is gated *in*, so if the window works, measurements are collected automatically as before; if it does not, nothing is lost, since that poll was going to fail anyway. What changes is only that polls fired by the clock alone stop burning a connect for a certain failure.

Settling it needs one deliberate run: take a measurement on the cuff, do not touch any button, and capture what happens on the `forced_transfer` advertisement — including the `via source=` field, so the transport is on record.

## Test plan
- [x] `pytest tests -q` — 144 passed (14 in `test_bond_policy_recovery.py`, 23 in `test_pairing_window_poll_gate.py`)
- [x] Every gate fix verified by reintroducing the defect and watching the suite fail — the earlier tests restated the condition in their own words and searched `__init__.py` for strings, which is why two real bugs passed them. The gate is now `ble_session.should_skip_scheduled_poll()` and the tests call it.
- [ ] Real HEM-7188T1: confirm scheduled polls stop producing failed connects when the cuff is idle
- [ ] Confirm the post-pairing first reading still arrives (parked-session exemption)
- [ ] **Take a measurement and touch nothing**: does the `forced_transfer` advertisement lead to a successful bond and read? This is the open question above, and the single most useful data point remaining
- [ ] Confirm a REUSE cuff (HEM-7142T2 / 716BT2) still polls on the interval

Refs #92, discussions#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)

