### PR TITLE
feat: keep the HEM-7188T1 application-layer bond across sessions

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -102,25 +102,45 @@ class PersistentSecureBondStore(SecureBondStore):
 
     async def async_load(self) -> None:
         """Populate the in-memory key. Call once, during setup."""
-        stored = None
         try:
             data = await self._store.async_load()
         except Exception as exc:  # noqa: BLE001 - a bad store must not block setup
             _LOGGER.warning("Could not read the stored secure bond key: %s", exc)
-            data = None
+            return
+
         if isinstance(data, dict):
-            stored = data.get("key")
-        if not stored:
-            # First run after the config flow paired: adopt the key it left on
-            # the entry. Left in place afterwards rather than removed, because
-            # removing it means updating the entry, which means a reload.
-            stored = self._entry.data.get(CONF_SECURE_BOND_KEY)
-            if stored:
-                _LOGGER.debug("Adopting the secure bond key left by the config flow")
-        if not stored:
+            # The store has spoken, including when it says there is no key.
+            # Falling back to the entry here would resurrect a key the cuff
+            # had rejected: clear() writes {"key": None}, and treating that as
+            # "nothing stored" would hand back the config flow's original on
+            # the next restart, so the same rejection would repeat forever and
+            # a -P- re-pair would look like it had not helped.
+            await self._adopt(data.get("key"))
+            return
+
+        # No store file at all: first run after the config flow paired. Adopt
+        # the key it left on the entry and write it through, so the store is
+        # the only source from here on. The entry copy is left in place rather
+        # than removed, because removing it means updating the entry, which
+        # means a reload.
+        seed = self._entry.data.get(CONF_SECURE_BOND_KEY)
+        if seed:
+            _LOGGER.debug("Adopting the secure bond key left by the config flow")
+            await self._adopt(seed, write_through=True)
+
+    async def _adopt(self, hex_key: str | None, *, write_through: bool = False) -> None:
+        if not hex_key:
             return
         try:
-            await super().save(bytes.fromhex(stored))
+            key = bytes.fromhex(hex_key)
+        except ValueError:
+            _LOGGER.warning("Ignoring an unreadable stored secure bond key")
+            return
+        try:
+            if write_through:
+                await self.save(key)
+            else:
+                await super().save(key)
         except ValueError as exc:
             _LOGGER.warning("Ignoring an unusable stored secure bond key: %s", exc)
 

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -30,6 +30,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
 from datetime import timedelta
+from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     CONF_DEVICE_MODEL,
@@ -74,45 +75,68 @@ _STALE_DROP_BINARY_DEVICE_CLASSES: frozenset = frozenset({
 })
 
 
-class ConfigEntrySecureBondStore(SecureBondStore):
-    """Keeps the application-layer bond key in the config entry.
+SECURE_BOND_STORE_VERSION = 1
 
-    It has to outlive Home Assistant restarts for the same reason it has to
-    outlive the link: pairing is the only moment the cuff hands one out, and
-    it only does that with the -P- button held. A key lost to a restart costs
-    the user a physical trip to the device.
+
+class PersistentSecureBondStore(SecureBondStore):
+    """Keeps the application-layer bond key in Home Assistant's own storage.
+
+    It has to outlive restarts for the same reason it has to outlive the
+    link: pairing is the only moment the cuff hands one out, and it wants the
+    -P- button held. A key lost to a restart costs a physical trip.
+
+    Deliberately not the config entry. Writing there fires the update
+    listener, which reloads the integration — and ``save()`` runs in the
+    middle of a handshake, so the reload would tear down the very session
+    that just paired. The entry is still where the config flow drops the
+    first key, because there is no entry id to store under until it exists;
+    that value is read once and then lives here.
     """
 
     def __init__(self, hass: HomeAssistant, entry: OmronConfigEntry) -> None:
-        stored = entry.data.get(CONF_SECURE_BOND_KEY)
-        try:
-            key = bytes.fromhex(stored) if stored else None
-        except ValueError:
-            _LOGGER.warning(
-                "Ignoring an unreadable stored secure bond key for %s",
-                entry.title,
-            )
-            key = None
-        super().__init__(key)
-        self._hass = hass
+        super().__init__()
+        self._store = Store(
+            hass, SECURE_BOND_STORE_VERSION, f"{DOMAIN}.secure_bond.{entry.entry_id}"
+        )
         self._entry = entry
+
+    async def async_load(self) -> None:
+        """Populate the in-memory key. Call once, during setup."""
+        stored = None
+        try:
+            data = await self._store.async_load()
+        except Exception as exc:  # noqa: BLE001 - a bad store must not block setup
+            _LOGGER.warning("Could not read the stored secure bond key: %s", exc)
+            data = None
+        if isinstance(data, dict):
+            stored = data.get("key")
+        if not stored:
+            # First run after the config flow paired: adopt the key it left on
+            # the entry. Left in place afterwards rather than removed, because
+            # removing it means updating the entry, which means a reload.
+            stored = self._entry.data.get(CONF_SECURE_BOND_KEY)
+            if stored:
+                _LOGGER.debug("Adopting the secure bond key left by the config flow")
+        if not stored:
+            return
+        try:
+            await super().save(bytes.fromhex(stored))
+        except ValueError as exc:
+            _LOGGER.warning("Ignoring an unusable stored secure bond key: %s", exc)
 
     async def save(self, key: bytes) -> None:
         await super().save(key)
-        self._write(key.hex())
+        await self._write(key.hex())
 
     async def clear(self) -> None:
         await super().clear()
-        self._write(None)
+        await self._write(None)
 
-    def _write(self, value: str | None) -> None:
-        data = dict(self._entry.data)
-        if value is None:
-            data.pop(CONF_SECURE_BOND_KEY, None)
-        else:
-            data[CONF_SECURE_BOND_KEY] = value
-        if data != dict(self._entry.data):
-            self._hass.config_entries.async_update_entry(self._entry, data=data)
+    async def _write(self, value: str | None) -> None:
+        try:
+            await self._store.async_save({"key": value})
+        except Exception as exc:  # noqa: BLE001 - never break a session over this
+            _LOGGER.warning("Could not persist the secure bond key: %s", exc)
 
 
 def _merge_poll_sensor_update(prev: SensorUpdate, new: SensorUpdate) -> SensorUpdate:
@@ -334,10 +358,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     device_model = entry.data.get(CONF_DEVICE_MODEL, DEFAULT_DEVICE_MODEL)
 
     slot_aliases = aliases_dict_from_entry(entry)
+    secure_bond_store = PersistentSecureBondStore(hass, entry)
+    await secure_bond_store.async_load()
     data = OmronBluetoothDeviceData(
         device_model=device_model,
         user_aliases=slot_aliases,
-        secure_bond_store=ConfigEntrySecureBondStore(hass, entry),
+        secure_bond_store=secure_bond_store,
     )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]['address'] = address

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -19,6 +19,7 @@ from .ble_session import (
 )
 from .omron_ble import OmronBluetoothDeviceData, SensorUpdate
 from .omron_ble.const import DEFAULT_DEVICE_MODEL
+from .omron_ble.secure_store import SecureBondStore
 from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
@@ -32,6 +33,7 @@ from datetime import timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     CONF_DEVICE_MODEL,
+    CONF_SECURE_BOND_KEY,
     DOMAIN,
 )
 from .util import aliases_dict_from_entry
@@ -70,6 +72,47 @@ _STALE_DROP_SENSOR_DEVICE_CLASSES: frozenset = frozenset({
 _STALE_DROP_BINARY_DEVICE_CLASSES: frozenset = frozenset({
     SSDBinarySensorDeviceClass.BATTERY,
 })
+
+
+class ConfigEntrySecureBondStore(SecureBondStore):
+    """Keeps the application-layer bond key in the config entry.
+
+    It has to outlive Home Assistant restarts for the same reason it has to
+    outlive the link: pairing is the only moment the cuff hands one out, and
+    it only does that with the -P- button held. A key lost to a restart costs
+    the user a physical trip to the device.
+    """
+
+    def __init__(self, hass: HomeAssistant, entry: OmronConfigEntry) -> None:
+        stored = entry.data.get(CONF_SECURE_BOND_KEY)
+        try:
+            key = bytes.fromhex(stored) if stored else None
+        except ValueError:
+            _LOGGER.warning(
+                "Ignoring an unreadable stored secure bond key for %s",
+                entry.title,
+            )
+            key = None
+        super().__init__(key)
+        self._hass = hass
+        self._entry = entry
+
+    async def save(self, key: bytes) -> None:
+        await super().save(key)
+        self._write(key.hex())
+
+    async def clear(self) -> None:
+        await super().clear()
+        self._write(None)
+
+    def _write(self, value: str | None) -> None:
+        data = dict(self._entry.data)
+        if value is None:
+            data.pop(CONF_SECURE_BOND_KEY, None)
+        else:
+            data[CONF_SECURE_BOND_KEY] = value
+        if data != dict(self._entry.data):
+            self._hass.config_entries.async_update_entry(self._entry, data=data)
 
 
 def _merge_poll_sensor_update(prev: SensorUpdate, new: SensorUpdate) -> SensorUpdate:
@@ -294,6 +337,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     data = OmronBluetoothDeviceData(
         device_model=device_model,
         user_aliases=slot_aliases,
+        secure_bond_store=ConfigEntrySecureBondStore(hass, entry),
     )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]['address'] = address

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -37,13 +37,20 @@ from homeassistant.config_entries import (
 from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
 
 from .ble_session import stash_handoff_session
-from .const import CONF_BINDKEY, CONF_DEVICE_MODEL, CONF_USER_ALIASES, DOMAIN
+from .const import (
+    CONF_BINDKEY,
+    CONF_DEVICE_MODEL,
+    CONF_SECURE_BOND_KEY,
+    CONF_USER_ALIASES,
+    DOMAIN,
+)
 from .omron_ble.omron_driver import OmronDeviceSession
 from .omron_ble.setup import (
     async_fetch_device_model_number,
     async_pair_and_sync_device,
 )
 from .omron_ble.const import DEFAULT_DEVICE_MODEL
+from .omron_ble.secure_store import SecureBondStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -409,7 +416,11 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
         if not ble_device:
             raise ConnectionError(f"BLE device {address} not available")
 
-        session = OmronDeviceSession(ble_device, config)
+        # Pairing is the only moment the cuff hands out a bond key, and there
+        # is no config entry yet to put it in — hold it here and let
+        # _async_get_or_create_entry write it into the entry it creates.
+        self._secure_bond_store = SecureBondStore()
+        session = OmronDeviceSession(ble_device, config, self._secure_bond_store)
         try:
             await session.connect()
             await async_pair_and_sync_device(
@@ -513,6 +524,15 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             getattr(self, "_scan_interval", 300)
         )
         data[CONF_USER_ALIASES] = dict(getattr(self, "_user_aliases", {}))
+
+        # Carry the key derived during pairing into the entry. Without it the
+        # first scheduled poll would have nothing to reconnect with and would
+        # have to ask the cuff to pair again, which it refuses once the -P-
+        # window has closed.
+        store = getattr(self, "_secure_bond_store", None)
+        secure_key = store.load() if store is not None else None
+        if secure_key:
+            data[CONF_SECURE_BOND_KEY] = secure_key.hex()
 
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(

--- a/custom_components/omron/const.py
+++ b/custom_components/omron/const.py
@@ -8,3 +8,7 @@ DOMAIN = "omron"
 CONF_BINDKEY: Final = "bindkey"
 CONF_DEVICE_MODEL: Final = "device_model"
 CONF_USER_ALIASES: Final = "user_aliases"
+# Application-layer bond key (hex). Written by the config flow after a
+# successful secure pairing and reused by every later session — see
+# omron_ble/secure_store.py.
+CONF_SECURE_BOND_KEY: Final = "secure_bond_key"

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.0-beta.4"
+  "version": "2.8.0-beta.2"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.0-beta.2"
+  "version": "2.8.0-beta.3"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.7"
+  "version": "2.8.0-beta.1"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.0-beta.3"
+  "version": "2.8.0-beta.4"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.7"
+  "version": "2.7.8-beta.7"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.0-beta.1"
+  "version": "2.8.0-beta.2"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1213,16 +1213,36 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # HEM-7188T1 / HEM-7183T1 family ("X2+ Connect" / "M2+" etc.) — dedicated single-user profile
     # with WLD4.0 transport (ConnectType.WLD4_0) and 30-slot 16-byte record
     # layout at 0x01C4 with index pointer layout at 0x0010.
-    # Operationally uses token-key transport (UnlockMode.TOKEN_KEY): an
-    # application-layer ECDH secure session (0x70 0x01) was tried, but real
-    # devices reject the pairing request with error frame 0xff26, while the
-    # plaintext token-key path reads real measurement values. Revisit
-    # unlock_mode=SECURE_SESSION once the ECDH rejection is understood.
+    # Uses the application-layer secure session (UnlockMode.SECURE_SESSION).
+    #
+    # This profile ran on the plaintext token-key path for a while, on the
+    # reading that the device "rejects the pairing request with error frame
+    # 0xff26". A phone btsnoop of a real HEM-7188T1-LEO (issue #92) says
+    # otherwise — the official app's primary path is the secure session, and
+    # the device answers it:
+    #
+    #   session 1:  0x11/0x91  ->  0x70 0x01 (89B)  ->  0xf0 0x81
+    #                          ->  0x70 0x05 -> 0xf0 0x85 -> 0x70 0x06 -> 0xf0 0x86
+    #                          ->  encrypted 0xc0 data
+    #   session 2:  0x11/0x91  ->  0x70 0x05 -> ...        (no 0x70 0x01)
+    #
+    # Our request was well-formed all along: the captured frame matches the
+    # 0x70 0x01 || salt(7) || challenge(16) || pubkey(64) layout byte for
+    # byte, and both peers' public keys only land on the P-256 curve read as
+    # little-endian X||Y, which is what we send. What we never did was keep
+    # the key the pairing produces, so every session opened by asking to pair
+    # again — and only a cuff in pairing mode answers that. Outside the -P-
+    # window it replies 0xff26, which is what got read as "the device rejects
+    # ECDH".
+    #
+    # token_key_fallback keeps the plaintext path as a safety net until real
+    # hardware confirms the secure path end to end.
     "HEM-7188T1": DeviceConfig(
         **_MODERN_OS_BONDING_BASE,
         model="HEM-7188T1",
         connect_type=ConnectType.WLD4_0,
-        unlock_mode=UnlockMode.TOKEN_KEY,
+        unlock_mode=UnlockMode.SECURE_SESSION,
+        token_key_fallback=True,
         bond_policy=_WLD3_BOND_POLICY,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -126,6 +126,14 @@ class DeviceConfig:
     unlock_uuid: str = CLASSIC_STACK_UNLOCK_CHARACTERISTIC_UUID
     unlock_mode: UnlockMode = UnlockMode.CLASSIC_KEY
     host_pairing_mode: HostPairingMode = HostPairingMode.CUSTOM_KEY
+    # Fall back to the plaintext token handshake when the secure session
+    # fails. The secure path is what the official app uses on these cuffs, but
+    # it is newly wired and only fully exercised once real hardware confirms
+    # it; without this a regression there would also take away the one read
+    # that works today, right after pairing. Only meaningful with
+    # unlock_mode=SECURE_SESSION.
+    token_key_fallback: bool = False
+
     # Enable more aggressive GATT timing for classic custom-key profiles
     # (extra refresh/retry and pre-unlock 0x02 probe).
     aggressive_gatt_timing: bool = False

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -2156,12 +2156,11 @@ class OmronDeviceSession:
             await asyncio.sleep(_PAIRING_SETTLE_DEFAULT_SEC)
 
         if not entered_programming:
-            self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
             try:
                 await self._client.stop_notify(self._config.unlock_uuid)
-                await self._client.stop_notify(self._config.rx_channel_uuids[0])
             except Exception:
                 pass
+            await self._release_primed_rx("pair")
             _LOGGER.error(
                 "Key programming mode not reached: model=%s aggressive_gatt_timing=%s "
                 "unlock_uuid=%s attempts=%s write_failures=%s "
@@ -2194,12 +2193,11 @@ class OmronDeviceSession:
             pass
 
         resp = response_holder[0]
-        self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
         try:
             await self._client.stop_notify(self._config.unlock_uuid)
-            await self._client.stop_notify(self._config.rx_channel_uuids[0])
         except Exception:
             pass
+        await self._release_primed_rx("pair")
 
         if not _is_unlock_pairing_key_ack(resp):
             raise ConnectionError(f"Failed to program pairing key. Response: {resp.hex() if resp else 'None'}")

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1544,19 +1544,40 @@ class OmronDeviceSession:
 
         await self._ensure_services_cache()
 
-        # Official app: RX notify CCCD (h=33) before unlock CCCD (h=28).
-        try:
-            await self._client.start_notify(
-                self._config.rx_channel_uuids[0], lambda _h, _d: None
-            )
-            rx_notify_primed = True
-            await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
-        except Exception as exc:
-            _LOGGER.debug("token unlock RX pre-notify prime skipped: %s", exc)
+        # CCCD order, and the two families disagree about it. Phone btsnoops:
+        #
+        #   HEM-7188T1-LEO (#92):   0x001c (unlock, h=28) then 0x0021 (RX, h=33)
+        #   HEM-7155T-ESLI (#67):   0x0021 (RX, h=33)     then 0x001c (unlock, h=28)
+        #
+        # The comment this replaces described the second order and applied it
+        # to both. That is what the 2.5.23 build did on a HEM-7188T1-LEO, and
+        # its log shows "CCD descriptor 33" then "28" followed immediately by
+        # 0xff26 on the pairing request — in the config flow, with the cuff in
+        # pairing mode, which is the one place that rejection was not supposed
+        # to happen. This module already knew CCCD handling can produce that
+        # exact frame; see the note in _secure_unlock about not re-subscribing.
+        async def _prime_rx() -> None:
+            nonlocal rx_notify_primed
+            try:
+                await self._client.start_notify(
+                    self._config.rx_channel_uuids[0], lambda _h, _d: None
+                )
+                rx_notify_primed = True
+                await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
+            except Exception as exc:
+                _LOGGER.debug("token unlock RX pre-notify prime skipped: %s", exc)
 
-        self._debug_ble_link("token_unlock_before_notify")
-        await self._client.start_notify(self._config.unlock_uuid, _unlock_dispatch)
-        await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
+        async def _subscribe_unlock() -> None:
+            self._debug_ble_link("token_unlock_before_notify")
+            await self._client.start_notify(self._config.unlock_uuid, _unlock_dispatch)
+            await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
+
+        if self._config.unlock_mode == UnlockMode.SECURE_SESSION:
+            await _subscribe_unlock()
+            await _prime_rx()
+        else:
+            await _prime_rx()
+            await _subscribe_unlock()
         try:
             unlock_event.clear()
             response_holder[0] = None

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1040,7 +1040,7 @@ class OmronDeviceSession:
             self._channel_fragments = [None] * 4
 
         # Decrypt if secure-session encryption is active
-        if self._config.unlock_mode == UnlockMode.SECURE_SESSION and self._secure_session is not None:
+        if self._secure_frames_active():
             try:
                 frame_bytes = bytearray(self._secure_session.decrypt(bytes(frame_bytes)))
             except Exception as exc:
@@ -1119,7 +1119,7 @@ class OmronDeviceSession:
         else:
             self._expected_reply_packet_type = None
 
-        if self._config.unlock_mode == UnlockMode.SECURE_SESSION and self._secure_session is not None:
+        if self._secure_frames_active():
             try:
                 command = bytearray(self._secure_session.encrypt(bytes(command)))
             except Exception as exc:
@@ -1434,6 +1434,12 @@ class OmronDeviceSession:
                     exc,
                 )
                 self._unlocked = False
+                # Drop the half-built session before falling back. Leaving it
+                # in place made every frame try to encrypt through a handshake
+                # that never reached PAIRED, which raises and takes the whole
+                # session down — a crash instead of the plaintext read the
+                # fallback exists to preserve.
+                self._secure_session = None
                 await self._token_unlock()
                 return
 
@@ -1815,6 +1821,13 @@ class OmronDeviceSession:
                 await self._client.stop_notify(self._config.rx_channel_uuids[0])
             except Exception as exc:
                 _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
+
+    def _secure_frames_active(self) -> bool:
+        """Whether this session's frames are encrypted right now."""
+        if self._config.unlock_mode != UnlockMode.SECURE_SESSION:
+            return False
+        session = self._secure_session
+        return session is not None and session.is_encrypting
 
     async def _discard_secure_bond(self, reason: str) -> None:
         """Forget a stored key the cuff would not accept.

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -4,6 +4,7 @@ import asyncio
 import datetime as dt
 import logging
 import secrets
+import time
 import traceback
 from contextlib import asynccontextmanager
 from typing import Any, AsyncIterator
@@ -1737,18 +1738,6 @@ class OmronDeviceSession:
                 self._secure_session.process_pair_resp(pair_resp)
                 _LOGGER.debug("Key exchange complete")
 
-                # The key that makes every later session a reconnect.
-                # Stored before the remaining stages so a failure further
-                # on does not throw away a pairing the cuff has accepted
-                # and will not offer again without another -P- press.
-                derived = self._secure_session.ltk
-                if derived:
-                    await self._secure_bond_store.save(derived)
-                    _LOGGER.debug(
-                        "Stored the secure bond key for %s (%d bytes)",
-                        self._config.model,
-                        len(derived),
-                    )
 
             # Step 2: Send Encryption Start Request
             start_enc_req = self._secure_session.build_start_enc_req()
@@ -1774,8 +1763,26 @@ class OmronDeviceSession:
                 raise ConnectionError("Invalid or empty encryption response")
 
             # Step 3: Challenge-Response mutual authentication
+            #
+            # The first frame carrying our own CCM ciphertext, and where a
+            # real device broke with GATT error 133 on the write itself
+            # (issue #92) — no application error frame, no response at all.
+            # That is what a cuff dropping the link looks like from here, and
+            # the reference capture cannot say why: it shows nothing between
+            # 0xf0 85 and 0x70 06 but 12 ms, and the same ATT opcode we use.
+            # So log what the capture cannot supply — how long we took, and
+            # whether the link was still up when we wrote.
+            enc_resp_at = time.monotonic()
             challenge_req = self._secure_session.build_challenge_req(enc_resp)
-            _LOGGER.debug("Sending Challenge Request (len=%d): %s", len(challenge_req), challenge_req.hex())
+            _LOGGER.debug(
+                "Sending Challenge Request (len=%d, %.0f ms after the "
+                "encryption response, is_connected=%s, via %s): %s",
+                len(challenge_req),
+                (time.monotonic() - enc_resp_at) * 1000,
+                getattr(self._client, "is_connected", "?"),
+                _connected_path(self._client, self._ble_device),
+                challenge_req.hex(),
+            )
             unlock_event.clear()
             response_holder[0] = None
             await self._client.write_gatt_char(self._config.unlock_uuid, challenge_req, response=True)
@@ -1801,6 +1808,24 @@ class OmronDeviceSession:
             _LOGGER.info("Secure handshake succeeded. Session unlocked.")
             self._unlocked = True
 
+            # Stored only now, with the handshake complete. An earlier draft
+            # saved it right after the key exchange, reasoning that a failure
+            # downstream should not waste a -P- press. The field log says
+            # otherwise: a run that got its key and then broke on 0x70 06 left
+            # us holding an LTK the cuff had not committed to, so the next
+            # session opened as a reconnect, was refused, and threw the key
+            # away — with the -P- press wasted anyway. The cuff appears to
+            # commit at 0xf0 86, so that is where we commit too.
+            if not reconnecting:
+                derived = self._secure_session.ltk
+                if derived:
+                    await self._secure_bond_store.save(derived)
+                    _LOGGER.debug(
+                        "Stored the secure bond key for %s (%d bytes)",
+                        self._config.model,
+                        len(derived),
+                    )
+
         except asyncio.TimeoutError as exc:
             _LOGGER.error("Secure handshake timed out during negotiation")
             raise ConnectionError("Secure unlock timeout") from exc
@@ -1810,17 +1835,30 @@ class OmronDeviceSession:
                 await self._discard_secure_bond(str(exc))
             raise ConnectionError(f"Secure unlock failed: {exc}") from exc
         finally:
-            self._unlock_notify_handler = None
-            try:
-                await self._client.stop_notify(self._config.unlock_uuid)
-            except Exception as exc:
-                _LOGGER.debug("secure unlock stop_notify skipped: %s", exc)
-            # _token_unlock(keep_notify=True) left the RX-channel CCCD enabled
-            # for us; release it here so it doesn't outlive the handshake.
-            try:
-                await self._client.stop_notify(self._config.rx_channel_uuids[0])
-            except Exception as exc:
-                _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
+            if self._unlocked:
+                # Encrypted traffic runs on these same subscriptions — the
+                # capture shows the app never drops them, and writes its 0xc0
+                # frames to the very characteristic we would be unsubscribing
+                # from. Tearing them down on the way out of a *successful*
+                # handshake would leave the session that just unlocked with no
+                # way to hear the replies.
+                _LOGGER.debug(
+                    "Secure handshake done; keeping the notify subscriptions "
+                    "for the encrypted session"
+                )
+            else:
+                self._unlock_notify_handler = None
+                try:
+                    await self._client.stop_notify(self._config.unlock_uuid)
+                except Exception as exc:
+                    _LOGGER.debug("secure unlock stop_notify skipped: %s", exc)
+                # _token_unlock(keep_notify=True) left the RX-channel CCCD
+                # enabled for us; release it here so it doesn't outlive a
+                # handshake that failed.
+                try:
+                    await self._client.stop_notify(self._config.rx_channel_uuids[0])
+                except Exception as exc:
+                    _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
 
     def _secure_frames_active(self) -> bool:
         """Whether this session's frames are encrypted right now."""

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -15,6 +15,7 @@ from bleak_retry_connector import establish_connection
 
 from .const import MODEL_NUMBER_UUID
 from .devices import DeviceConfig, HostPairingMode, UnlockMode
+from .secure_store import SecureBondStore
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -571,9 +572,18 @@ class OmronDeviceSession:
     (OS-bonding) and multi-channel (classic pairing) profiles.
     """
 
-    def __init__(self, ble_device: BLEDevice, device_config: DeviceConfig) -> None:
+    def __init__(
+        self,
+        ble_device: BLEDevice,
+        device_config: DeviceConfig,
+        secure_bond_store: SecureBondStore | None = None,
+    ) -> None:
         self._ble_device = ble_device
         self._config = device_config
+        # Where the application-layer bond key lives across sessions. Without
+        # one every secure session has to pair again, which only a cuff in
+        # pairing mode will accept.
+        self._secure_bond_store = secure_bond_store or SecureBondStore()
         self._init_session_state(client=None, owns_connection=True)
 
     def _init_session_state(
@@ -612,6 +622,7 @@ class OmronDeviceSession:
         session = cls.__new__(cls)
         session._ble_device = getattr(client, "_device", None)
         session._config = device_config
+        session._secure_bond_store = SecureBondStore()
         session._init_session_state(client=client, owns_connection=False)
         return session
 
@@ -1398,8 +1409,26 @@ class OmronDeviceSession:
 
         # Encrypted secure handshake path
         if self._config.unlock_mode == UnlockMode.SECURE_SESSION:
-            await self._secure_unlock()
-            return
+            try:
+                await self._secure_unlock()
+                return
+            except Exception as exc:
+                if not self._config.token_key_fallback:
+                    raise
+                # The secure path already discarded a rejected key, so the
+                # next pairing-mode session can recover. Meanwhile the
+                # plaintext handshake still reads records right after
+                # pairing, which is what this profile did before the secure
+                # path was wired — degrade to that rather than to nothing.
+                _LOGGER.warning(
+                    "Secure session failed for %s (%s); falling back to the "
+                    "plaintext token handshake",
+                    self._config.model,
+                    exc,
+                )
+                self._unlocked = False
+                await self._token_unlock()
+                return
 
         # Stateless token handshake (0x11 / 0x91)
         if self._config.unlock_mode == UnlockMode.TOKEN_KEY:
@@ -1597,7 +1626,22 @@ class OmronDeviceSession:
         # swap in the secure-stage callback below.
         from .secure_session import SecureSession
 
-        self._secure_session = SecureSession()
+        # A stored key puts the session straight into reconnect mode, where
+        # build_start_enc_req() reuses it instead of deriving a new one. That
+        # is the difference between the two sessions in the reference
+        # btsnoop: the first runs 0x70 0x01 in pairing mode, every later one
+        # opens at 0x70 0x05 — which is the only thing a cuff outside pairing
+        # mode will answer.
+        stored_key = self._secure_bond_store.load()
+        self._secure_session = SecureSession(stored_ltk=stored_key)
+        reconnecting = stored_key is not None
+        _LOGGER.debug(
+            "Secure session for %s: %s",
+            self._config.model,
+            "reconnecting with the stored bond key"
+            if reconnecting
+            else "no stored bond key — pairing (needs the cuff in -P- mode)",
+        )
         unlock_event = asyncio.Event()
         response_holder: list[bytes | None] = [None]
 
@@ -1618,38 +1662,54 @@ class OmronDeviceSession:
             # already-enabled CCCD.
             self._unlock_notify_handler = _secure_callback
 
-            # Step 1: Send Pairing Request
-            pair_req = self._secure_session.build_pair_req()
-            _LOGGER.debug("Sending Pairing Request (len=%d): %s", len(pair_req), pair_req.hex())
-            unlock_event.clear()
-            response_holder[0] = None
-            await self._client.write_gatt_char(self._config.unlock_uuid, pair_req, response=True)
-            
-            # Wait for Pairing Response
-            await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
-            pair_resp = response_holder[0]
-            _LOGGER.debug("Received Pairing Response (len=%d): %s", len(pair_resp) if pair_resp else 0, pair_resp.hex() if pair_resp else "None")
-            if not pair_resp:
-                raise ConnectionError("Empty pairing response")
-            err = _secure_error_frame_code(pair_resp)
-            if err is not None:
-                # Device rejected the ECDH pairing request with an error frame
-                # (e.g. 0xff26). The request itself is well-formed (structure and
-                # SECP256R1 little-endian pubkey are valid), so this is a
-                # device-state rejection: the cuff is likely already bonded to
-                # another host or is not currently accepting a fresh pairing.
-                raise ConnectionError(
-                    f"Device rejected secure pairing (error frame 0x{pair_resp[0]:02x}, "
-                    f"code 0x{err:02x}); the cuff may already be bonded to another "
-                    f"host or is not in pairing mode. Fully unpair/factory-reset "
-                    f"the cuff and try again."
-                )
-            if len(pair_resp) < 2:
-                raise ConnectionError("Invalid or empty pairing response")
+            # Step 1: Pairing. Skipped entirely when a stored key already
+            # makes us a registered host — the cuff only accepts this in
+            # pairing mode, so a reconnect that tried it would be refused.
+            if not reconnecting:
+                pair_req = self._secure_session.build_pair_req()
+                _LOGGER.debug("Sending Pairing Request (len=%d): %s", len(pair_req), pair_req.hex())
+                unlock_event.clear()
+                response_holder[0] = None
+                await self._client.write_gatt_char(self._config.unlock_uuid, pair_req, response=True)
 
-            # Process Pairing Response and derive LTK
-            self._secure_session.process_pair_resp(pair_resp)
-            _LOGGER.debug("Key exchange complete")
+                # Wait for Pairing Response
+                await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
+                pair_resp = response_holder[0]
+                _LOGGER.debug("Received Pairing Response (len=%d): %s", len(pair_resp) if pair_resp else 0, pair_resp.hex() if pair_resp else "None")
+                if not pair_resp:
+                    raise ConnectionError("Empty pairing response")
+                err = _secure_error_frame_code(pair_resp)
+                if err is not None:
+                    # Device rejected the ECDH pairing request with an error frame
+                    # (e.g. 0xff26). The request itself is well-formed (structure and
+                    # SECP256R1 little-endian pubkey are valid), so this is a
+                    # device-state rejection: the cuff is likely already bonded to
+                    # another host or is not currently accepting a fresh pairing.
+                    raise ConnectionError(
+                        f"Device rejected secure pairing (error frame 0x{pair_resp[0]:02x}, "
+                        f"code 0x{err:02x}); the cuff may already be bonded to another "
+                        f"host or is not in pairing mode. Fully unpair/factory-reset "
+                        f"the cuff and try again."
+                    )
+                if len(pair_resp) < 2:
+                    raise ConnectionError("Invalid or empty pairing response")
+
+                # Process Pairing Response and derive LTK
+                self._secure_session.process_pair_resp(pair_resp)
+                _LOGGER.debug("Key exchange complete")
+
+                # The key that makes every later session a reconnect.
+                # Stored before the remaining stages so a failure further
+                # on does not throw away a pairing the cuff has accepted
+                # and will not offer again without another -P- press.
+                derived = self._secure_session.ltk
+                if derived:
+                    await self._secure_bond_store.save(derived)
+                    _LOGGER.debug(
+                        "Stored the secure bond key for %s (%d bytes)",
+                        self._config.model,
+                        len(derived),
+                    )
 
             # Step 2: Send Encryption Start Request
             start_enc_req = self._secure_session.build_start_enc_req()
@@ -1702,9 +1762,13 @@ class OmronDeviceSession:
 
         except asyncio.TimeoutError as exc:
             _LOGGER.error("Secure handshake timed out during negotiation")
+            if reconnecting:
+                await self._discard_secure_bond("the handshake timed out")
             raise ConnectionError("Secure unlock timeout") from exc
         except Exception as exc:
             _LOGGER.error("Secure handshake failed: %s", exc)
+            if reconnecting:
+                await self._discard_secure_bond(str(exc))
             raise ConnectionError(f"Secure unlock failed: {exc}") from exc
         finally:
             self._unlock_notify_handler = None
@@ -1718,6 +1782,25 @@ class OmronDeviceSession:
                 await self._client.stop_notify(self._config.rx_channel_uuids[0])
             except Exception as exc:
                 _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
+
+    async def _discard_secure_bond(self, reason: str) -> None:
+        """Forget a stored key the cuff would not accept.
+
+        Keeping it would send every future reconnect down the encryption
+        path and fail there, with no way back: pairing only happens when
+        there is no key, so a bad one locks the device out of the one
+        session that could fix it. Dropping it costs a single -P- press.
+        """
+        _LOGGER.warning(
+            "Discarding the stored secure bond key for %s (%s). Put the cuff "
+            "in pairing mode (blinking -P-) so it can be paired again",
+            self._config.model,
+            reason,
+        )
+        try:
+            await self._secure_bond_store.clear()
+        except Exception as exc:
+            _LOGGER.debug("Clearing the secure bond key failed (ignored): %s", exc)
 
     async def _pair_os_bonding(self) -> None:
         """Best-effort OS-level BLE bond establishment for modern profiles."""

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -634,6 +634,16 @@ class OmronDeviceSession:
         # same subscription — re-subscribing mid-flow either resets the device
         # session or trips the backend's "already enabled" guard.
         self._unlock_notify_handler: Any = None
+        # The RX channel gets the same treatment as the unlock characteristic:
+        # subscribed once through a fixed dispatcher, with the handler swapped
+        # underneath. The handshake primes it with no handler (data dropped),
+        # and the memory session points it at the reassembler. Without this the
+        # prime installs a throwaway lambda, and the only way to attach the
+        # real callback is to drop the CCCD and re-add it — undoing the
+        # subscription a successful handshake deliberately keeps, right before
+        # the first encrypted frame.
+        self._rx_notify_handler: Any = None
+        self._primed_notify_uuids: set[str] = set()
 
     # -- connection lifecycle -------------------------------------------------
 
@@ -915,7 +925,20 @@ class OmronDeviceSession:
         await self._ensure_services_cache()
         self._rebuild_notify_handle_index_map()
 
+        # A channel the handshake already holds is left alone: re-subscribing
+        # goes through _start_notify_with_recovery, which answers "already
+        # enabled" by dropping the CCCD and re-adding it. That is exactly the
+        # subscription a successful secure handshake keeps on purpose, and the
+        # capture shows the app never drops it.
+        self._rx_notify_handler = self._on_notify_channel_data
         for uuid in self._config.rx_channel_uuids:
+            if uuid in self._primed_notify_uuids:
+                _LOGGER.debug(
+                    "RX %s already subscribed by the handshake; swapping the "
+                    "handler instead of re-subscribing",
+                    uuid,
+                )
+                continue
             await self._start_notify_with_recovery(uuid)
         await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
         self._notify_subscribed = True
@@ -979,6 +1002,8 @@ class OmronDeviceSession:
             except Exception as exc:
                 _LOGGER.debug("stop_notify for %s ignored: %s", uuid, exc)
         self._notify_subscribed = False
+        self._rx_notify_handler = None
+        self._primed_notify_uuids.clear()
         self._debug_ble_link("after_rx_unsubscribe")
 
     async def reset_session_state(self) -> None:
@@ -997,6 +1022,12 @@ class OmronDeviceSession:
         self._expected_reply_packet_type = None
         self._reply_ready.clear()
         self._debug_ble_link("reset_session_state")
+
+    def _rx_dispatch(self, char: Any, rx_bytes: bytearray) -> None:
+        """Fixed RX callback; the real handler is swapped in behind it."""
+        handler = self._rx_notify_handler
+        if handler is not None:
+            handler(char, rx_bytes)
 
     def _on_notify_channel_data(self, char: Any, rx_bytes: bytearray) -> None:
         """Callback for received BLE notifications. Reassembles multi-channel packets."""
@@ -1487,8 +1518,9 @@ class OmronDeviceSession:
         # a security request trigger can establish encrypted notify reliably.
         try:
             await self._client.start_notify(
-                self._config.rx_channel_uuids[0], lambda _h, _d: None
+                self._config.rx_channel_uuids[0], self._rx_dispatch
             )
+            self._primed_notify_uuids.add(self._config.rx_channel_uuids[0])
             rx_notify_primed = True
             await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
         except Exception as exc:
@@ -1592,8 +1624,9 @@ class OmronDeviceSession:
             nonlocal rx_notify_primed
             try:
                 await self._client.start_notify(
-                    self._config.rx_channel_uuids[0], lambda _h, _d: None
+                    self._config.rx_channel_uuids[0], self._rx_dispatch
                 )
+                self._primed_notify_uuids.add(self._config.rx_channel_uuids[0])
                 rx_notify_primed = True
                 await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
             except Exception as exc:
@@ -1667,6 +1700,7 @@ class OmronDeviceSession:
                         await self._client.stop_notify(self._config.rx_channel_uuids[0])
                     except Exception as exc:
                         _LOGGER.debug("token unlock RX pre-notify stop skipped: %s", exc)
+                    self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
                 self._debug_ble_link("token_unlock_after_stop_notify")
 
     async def _secure_unlock(self) -> None:
@@ -1774,6 +1808,10 @@ class OmronDeviceSession:
             # Wait for Encryption Response
             await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
             enc_resp = response_holder[0]
+            # Timed from here, not from where the request is built: the gap
+            # that matters is the one the capture shows at 12 ms, between the
+            # device's 0xf0 85 landing and our 0x70 06 going out.
+            enc_resp_at = time.monotonic()
             _LOGGER.debug("Received Encryption Response (len=%d): %s", len(enc_resp) if enc_resp else 0, enc_resp.hex() if enc_resp else "None")
             if not enc_resp:
                 raise ConnectionError("Empty encryption response")
@@ -1797,20 +1835,39 @@ class OmronDeviceSession:
             # 0xf0 85 and 0x70 06 but 12 ms, and the same ATT opcode we use.
             # So log what the capture cannot supply — how long we took, and
             # whether the link was still up when we wrote.
-            enc_resp_at = time.monotonic()
             challenge_req = self._secure_session.build_challenge_req(enc_resp)
             _LOGGER.debug(
-                "Sending Challenge Request (len=%d, %.0f ms after the "
-                "encryption response, is_connected=%s, via %s): %s",
+                "Sending Challenge Request (len=%d, is_connected=%s, via %s): %s",
                 len(challenge_req),
-                (time.monotonic() - enc_resp_at) * 1000,
                 getattr(self._client, "is_connected", "?"),
                 _connected_path(self._client, self._ble_device),
                 challenge_req.hex(),
             )
             unlock_event.clear()
             response_holder[0] = None
-            await self._client.write_gatt_char(self._config.unlock_uuid, challenge_req, response=True)
+            try:
+                await self._client.write_gatt_char(
+                    self._config.unlock_uuid, challenge_req, response=True
+                )
+            except Exception as exc:
+                # The span the reference capture puts at 12 ms, measured to
+                # the point the write actually failed — plus the link state
+                # then, since a GATT 133 here reads the same whether the cuff
+                # hung up on our ciphertext or the transport dropped out.
+                _LOGGER.warning(
+                    "Challenge Request write failed %.0f ms after the "
+                    "encryption response (capture does this in ~12 ms); "
+                    "is_connected=%s via %s: %s",
+                    (time.monotonic() - enc_resp_at) * 1000,
+                    getattr(self._client, "is_connected", "?"),
+                    _connected_path(self._client, self._ble_device),
+                    exc,
+                )
+                raise
+            _LOGGER.debug(
+                "Challenge Request written %.0f ms after the encryption response",
+                (time.monotonic() - enc_resp_at) * 1000,
+            )
 
             # Wait for Challenge Response
             await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
@@ -1884,6 +1941,7 @@ class OmronDeviceSession:
                     await self._client.stop_notify(self._config.rx_channel_uuids[0])
                 except Exception as exc:
                     _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
+                self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
 
     def _secure_frames_active(self) -> bool:
         """Whether this session's frames are encrypted right now."""

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -100,6 +100,31 @@ def _connection_source(ble_device: BLEDevice) -> str:
     return "unknown"
 
 
+def _connected_path(client: BleakClient, ble_device: BLEDevice) -> str:
+    """Best-effort identity of the link a connection actually went over.
+
+    ``_connection_source`` reads the BLEDevice, which names the scanner that
+    saw the *advertisement* — not necessarily the path the connection took.
+    habluetooth picks that at connect time from whichever proxy scores best,
+    so on a multi-proxy setup two writes in one session can be reported
+    against different radios. Issue #92 has three proxies, two of them
+    devices with another job, which is one candidate for the GATT error that
+    breaks the challenge write.
+
+    Probes the backend because that is the only place the answer exists, and
+    falls back to the advertised source when it does not — the shapes here
+    are private to bleak and bleak-esphome and may change.
+    """
+    backend = getattr(client, "_backend", None)
+    if backend is not None:
+        for attr in ("_source", "source"):
+            if value := getattr(backend, attr, None):
+                return str(value)
+        if path := getattr(backend, "_device_path", None):
+            return str(path)
+    return _connection_source(ble_device)
+
+
 async def _connect_once(
     ble_device: BLEDevice, name: str, *, pair: bool
 ) -> BleakClient:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1023,6 +1023,23 @@ class OmronDeviceSession:
         self._reply_ready.clear()
         self._debug_ble_link("reset_session_state")
 
+    async def _release_primed_rx(self, context: str) -> None:
+        """Drop the primed RX subscription and forget it, together.
+
+        The record and the CCCD have to move as one. If the set still claims a
+        channel is subscribed after the CCCD went down,
+        ``_subscribe_notify_channels`` skips ``start_notify`` for it and the
+        memory session listens on a descriptor nobody enabled — which is what
+        every CLASSIC_KEY profile got when only two of the three release paths
+        remembered to discard.
+        """
+        uuid = self._config.rx_channel_uuids[0]
+        try:
+            await self._client.stop_notify(uuid)
+        except Exception as exc:
+            _LOGGER.debug("%s RX pre-notify stop skipped: %s", context, exc)
+        self._primed_notify_uuids.discard(uuid)
+
     def _rx_dispatch(self, char: Any, rx_bytes: bytearray) -> None:
         """Fixed RX callback; the real handler is swapped in behind it."""
         handler = self._rx_notify_handler
@@ -1556,10 +1573,7 @@ class OmronDeviceSession:
         finally:
             await self._client.stop_notify(self._config.unlock_uuid)
             if rx_notify_primed:
-                try:
-                    await self._client.stop_notify(self._config.rx_channel_uuids[0])
-                except Exception as exc:
-                    _LOGGER.debug("unlock RX pre-notify stop skipped: %s", exc)
+                await self._release_primed_rx("unlock")
             self._debug_ble_link("unlock_after_stop_notify")
 
     async def _token_unlock(self, *, keep_notify: bool = False) -> None:
@@ -1696,11 +1710,7 @@ class OmronDeviceSession:
                 except Exception as exc:
                     _LOGGER.debug("token unlock stop_notify skipped: %s", exc)
                 if rx_notify_primed:
-                    try:
-                        await self._client.stop_notify(self._config.rx_channel_uuids[0])
-                    except Exception as exc:
-                        _LOGGER.debug("token unlock RX pre-notify stop skipped: %s", exc)
-                    self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
+                    await self._release_primed_rx("token unlock")
                 self._debug_ble_link("token_unlock_after_stop_notify")
 
     async def _secure_unlock(self) -> None:
@@ -1937,11 +1947,7 @@ class OmronDeviceSession:
                 # _token_unlock(keep_notify=True) left the RX-channel CCCD
                 # enabled for us; release it here so it doesn't outlive a
                 # handshake that failed.
-                try:
-                    await self._client.stop_notify(self._config.rx_channel_uuids[0])
-                except Exception as exc:
-                    _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
-                self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
+                await self._release_primed_rx("secure unlock")
 
     def _secure_frames_active(self) -> bool:
         """Whether this session's frames are encrypted right now."""
@@ -2150,6 +2156,7 @@ class OmronDeviceSession:
             await asyncio.sleep(_PAIRING_SETTLE_DEFAULT_SEC)
 
         if not entered_programming:
+            self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
             try:
                 await self._client.stop_notify(self._config.unlock_uuid)
                 await self._client.stop_notify(self._config.rx_channel_uuids[0])
@@ -2187,6 +2194,7 @@ class OmronDeviceSession:
             pass
 
         resp = response_holder[0]
+        self._primed_notify_uuids.discard(self._config.rx_channel_uuids[0])
         try:
             await self._client.stop_notify(self._config.unlock_uuid)
             await self._client.stop_notify(self._config.rx_channel_uuids[0])

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -613,7 +613,10 @@ class OmronDeviceSession:
 
     @classmethod
     def adopt(
-        cls, client: BleakClient, device_config: DeviceConfig
+        cls,
+        client: BleakClient,
+        device_config: DeviceConfig,
+        secure_bond_store: SecureBondStore | None = None,
     ) -> "OmronDeviceSession":
         """Wrap an already-open client to run ops over a connection owned elsewhere.
 
@@ -622,7 +625,11 @@ class OmronDeviceSession:
         session = cls.__new__(cls)
         session._ble_device = getattr(client, "_device", None)
         session._config = device_config
-        session._secure_bond_store = SecureBondStore()
+        # Without the caller's store an adopted session has no key, so it
+        # would open with a pairing request — the one thing a cuff outside
+        # pairing mode refuses. See setup_time_sync, which adopts a client
+        # and then unlocks.
+        session._secure_bond_store = secure_bond_store or SecureBondStore()
         session._init_session_state(client=client, owns_connection=False)
         return session
 
@@ -1632,6 +1639,11 @@ class OmronDeviceSession:
         # btsnoop: the first runs 0x70 0x01 in pairing mode, every later one
         # opens at 0x70 0x05 — which is the only thing a cuff outside pairing
         # mode will answer.
+        # Set only when the cuff answers a secure stage with an error frame.
+        # A key that cost a -P- press must not be thrown away because the
+        # token prelude timed out or the link blinked — those retry fine with
+        # the same key, and discarding forces the user back to the device.
+        key_was_rejected = False
         stored_key = self._secure_bond_store.load()
         self._secure_session = SecureSession(stored_ltk=stored_key)
         reconnecting = stored_key is not None
@@ -1726,6 +1738,7 @@ class OmronDeviceSession:
                 raise ConnectionError("Empty encryption response")
             err = _secure_error_frame_code(enc_resp)
             if err is not None:
+                key_was_rejected = True
                 raise ConnectionError(
                     f"Device rejected encryption start (error frame 0x{enc_resp[0]:02x}, "
                     f"code 0x{err:02x})"
@@ -1748,6 +1761,7 @@ class OmronDeviceSession:
                 raise ConnectionError("Empty challenge response")
             err = _secure_error_frame_code(challenge_resp)
             if err is not None:
+                key_was_rejected = True
                 raise ConnectionError(
                     f"Device rejected challenge (error frame 0x{challenge_resp[0]:02x}, "
                     f"code 0x{err:02x})"
@@ -1762,12 +1776,10 @@ class OmronDeviceSession:
 
         except asyncio.TimeoutError as exc:
             _LOGGER.error("Secure handshake timed out during negotiation")
-            if reconnecting:
-                await self._discard_secure_bond("the handshake timed out")
             raise ConnectionError("Secure unlock timeout") from exc
         except Exception as exc:
             _LOGGER.error("Secure handshake failed: %s", exc)
-            if reconnecting:
+            if reconnecting and key_was_rejected:
                 await self._discard_secure_bond(str(exc))
             raise ConnectionError(f"Secure unlock failed: {exc}") from exc
         finally:

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -37,6 +37,7 @@ from .const import (
 )
 from .setup import async_sync_device_time, async_sync_eeprom_time
 from .devices import HostPairingMode, DeviceConfig, get_device_config, resolve_profile_model_id
+from .secure_store import SecureBondStore
 from .omron_driver import (
     OmronDeviceSession,
     OmronDeviceDriver,
@@ -67,8 +68,14 @@ class OmronBluetoothDeviceData(BluetoothData):
         self,
         device_model: str = DEFAULT_DEVICE_MODEL,
         user_aliases: dict[int, str] | None = None,
+        secure_bond_store: SecureBondStore | None = None,
     ) -> None:
         super().__init__()
+        # Handed to every session so the application-layer bond outlives the
+        # link. The default keeps the key for the lifetime of this object,
+        # which is enough for the config flow and for tests; the integration
+        # supplies one backed by the config entry.
+        self._secure_bond_store = secure_bond_store or SecureBondStore()
         self.last_service_info: BluetoothServiceInfoBleak | None = None
         self.pending = True
         self._device_model = device_model
@@ -1108,7 +1115,11 @@ class OmronBluetoothDeviceData(BluetoothData):
                         )
                         preconnected_session.reclaim_ownership()
                         await preconnected_session.aclose()
-                    session = OmronDeviceSession(ble_device, self._device_config)
+                    session = OmronDeviceSession(
+                        ble_device,
+                        self._device_config,
+                        self._secure_bond_store,
+                    )
                 async with session:
                     client = session.client
 
@@ -1296,7 +1307,9 @@ class OmronBluetoothDeviceData(BluetoothData):
         ``async_poll`` adopts this link instead of opening a new one; a caller
         that does not park it still owns the link and must close it.
         """
-        session = OmronDeviceSession(ble_device, self._device_config)
+        session = OmronDeviceSession(
+            ble_device, self._device_config, self._secure_bond_store
+        )
         try:
             await session.connect()
             if not await session.verify_parent_service():
@@ -1333,7 +1346,9 @@ class OmronBluetoothDeviceData(BluetoothData):
 
     async def async_sync_time(self, ble_device: BLEDevice) -> None:
         """Connect to the device and synchronize time only."""
-        async with OmronDeviceSession(ble_device, self._device_config) as session:
+        async with OmronDeviceSession(
+            ble_device, self._device_config, self._secure_bond_store
+        ) as session:
             await self._async_sync_current_time_with_client(
                 session.client, ble_device.address, session
             )

--- a/custom_components/omron/omron_ble/secure_session.py
+++ b/custom_components/omron/omron_ble/secure_session.py
@@ -106,6 +106,16 @@ class SecureSession:
         c.update(message)
         return c.finalize()
 
+    @property
+    def is_encrypting(self) -> bool:
+        """Whether frames should go through this session.
+
+        Presence is not the same as readiness: a handshake that got partway
+        and failed leaves an object behind that raises on encrypt. Callers
+        should ask this, not ``is not None``.
+        """
+        return self.state == self.STATE_PAIRED
+
     # -- Stage 1: Pairing Request (cmd 0x01) --
     def build_pair_req(self) -> bytes:
         """Build a 89-byte Pairing Request.

--- a/custom_components/omron/omron_ble/secure_store.py
+++ b/custom_components/omron/omron_ble/secure_store.py
@@ -1,0 +1,56 @@
+"""Persistence for the application-layer bond key.
+
+The modern-stack cuffs keep a bond of their own, above SMP. A phone btsnoop
+of a HEM-7188T1-LEO shows the official app running the ECDH pairing
+(``0x70 0x01``) exactly once, when the cuff is in pairing mode, and every
+later session skipping straight to ``0x70 0x05`` with the key it derived
+then. That key is what makes the host a registered one; without it the only
+thing a reconnect can do is ask to pair again, which the cuff refuses outside
+pairing mode.
+
+Nothing here touches Home Assistant: the driver takes a store, and the
+integration layer supplies one backed by the config entry.
+"""
+
+from __future__ import annotations
+
+import logging
+
+_LOGGER = logging.getLogger(__name__)
+
+# 16-byte LTK, or the 80-byte extended token some firmware returns.
+VALID_KEY_LENGTHS = (16, 80)
+
+
+class SecureBondStore:
+    """In-memory bond key for one device.
+
+    Also the base class for persistent stores, and the whole implementation
+    for the config flow — pairing happens before a config entry exists, so
+    the flow keeps the key here and writes it into the entry it creates.
+    """
+
+    def __init__(self, key: bytes | None = None) -> None:
+        self._key = key
+
+    def load(self) -> bytes | None:
+        """Return the stored key, or None when this host is not bonded yet."""
+        return self._key
+
+    async def save(self, key: bytes) -> None:
+        """Record a key derived by a successful pairing."""
+        if len(key) not in VALID_KEY_LENGTHS:
+            raise ValueError(
+                f"Secure bond key must be one of {VALID_KEY_LENGTHS} bytes, "
+                f"got {len(key)}"
+            )
+        self._key = bytes(key)
+
+    async def clear(self) -> None:
+        """Forget the key, so the next session pairs from scratch.
+
+        Called when the device rejects it: a key the cuff no longer honours
+        is worse than none, because it sends every reconnect down the
+        encryption path instead of letting one pairing-mode session fix it.
+        """
+        self._key = None

--- a/custom_components/omron/omron_ble/setup_time_sync.py
+++ b/custom_components/omron/omron_ble/setup_time_sync.py
@@ -198,12 +198,16 @@ async def _sync_eeprom_with_session(
     transport: OmronDeviceSession | None,
     *,
     leave_memory_session_open: bool = False,
+    secure_bond_store: SecureBondStore | None = None,
 ) -> bool:
     """EEPROM time sync, opening a memory session when one is not already held."""
     if not config.supports_eeprom_time_sync:
         return False
     if transport is None:
-        transport = OmronDeviceSession.adopt(client, config)
+        # No store here means no key, and an unlock that opens with a
+        # pairing request the cuff will refuse. Callers that already
+        # hold a session should pass it instead of letting this adopt.
+        transport = OmronDeviceSession.adopt(client, config, secure_bond_store)
     if transport.memory_session_active:
         return await _sync_time_via_eeprom(client, model, config, transport)
     if leave_memory_session_open:
@@ -219,6 +223,7 @@ async def async_sync_eeprom_time(
     model: str,
     config: DeviceConfig | None = None,
     transport: OmronDeviceSession | None = None,
+    secure_bond_store: SecureBondStore | None = None,
 ) -> bool:
     """EEPROM-only time sync (uses or opens a memory readout session)."""
     if not client.is_connected:
@@ -229,7 +234,9 @@ async def async_sync_eeprom_time(
         return False
     if config is None:
         config = get_device_config(model)
-    return await _sync_eeprom_with_session(client, model, config, transport)
+    return await _sync_eeprom_with_session(
+        client, model, config, transport, secure_bond_store=secure_bond_store
+    )
 
 
 async def async_sync_device_time(
@@ -239,6 +246,7 @@ async def async_sync_device_time(
     transport: OmronDeviceSession | None = None,
     *,
     leave_memory_session_open: bool = False,
+    secure_bond_store: SecureBondStore | None = None,
 ) -> bool:
     """Sync current local time via EEPROM (memory session) then CTS.
 
@@ -263,6 +271,7 @@ async def async_sync_device_time(
         eeprom_success = await _sync_eeprom_with_session(
             client, model, config, transport,
             leave_memory_session_open=leave_memory_session_open,
+            secure_bond_store=secure_bond_store,
         )
         if eeprom_success:
             return True

--- a/custom_components/omron/omron_ble/setup_time_sync.py
+++ b/custom_components/omron/omron_ble/setup_time_sync.py
@@ -12,6 +12,7 @@ from bleak import BleakClient
 from .const import CTS_CHARACTERISTIC_UUID, LOCAL_TIME_INFO_UUID
 from .devices import get_device_config
 from .omron_driver import OmronDeviceDriver, OmronDeviceSession, _bleak_refresh_services
+from .secure_store import SecureBondStore
 
 if TYPE_CHECKING:
     from .devices import DeviceConfig
@@ -282,6 +283,7 @@ async def async_sync_device_time(
         eeprom_success = await _sync_eeprom_with_session(
             client, model, config, transport,
             leave_memory_session_open=leave_memory_session_open,
+            secure_bond_store=secure_bond_store,
         )
 
     if not config.supports_eeprom_time_sync and not cts_success:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,9 @@ sys.modules["homeassistant.const"] = MagicMock()
 sys.modules["homeassistant.core"] = MagicMock()
 sys.modules["homeassistant.helpers"] = MagicMock()
 sys.modules["homeassistant.helpers.device_registry"] = MagicMock()
+# Store backs the secure bond key; the driver never touches it, but
+# custom_components.omron imports it at module level.
+sys.modules["homeassistant.helpers.storage"] = MagicMock()
 sys.modules["homeassistant.util"] = MagicMock()
 sys.modules["homeassistant.util.dt"] = MagicMock()
 

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -139,7 +139,17 @@ class TestCatalogResolution:
         assert resolve_profile_model_id("HEM-7183T1_FLIN") == "HEM-7188T1"
         cfg = get_device_config("HEM-7188T1-LEO")
         assert cfg.model == "HEM-7188T1-LEO"
-        assert cfg.unlock_mode.value == "token_key"
+        # Secure session, not the plaintext token path. A phone btsnoop of a
+        # real HEM-7188T1-LEO (issue #92) shows the official app pairing with
+        # 0x70 0x01 and then carrying every reading over encrypted 0xc0
+        # frames; the token handshake only opens that exchange. The earlier
+        # reading — that the device rejects ECDH with 0xff26 — was our own
+        # unstored key sending each session back to a pairing request the
+        # cuff only answers in -P- mode.
+        assert cfg.unlock_mode.value == "secure_session"
+        # The plaintext path stays reachable as a fallback until real
+        # hardware confirms the secure one end to end.
+        assert cfg.token_key_fallback is True
         assert cfg.connect_type == ConnectType.WLD4_0
         assert cfg.user_start_addresses == [0x01C4]
         assert cfg.per_user_records_count == [30]

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -1,0 +1,196 @@
+"""앱 레이어 본드 키 영속화 회귀 테스트.
+
+실기기 btsnoop(이슈 #92, HEM-7188T1-LEO)이 보여주는 공식 앱의 동작:
+
+    세션 1 (페어링 모드): 0x11/0x91 → 0x70 01 → 0xf0 81 → 0x70 05 → 0xf0 85
+                                    → 0x70 06 → 0xf0 86 → 암호화된 0xc0 데이터
+    세션 2 (재연결):      0x11/0x91 →           0x70 05 → 0xf0 85
+                                    → 0x70 06 → 0xf0 86 → 암호화된 0xc0 데이터
+
+두 번째 세션에 ``0x70 01`` 이 없다. 페어링이 만들어낸 키를 들고 있으니 다시
+페어링할 이유가 없고, 애초에 -P- 모드가 아닌 커프는 그 요청을 받아주지 않는다.
+
+``SecureSession`` 은 처음부터 ``stored_ltk`` 로 재연결 모드를 지원했지만, 키를
+어디에도 저장하지 않아 매 세션이 ``is_bonding=True`` 로 시작했다 — 즉 항상
+페어링을 요청했고, -P- 창 밖에서는 ``0xff26`` 을 받았다. 그게 "이 기기는 ECDH
+를 거부한다" 로 읽혔다.
+"""
+import asyncio
+
+import pytest
+
+from custom_components.omron.omron_ble.secure_store import (
+    VALID_KEY_LENGTHS,
+    SecureBondStore,
+)
+from custom_components.omron.omron_ble.secure_session import SecureSession
+
+
+LTK = bytes(range(16))
+
+
+# ── 저장소 ────────────────────────────────────────────────────────────────
+
+def test_store_starts_empty_so_the_first_session_pairs():
+    assert SecureBondStore().load() is None
+
+
+def test_store_round_trips_a_key():
+    store = SecureBondStore()
+    asyncio.run(store.save(LTK))
+    assert store.load() == LTK
+
+
+def test_store_clears_so_a_rejected_key_cannot_lock_us_out():
+    """거부된 키를 계속 들고 있으면 영영 페어링으로 못 돌아간다.
+
+    페어링은 키가 없을 때만 일어나므로, 나쁜 키는 그것을 고칠 수 있는 유일한
+    세션을 막아버린다.
+    """
+    store = SecureBondStore(LTK)
+    asyncio.run(store.clear())
+    assert store.load() is None
+
+
+@pytest.mark.parametrize("length", [0, 8, 15, 17, 79, 81])
+def test_store_rejects_keys_of_the_wrong_size(length):
+    """잘못된 길이를 저장하면 재연결 때 조용히 깨진다 — 그때는 원인이 안 보인다."""
+    with pytest.raises(ValueError):
+        asyncio.run(SecureBondStore().save(bytes(length)))
+
+
+@pytest.mark.parametrize("length", VALID_KEY_LENGTHS)
+def test_store_accepts_both_key_forms(length):
+    """16B LTK 와 일부 펌웨어가 주는 80B 확장 토큰 둘 다."""
+    store = SecureBondStore()
+    asyncio.run(store.save(bytes(length)))
+    assert store.load() == bytes(length)
+
+
+# ── 세션 모드 ─────────────────────────────────────────────────────────────
+
+def test_no_stored_key_means_pairing_mode():
+    assert SecureSession().is_bonding is True
+
+
+def test_stored_key_means_reconnect_mode():
+    """재연결 모드는 ``0x70 01`` 을 거부해야 한다 — 그게 이 변경의 핵심이다."""
+    session = SecureSession(stored_ltk=LTK)
+
+    assert session.is_bonding is False
+    assert session.ltk == LTK
+    with pytest.raises(RuntimeError, match="reconnect mode"):
+        session.build_pair_req()
+
+
+def test_reconnect_opens_at_0x7005_with_the_stored_key():
+    """저장된 키로 시작하는 세션은 곧바로 Start Encryption 을 만든다.
+
+    캡처의 두 번째 세션이 정확히 이 프레임으로 열린다.
+    """
+    pytest.importorskip("cryptography")
+    session = SecureSession(stored_ltk=LTK)
+
+    frame = session.build_start_enc_req()
+
+    assert frame[:2] == b"\x70\x05"
+    assert len(frame) == 46          # 캡처된 0x7005 프레임과 같은 길이
+    assert session.ltk == LTK, "재연결이 저장된 키를 새로 유도해서는 안 된다"
+
+
+def test_pairing_derives_a_storable_key():
+    """페어링 요청은 캡처와 같은 89바이트 레이아웃이어야 한다."""
+    pytest.importorskip("cryptography")
+    session = SecureSession()
+
+    req = session.build_pair_req()
+
+    assert req[:2] == b"\x70\x01"
+    assert len(req) == 89            # 2 + salt(7) + challenge(16) + pubkey(64)
+
+
+# ── 배선 ──────────────────────────────────────────────────────────────────
+
+def test_session_and_parser_hand_the_store_down():
+    """키는 링크보다 오래 살아야 한다 — 세션마다 새로 만들면 의미가 없다."""
+    from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+
+    store = SecureBondStore(LTK)
+    session = OmronDeviceSession(object(), _config(), store)
+    assert session._secure_bond_store is store
+
+    # 파서는 conftest 가 MagicMock 베이스로 대체해서 인스턴스 속성을 확인할 수
+    # 없으므로 배선 자체를 본다. 이 줄이 빠지면 폴마다 새 키로 시작한다.
+    parser = _parser_source()
+    assert "secure_bond_store or SecureBondStore()" in parser
+    # 대입 1회 + 세션 생성 3곳.
+    assert parser.count("self._secure_bond_store") == 4, (
+        "세 곳의 세션 생성 모두가 저장소를 넘겨야 한다"
+    )
+    assert "secure_bond_store or SecureBondStore()" in _driver_source()
+
+
+def test_driver_only_pairs_when_there_is_no_stored_key():
+    """재연결에서 ``0x70 01`` 을 보내면 -P- 창 밖이라 거부당한다."""
+    source = _driver_source()
+    body = source[source.index("async def _secure_unlock") :]
+    body = body[: body.index("\n    async def _discard_secure_bond")]
+
+    guard = body.index("if not reconnecting:")
+    assert guard < body.index("build_pair_req()"), (
+        "페어링 요청이 재연결 가드 밖에 있다"
+    )
+    assert "SecureSession(stored_ltk=stored_key)" in body
+
+
+def test_driver_stores_the_key_pairing_produced():
+    source = _driver_source()
+    body = source[source.index("async def _secure_unlock") :]
+    body = body[: body.index("\n    async def _discard_secure_bond")]
+
+    save = body.index("self._secure_bond_store.save(derived)")
+    # 나머지 단계가 실패해도 키는 남아야 한다: 커프는 -P- 를 다시 누르기
+    # 전까지 같은 페어링을 두 번 내주지 않는다.
+    assert save < body.index("# Step 2: Send Encryption Start Request")
+
+
+def test_driver_discards_a_key_the_cuff_refused():
+    source = _driver_source()
+    body = source[source.index("async def _secure_unlock") :]
+    body = body[: body.index("\n    async def _discard_secure_bond")]
+
+    assert body.count("await self._discard_secure_bond(") == 2, (
+        "타임아웃과 그 밖의 실패 모두에서 상한 키를 버려야 한다"
+    )
+    assert "if reconnecting:" in body
+
+
+def test_secure_failure_falls_back_to_the_token_path():
+    """새로 배선한 경로가 실패해도 오늘 되던 읽기까지 잃지는 않는다."""
+    source = _driver_source()
+    body = source[source.index("async def unlock(self, key") :]
+    body = body[: body.index("\n    async def ")]
+
+    assert "if not self._config.token_key_fallback:" in body
+    assert "raise" in body
+    assert "await self._token_unlock()" in body
+
+
+def _config():
+    from custom_components.omron.omron_ble.devices import get_device_config
+
+    return get_device_config("HEM-7188T1")
+
+
+def _driver_source():
+    import pathlib
+
+    return pathlib.Path(
+        "custom_components/omron/omron_ble/omron_driver.py"
+    ).read_text()
+
+
+def _parser_source():
+    import pathlib
+
+    return pathlib.Path("custom_components/omron/omron_ble/parser.py").read_text()

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -153,15 +153,21 @@ def test_driver_only_pairs_when_there_is_no_stored_key():
     assert "SecureSession(stored_ltk=stored_key)" in body
 
 
-def test_driver_stores_the_key_pairing_produced():
-    source = _driver_source()
-    body = source[source.index("async def _secure_unlock") :]
-    body = body[: body.index("\n    async def _discard_secure_bond")]
+def test_driver_stores_the_key_only_once_the_handshake_completes():
+    """핸드셰이크가 끝난 뒤에 저장해야 한다.
+
+    초안은 키 교환 직후에 저장했다. "뒤에서 실패해도 -P- 를 낭비하지 말자"는
+    의도였는데, 실기기 로그(이슈 #92)가 반대를 보여준다: 키를 받고 0x70 06 에서
+    깨진 실행은 커프가 커밋하지 않은 LTK 를 우리만 들고 있게 만들었고, 다음
+    세션이 재연결로 열려 거부당하고 키를 버렸다 — -P- 는 결국 낭비됐다.
+    커프는 0xf0 86 에서 커밋하는 것으로 보인다.
+    """
+    body = _method_body(_driver_source(), "_secure_unlock")
 
     save = body.index("self._secure_bond_store.save(derived)")
-    # 나머지 단계가 실패해도 키는 남아야 한다: 커프는 -P- 를 다시 누르기
-    # 전까지 같은 페어링을 두 번 내주지 않는다.
-    assert save < body.index("# Step 2: Send Encryption Start Request")
+    assert save > body.index("process_challenge_resp(challenge_resp)")
+    # 재연결에는 저장할 새 키가 없다.
+    assert "if not reconnecting:" in body[body.index("self._unlocked = True") : save]
 
 
 def test_driver_discards_a_key_the_cuff_refused():
@@ -205,6 +211,21 @@ def test_secure_failure_falls_back_to_the_token_path():
     assert "raise" in body
     assert "await self._token_unlock()" in body
 
+
+
+def _method_body(source: str, name: str) -> str:
+    """``source`` 에서 메서드 하나의 본문만 잘라낸다.
+
+    문자열 인덱스로 대충 자르면 다음 메서드까지 딸려 들어와 단언이 엉뚱한
+    코드를 보게 된다.
+    """
+    import re
+
+    start = re.search(rf"\n    (?:async )?def {name}\(", source)
+    assert start, name
+    rest = source[start.end() :]
+    end = re.search(r"\n    (?:async )?def ", rest)
+    return rest[: end.start()] if end else rest
 
 def _config():
     from custom_components.omron.omron_ble.devices import get_device_config
@@ -383,3 +404,40 @@ def test_fallback_drops_the_failed_session():
 
     drop = body.index("self._secure_session = None")
     assert drop < body.index("await self._token_unlock()")
+
+
+def test_successful_handshake_keeps_its_subscriptions():
+    """성공한 핸드셰이크의 구독을 끄면 암호화 세션이 귀머거리가 된다.
+
+    캡처에서 앱은 구독을 한 번도 놓지 않고, 암호화 0xc0 프레임을 바로 그
+    언락 특성(handle 0x001b)에 쓴다. 성공 경로에서 stop_notify 하면 방금
+    언락한 세션이 응답을 못 듣는다. 실패 경로는 종전대로 정리한다.
+    """
+    body = _method_body(_driver_source(), "_secure_unlock")
+
+    finally_at = body.rindex("finally:")
+    tail = body[finally_at:]
+    assert "if self._unlocked:" in tail, "성공/실패를 갈라야 한다"
+    success, failure = tail.split("else:", 1)
+    # 실제 호출만 센다 — 로그 문자열에도 이름이 들어 있다.
+    assert "await self._client.stop_notify(" not in success
+    assert failure.count("await self._client.stop_notify(") == 2
+
+
+def test_challenge_request_logs_what_the_capture_cannot():
+    """133 은 캡처가 설명하지 못한다 — 우리 쪽 값만이라도 남긴다.
+
+    캡처는 0xf0 85 와 0x70 06 사이에 12ms 말고 아무것도 없고, ATT opcode 도
+    우리와 같은 Write Request 다. 그래서 추측을 코드에 넣는 대신 경과 시간과
+    링크 상태, 실제 연결 경로를 로그로 남긴다.
+    """
+    body = _method_body(_driver_source(), "_secure_unlock")
+
+    log = body.index("Sending Challenge Request")
+    assert "ms after the" in body[log : log + 400]
+    assert "is_connected=%s" in body[log : log + 400]
+    assert "_connected_path(" in body[log : log + 600]
+    # 캡처에 없는 동작은 넣지 않는다.
+    between = body[body.index("build_challenge_req(enc_resp)") : body.index("write_gatt_char(self._config.unlock_uuid, challenge_req")]
+    assert "start_notify" not in between
+    assert "asyncio.sleep" not in between

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -344,3 +344,42 @@ def test_secure_family_subscribes_the_unlock_cccd_first():
     assert secure.index("_subscribe_unlock()") < secure.index("_prime_rx()")
     # 나머지: RX 먼저 (7155T-ESLI/7142T2 캡처 그대로)
     assert other.index("_prime_rx()") < other.index("_subscribe_unlock()")
+
+
+# ── 폴백이 세션을 무너뜨리면 안 된다 ───────────────────────────────────────
+
+def test_a_half_built_session_does_not_encrypt():
+    """실패한 핸드셰이크가 남긴 객체로 암호화하면 예외가 난다.
+
+    실기기 로그(이슈 #92, 2.8.0-beta.1): secure 가 거부돼 평문으로 폴백하고
+    토큰 언락까지 성공했는데, 그 다음 명령이 남아 있던 세션으로 암호화를
+    시도해 ``encrypt is only valid in PAIRED state`` 로 세션 전체가 죽었다.
+    폴백이 지키려던 그 읽기가 크래시로 바뀐 것이다.
+    """
+    pytest.importorskip("cryptography")
+    session = SecureSession()
+
+    assert session.is_encrypting is False       # IDLE
+    session.build_pair_req()
+    assert session.is_encrypting is False       # PAIR_REQ_SENT — 아직 아니다
+
+
+def test_driver_asks_the_state_not_the_object():
+    """``is not None`` 은 준비됐다는 뜻이 아니다."""
+    source = _driver_source()
+
+    assert source.count("if self._secure_frames_active():") == 2, (
+        "암복호화 두 곳 모두 상태를 물어야 한다"
+    )
+    assert "session is not None and session.is_encrypting" in source
+    assert "self._secure_session is not None:" not in source
+
+
+def test_fallback_drops_the_failed_session():
+    """폴백 전에 세션을 버려야 프레임이 평문으로 나간다."""
+    source = _driver_source()
+    body = source[source.index("async def unlock(self, key") :]
+    body = body[: body.index("\n    async def ")]
+
+    drop = body.index("self._secure_session = None")
+    assert drop < body.index("await self._token_unlock()")

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -579,3 +579,65 @@ def test_rx_dispatcher_routes_only_when_a_handler_is_set():
     session._rx_notify_handler = lambda _c, data: seen.append(bytes(data))
     session._rx_dispatch(None, bytearray(b"\x03\x04"))
     assert seen == [b"\x03\x04"]
+
+
+# ── 실기기 프레임 리플레이 ─────────────────────────────────────────────────
+#
+# #92 btsnoop 세션1 에서 실제 HEM-7188T1-LEO 가 보낸 응답들. 하드웨어 없이
+# 핸드셰이크 전체를 돌려볼 수 있는 유일한 방법이고, 지금까지 실기기에서
+# 0x70 01 너머로 가 본 적이 없는 코드 경로다.
+DEVICE_F081 = bytes.fromhex(
+    "f08160db277084c587e475a1980e50905a90cecec57d7ad65b0f36f3d20cda2c"
+    "13648febf4dd21ca6009ec10096ce9df055774efb44643aba442c849c0607ab5"
+    "039330894760c12afa68f838182197f3dca2a0e7a099752628"
+)
+DEVICE_F085 = bytes.fromhex(
+    "f085beb82b482e9c9415e1f92029f8d045df72ab444be20fba013e3f71fac144"
+    "0a27696600000000000000000000"
+)
+DEVICE_F086 = bytes.fromhex(
+    "f086b78e89826c9d63c9c8a9ae390e3405d2fe3180c0f1982bb8f3d855258007"
+    "cacf512c7a9b7e2dbc7c6aa8aba7"
+)
+
+
+def test_handshake_replays_against_real_device_frames():
+    """실기기가 보낸 응답을 그대로 먹여 핸드셰이크를 끝까지 돌린다.
+
+    폰의 개인키가 없으니 마지막 인증은 통과할 수 없다. 확인하는 것은 그게
+    아니라, 우리 구현이 **실제 기기 프레임을 파싱하고 올바른 모양의 요청을
+    만들어내는가** 다. 특히 4단계 — 현장에서 GATT 133 이 나는 그 0x70 06 —
+    까지 도달하는지.
+    """
+    pytest.importorskip("cryptography")
+    session = SecureSession()
+
+    req = session.build_pair_req()
+    assert (req[:2], len(req)) == (b"\x70\x01", 89)
+
+    # 기기의 공개키·챌린지·솔트를 실제 바이트로 처리한다.
+    session.process_pair_resp(DEVICE_F081)
+    assert session.ltk is not None and len(session.ltk) == 16
+
+    enc = session.build_start_enc_req()
+    assert (enc[:2], len(enc)) == (b"\x70\x05", 46)
+
+    # 기기의 0xf0 85 에서 챌린지와 nonce 를 뽑아 CCM 으로 감싼다.
+    challenge = session.build_challenge_req(DEVICE_F085)
+    assert (challenge[:2], len(challenge)) == (b"\x70\x06", 46)
+
+
+def test_replay_rejects_the_peer_response_it_cannot_authenticate():
+    """키가 다르면 조용히 넘어가지 말고 태그 불일치로 막아야 한다.
+
+    여기서 통과한다면 상호 인증이 실제로는 검증을 안 하고 있다는 뜻이다.
+    """
+    pytest.importorskip("cryptography")
+    session = SecureSession()
+    session.build_pair_req()
+    session.process_pair_resp(DEVICE_F081)
+    session.build_start_enc_req()
+    session.build_challenge_req(DEVICE_F085)
+
+    with pytest.raises(ValueError, match="tag mismatch"):
+        session.process_challenge_resp(DEVICE_F086)

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -288,3 +288,59 @@ def test_adopted_sessions_keep_the_store():
     assert "session._secure_bond_store = secure_bond_store or SecureBondStore()" in driver
     # setup_time_sync 는 transport 가 없을 때 직접 adopt 한다.
     assert "OmronDeviceSession.adopt(client, config, secure_bond_store)" in time_sync
+
+
+def test_a_cleared_key_stays_cleared_across_a_restart():
+    """엔트리에 남은 첫 키가 재시작 때 되살아나면 안 된다.
+
+    ``clear()`` 는 스토어에 ``{"key": None}`` 을 쓴다. 그걸 "저장된 게 없음"
+    으로 읽고 엔트리로 폴백하면, 커프가 거부해서 버린 키를 다시 집어온다 —
+    같은 거부가 영원히 반복되고, -P- 로 다시 페어링해도 고쳐지지 않은 것처럼
+    보인다. 스토어 파일이 아예 없을 때만 엔트리를 본다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("class PersistentSecureBondStore") :]
+    body = body[: body.index("\ndef _merge_poll_sensor_update")]
+
+    load = body[body.index("async def async_load") :]
+    load = load[: load.index("async def _adopt")]
+
+    # dict 를 받았으면(=명시적으로 지웠어도) 거기서 끝난다.
+    dict_branch = load.index("if isinstance(data, dict):")
+    entry_fallback = load.index("self._entry.data.get(CONF_SECURE_BOND_KEY)")
+    assert dict_branch < entry_fallback
+    assert "return" in load[dict_branch:entry_fallback], (
+        "스토어가 답했는데도 엔트리로 넘어가면 지운 키가 되살아난다"
+    )
+    # 엔트리 키는 한 번 흡수하면서 스토어에 써 둔다.
+    assert "write_through=True" in load
+
+
+def test_secure_family_subscribes_the_unlock_cccd_first():
+    """CCCD 순서가 계열마다 다르다 — 폰 btsnoop 두 개가 정반대다.
+
+        HEM-7188T1-LEO (#92):  0x001c(언락, 28) → 0x0021(RX, 33)
+        HEM-7155T-ESLI (#67):  0x0021(RX, 33)   → 0x001c(언락, 28)
+
+    2.5.23 은 두 계열 모두에 두 번째 순서를 썼고, 그 로그는 "CCD descriptor
+    33" → "28" 직후 페어링 요청이 0xff26 으로 거부되는 것을 보여준다 —
+    config flow 안에서, 커프가 페어링 모드일 때. 이 모듈은 CCCD 조작이 바로
+    그 프레임을 유발할 수 있다는 것을 이미 알고 있었다(_secure_unlock 주석).
+    """
+    import pathlib
+
+    source = pathlib.Path(
+        "custom_components/omron/omron_ble/omron_driver.py"
+    ).read_text()
+    body = source[source.index("async def _token_unlock") :]
+    body = body[: body.index("\n    async def ")]
+
+    assert "if self._config.unlock_mode == UnlockMode.SECURE_SESSION:" in body
+    branch = body.index("if self._config.unlock_mode == UnlockMode.SECURE_SESSION:")
+    secure, other = body[branch:].split("else:", 1)
+    # secure 계열: 언락 먼저
+    assert secure.index("_subscribe_unlock()") < secure.index("_prime_rx()")
+    # 나머지: RX 먼저 (7155T-ESLI/7142T2 캡처 그대로)
+    assert other.index("_prime_rx()") < other.index("_subscribe_unlock()")

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -441,3 +441,23 @@ def test_challenge_request_logs_what_the_capture_cannot():
     between = body[body.index("build_challenge_req(enc_resp)") : body.index("write_gatt_char(self._config.unlock_uuid, challenge_req")]
     assert "start_notify" not in between
     assert "asyncio.sleep" not in between
+
+
+def test_the_driver_module_has_no_undefined_names():
+    """소스 문자열만 보는 테스트는 NameError 를 못 잡는다.
+
+    챌린지 로그를 넣으면서 다른 브랜치에만 있던 헬퍼를 참조했는데, 이 파일의
+    단언들은 "그 이름이 소스에 있다" 만 확인하므로 전부 통과했다. 잡아낸 것은
+    CI 의 lint 였다.
+    """
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-m", "ruff", "check", "custom_components/"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 127 or "No module named" in result.stderr:
+        pytest.skip("ruff not installed")
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -169,10 +169,30 @@ def test_driver_discards_a_key_the_cuff_refused():
     body = source[source.index("async def _secure_unlock") :]
     body = body[: body.index("\n    async def _discard_secure_bond")]
 
-    assert body.count("await self._discard_secure_bond(") == 2, (
-        "타임아웃과 그 밖의 실패 모두에서 상한 키를 버려야 한다"
+    # 정확히 한 곳에서만, 그리고 실제로 거부당했을 때만 버린다.
+    assert body.count("await self._discard_secure_bond(") == 1
+    assert "if reconnecting and key_was_rejected:" in body
+
+
+def test_a_blip_does_not_cost_the_key():
+    """-P- 를 눌러 얻은 키를 BLE 한 번 흔들림으로 지우면 안 된다.
+
+    ``_secure_unlock`` 은 토큰 핸드셰이크로 시작한다. 재연결 중 거기서
+    타임아웃이 나거나 링크가 끊겼다는 이유로 키를 버리면, 사용자는 기기까지
+    다시 가야 한다. 같은 키로 다음 폴에서 재시도하면 되는 실패다.
+    """
+    source = _driver_source()
+    body = source[source.index("async def _secure_unlock") :]
+    body = body[: body.index("\n    async def _discard_secure_bond")]
+
+    # 커프가 secure 단계를 에러 프레임으로 거부했을 때만 세워진다.
+    assert body.count("key_was_rejected = True") == 2, (
+        "encryption start 와 challenge 거부 두 곳에서만 세워야 한다"
     )
-    assert "if reconnecting:" in body
+    timeout = body.index("except asyncio.TimeoutError")
+    generic = body.index("except Exception as exc:")
+    discard = body.index("await self._discard_secure_bond(")
+    assert timeout < generic < discard, "타임아웃 경로는 키를 건드리지 않아야 한다"
 
 
 def test_secure_failure_falls_back_to_the_token_path():
@@ -204,3 +224,67 @@ def _parser_source():
     import pathlib
 
     return pathlib.Path("custom_components/omron/omron_ble/parser.py").read_text()
+
+
+# ── 리뷰 반영: 저장이 통합을 리로드하면 안 된다 ────────────────────────────
+
+def test_saving_the_key_does_not_touch_the_config_entry():
+    """엔트리를 고치면 update_listener 가 통합을 리로드한다.
+
+    ``save()`` 는 핸드셰이크 도중에 불린다. 거기서 리로드가 걸리면 방금
+    페어링한 그 세션이 뜯긴다. 그래서 키는 HA 자체 저장소로 간다.
+    """
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("class PersistentSecureBondStore") :]
+    body = body[: body.index("\ndef _merge_poll_sensor_update")]
+
+    assert "async_update_entry" not in body, (
+        "키 저장이 엔트리를 고치면 세션 도중 리로드가 걸린다"
+    )
+    assert "self._store.async_save" in body
+    # update_listener 는 여전히 무조건 리로드한다 — 그래서 피해야 하는 것이다.
+    listener = source[source.index("async def update_listener") :][:300]
+    assert "async_reload" in listener
+
+
+def test_the_config_flow_key_is_adopted_once_then_lives_in_storage():
+    """엔트리는 첫 키가 놓이는 자리일 뿐이다 — 저장할 entry_id 가 없어서."""
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    body = source[source.index("class PersistentSecureBondStore") :]
+    body = body[: body.index("\ndef _merge_poll_sensor_update")]
+
+    load = body.index("async def async_load")
+    assert body.index("self._entry.data.get(CONF_SECURE_BOND_KEY)") > load
+    # 읽고 나서 엔트리에서 지우지 않는다: 지우는 것도 엔트리 수정이다.
+    assert "data.pop(CONF_SECURE_BOND_KEY" not in body
+
+
+def test_setup_loads_the_key_before_the_first_session():
+    import pathlib
+
+    source = pathlib.Path("custom_components/omron/__init__.py").read_text()
+    assert "await secure_bond_store.async_load()" in source
+    assert source.index("await secure_bond_store.async_load()") < source.index(
+        "secure_bond_store=secure_bond_store,"
+    )
+
+
+def test_adopted_sessions_keep_the_store():
+    """``adopt()`` 가 빈 저장소를 만들면 그 세션은 페어링 요청으로 시작한다."""
+    import pathlib
+
+    driver = pathlib.Path(
+        "custom_components/omron/omron_ble/omron_driver.py"
+    ).read_text()
+    time_sync = pathlib.Path(
+        "custom_components/omron/omron_ble/setup_time_sync.py"
+    ).read_text()
+
+    assert "secure_bond_store: SecureBondStore | None = None," in driver
+    assert "session._secure_bond_store = secure_bond_store or SecureBondStore()" in driver
+    # setup_time_sync 는 transport 가 없을 때 직접 adopt 한다.
+    assert "OmronDeviceSession.adopt(client, config, secure_bond_store)" in time_sync

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -423,9 +423,12 @@ def test_successful_handshake_keeps_its_subscriptions():
     tail = body[finally_at:]
     assert "if self._unlocked:" in tail, "성공/실패를 갈라야 한다"
     success, failure = tail.split("else:", 1)
-    # 실제 호출만 센다 — 로그 문자열에도 이름이 들어 있다.
-    assert "await self._client.stop_notify(" not in success
-    assert failure.count("await self._client.stop_notify(") == 2
+    # 성공 경로는 아무것도 내리지 않는다.
+    assert "stop_notify" not in success
+    assert "_release_primed_rx" not in success
+    # 실패 경로는 언락과 RX 를 모두 내린다 — RX 는 기록까지 지우는 헬퍼로.
+    assert "await self._client.stop_notify(self._config.unlock_uuid)" in failure
+    assert "_release_primed_rx(" in failure
 
 
 def test_challenge_request_logs_what_the_capture_cannot():
@@ -505,13 +508,47 @@ def test_memory_session_swaps_the_handler_instead_of_resubscribing():
     assert "continue" in body[guard : body.index("_start_notify_with_recovery(uuid)")]
 
 
-def test_dropping_the_rx_subscription_forgets_it():
-    """프라임 기록이 남으면 다음 세션이 없는 구독을 있다고 믿는다."""
-    driver = _driver_source()
+def test_every_method_that_primes_rx_also_releases_it():
+    """기록과 CCCD 가 따로 놀면 그 채널은 조용히 죽는다.
 
-    assert driver.count("_primed_notify_uuids.discard(") == 2, (
-        "프라임을 되돌리는 두 곳 모두에서 기록을 지워야 한다"
+    ``_subscribe_notify_channels`` 는 기록을 믿고 ``start_notify`` 를 건너뛴다.
+    그러니 CCCD 를 내린 곳이 기록을 안 지우면, 메모리 세션은 아무도 켜지 않은
+    디스크립터를 듣는다 — 클래식 언락 경로가 정확히 그랬고, 그 경로를 타는
+    프로필이 카탈로그의 대부분이다.
+
+    개수로 세지 않는다. 앞선 버전은 ``count(...) == 2`` 였고, 그래서 세 번째를
+    더하는 **수정 자체를 실패시켰다**.
+    """
+    import re
+
+    driver = _driver_source()
+    lines = driver.splitlines()
+
+    def method_of(idx):
+        for j in range(idx, -1, -1):
+            m = re.match(r"    (?:async )?def (\w+)\(", lines[j])
+            if m:
+                return m.group(1)
+        return "?"
+
+    primes = {
+        method_of(i) for i, l in enumerate(lines) if "_primed_notify_uuids.add(" in l
+    }
+    releases = {
+        method_of(i)
+        for i, l in enumerate(lines)
+        if "_release_primed_rx(" in l and "def _release_primed_rx" not in l
+    }
+    assert primes, "프라임하는 곳이 있어야 한다"
+    assert primes <= releases, (
+        f"프라임만 하고 해제하지 않는 메서드: {sorted(primes - releases)}"
     )
+
+    # 해제 헬퍼는 stop 과 discard 를 같이 한다 — 둘이 갈라질 수 없게.
+    helper = _method_body(driver, "_release_primed_rx")
+    assert "stop_notify(uuid)" in helper
+    assert "_primed_notify_uuids.discard(uuid)" in helper
+
     assert "_primed_notify_uuids.clear()" in _method_body(
         driver, "_unsubscribe_notify_channels"
     )

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -549,6 +549,18 @@ def test_every_method_that_primes_rx_also_releases_it():
     assert "stop_notify(uuid)" in helper
     assert "_primed_notify_uuids.discard(uuid)" in helper
 
+    # 그리고 기록을 지우는 방법은 그 헬퍼 하나뿐이어야 한다. 두 번째 방법이
+    # 생기면 위 primes ⊆ releases 검사가 그걸 못 보고, 직접 discard 하는
+    # 메서드가 언젠가 프라임까지 하게 되면 조용히 어긋난다.
+    discarders = {
+        method_of(i)
+        for i, l in enumerate(lines)
+        if "_primed_notify_uuids.discard(" in l
+    }
+    assert discarders == {"_release_primed_rx"}, (
+        f"헬퍼 밖에서 기록을 지우는 곳: {sorted(discarders - {'_release_primed_rx'})}"
+    )
+
     assert "_primed_notify_uuids.clear()" in _method_body(
         driver, "_unsubscribe_notify_channels"
     )

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -195,10 +195,14 @@ def test_a_blip_does_not_cost_the_key():
     assert body.count("key_was_rejected = True") == 2, (
         "encryption start 와 challenge 거부 두 곳에서만 세워야 한다"
     )
-    timeout = body.index("except asyncio.TimeoutError")
-    generic = body.index("except Exception as exc:")
-    discard = body.index("await self._discard_secure_bond(")
-    assert timeout < generic < discard, "타임아웃 경로는 키를 건드리지 않아야 한다"
+    # 타임아웃 핸들러 블록만 떼어내 그 안에 폐기가 없는지 본다. 인덱스 대소
+    # 비교는 try 안에 다른 except 가 생기면 엉뚱한 것을 집는다.
+    timeout_at = body.index("        except asyncio.TimeoutError")
+    tail = body[timeout_at:]
+    timeout_block = tail[: tail.index("\n        except Exception as exc:")]
+    assert "_discard_secure_bond" not in timeout_block, (
+        "타임아웃 경로가 키를 버린다"
+    )
 
 
 def test_secure_failure_falls_back_to_the_token_path():
@@ -434,11 +438,20 @@ def test_challenge_request_logs_what_the_capture_cannot():
     body = _method_body(_driver_source(), "_secure_unlock")
 
     log = body.index("Sending Challenge Request")
-    assert "ms after the" in body[log : log + 400]
-    assert "is_connected=%s" in body[log : log + 400]
-    assert "_connected_path(" in body[log : log + 600]
+    after = body[log:]
+    # 경과는 write 가 실제로 끝나거나 실패한 뒤에 찍혀야 한다 — 요청을 만드는
+    # 데 걸린 시간만 재면 캡처의 12ms 와 비교할 값이 아니다.
+    assert "ms after the" in after
+    assert after.index("write_gatt_char") < after.index("ms after the")
+    assert "is_connected=%s" in after
+    assert "_connected_path(" in after
+    # 시작점은 0xf0 85 를 받은 지점이어야 한다.
+    assert body.index("enc_resp_at = time.monotonic()") < body.index(
+        "build_challenge_req(enc_resp)"
+    )
     # 캡처에 없는 동작은 넣지 않는다.
-    between = body[body.index("build_challenge_req(enc_resp)") : body.index("write_gatt_char(self._config.unlock_uuid, challenge_req")]
+    start = body.index("build_challenge_req(enc_resp)")
+    between = body[start : body.index("challenge_req, response=True", start)]
     assert "start_notify" not in between
     assert "asyncio.sleep" not in between
 
@@ -461,3 +474,59 @@ def test_the_driver_module_has_no_undefined_names():
     if result.returncode == 127 or "No module named" in result.stderr:
         pytest.skip("ruff not installed")
     assert result.returncode == 0, result.stdout + result.stderr
+
+
+# ── RX 디스패처 ───────────────────────────────────────────────────────────
+
+def test_rx_prime_installs_a_dispatcher_not_a_throwaway_lambda():
+    """더미 람다로 구독해두면 실제 콜백을 붙일 방법이 재구독뿐이다.
+
+    그리고 재구독은 ``_start_notify_with_recovery`` 를 타는데, 그건
+    "already enabled" 를 보면 CCCD 를 내렸다 다시 올린다 — 성공한 핸드셰이크가
+    일부러 유지한 그 구독을, 첫 암호화 프레임 직전에.
+    """
+    driver = _driver_source()
+
+    # 프라임은 두 곳에 있다 — _token_unlock 과 unlock() 의 클래식 경로.
+    assert "lambda _h, _d: None" not in driver, "프라임이 아직 더미 람다다"
+    assert driver.count(
+        "self._config.rx_channel_uuids[0], self._rx_dispatch"
+    ) == 2, "두 프라임 지점 모두 디스패처를 써야 한다"
+    assert "def _rx_dispatch" in driver
+    assert "handler = self._rx_notify_handler" in driver
+
+
+def test_memory_session_swaps_the_handler_instead_of_resubscribing():
+    body = _method_body(_driver_source(), "_subscribe_notify_channels")
+
+    assert "self._rx_notify_handler = self._on_notify_channel_data" in body
+    guard = body.index("if uuid in self._primed_notify_uuids:")
+    assert guard < body.index("_start_notify_with_recovery(uuid)")
+    assert "continue" in body[guard : body.index("_start_notify_with_recovery(uuid)")]
+
+
+def test_dropping_the_rx_subscription_forgets_it():
+    """프라임 기록이 남으면 다음 세션이 없는 구독을 있다고 믿는다."""
+    driver = _driver_source()
+
+    assert driver.count("_primed_notify_uuids.discard(") == 2, (
+        "프라임을 되돌리는 두 곳 모두에서 기록을 지워야 한다"
+    )
+    assert "_primed_notify_uuids.clear()" in _method_body(
+        driver, "_unsubscribe_notify_channels"
+    )
+
+
+def test_rx_dispatcher_routes_only_when_a_handler_is_set():
+    """실제로 호출해 본다 — 소스 문자열만 보면 배선 실수를 놓친다."""
+    from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+
+    session = OmronDeviceSession(object(), _config())
+    seen: list[bytes] = []
+
+    session._rx_dispatch(None, bytearray(b"\x01\x02"))   # 핸들러 없음: 버린다
+    assert seen == []
+
+    session._rx_notify_handler = lambda _c, data: seen.append(bytes(data))
+    session._rx_dispatch(None, bytearray(b"\x03\x04"))
+    assert seen == [b"\x03\x04"]

--- a/tests/test_secure_bond_persistence.py
+++ b/tests/test_secure_bond_persistence.py
@@ -74,11 +74,21 @@ def test_no_stored_key_means_pairing_mode():
 
 
 def test_stored_key_means_reconnect_mode():
-    """재연결 모드는 ``0x70 01`` 을 거부해야 한다 — 그게 이 변경의 핵심이다."""
     session = SecureSession(stored_ltk=LTK)
 
     assert session.is_bonding is False
     assert session.ltk == LTK
+
+
+def test_reconnect_mode_refuses_to_pair():
+    """재연결 모드는 ``0x70 01`` 을 거부해야 한다 — 그게 이 변경의 핵심이다.
+
+    ``build_pair_req`` 는 모드를 보기 전에 cryptography 를 먼저 요구하므로,
+    그 패키지가 없는 환경에서는 이 단언을 할 수 없다(HA 에는 기본 포함).
+    """
+    pytest.importorskip("cryptography")
+    session = SecureSession(stored_ltk=LTK)
+
     with pytest.raises(RuntimeError, match="reconnect mode"):
         session.build_pair_req()
 


### PR DESCRIPTION
> Draft until a real HEM-7188T1 confirms the secure path end to end. Behind `token_key_fallback`, so a failure degrades to today's behaviour rather than taking away the read that works.

## What the btsnoop shows

A phone capture of a real HEM-7188T1-LEO ([#92](https://github.com/eigger/hass-omron/issues/92)) contains two sessions with the official app:

```
session 1:  0x11/0x91  ->  0x70 01 (89B)  ->  0xf0 81
                       ->  0x70 05 -> 0xf0 85 -> 0x70 06 -> 0xf0 86
                       ->  encrypted 0xc0 data   (0x48 frames)

session 2:  0x11/0x91  ->  0x70 05 -> 0xf0 85 -> 0x70 06 -> 0xf0 86
                       ->  encrypted 0xc0 data
                           ^ no 0x70 01
```

The second session does not pair. These cuffs keep a bond **above SMP**, and the app keeps the key that pairing produced. That key is what makes a host a *registered* one. Without it, a reconnect can only ask to pair again — and only a cuff in pairing mode answers that.

Also in the capture: **no SMP frames at all**, and an ATT MTU of 247 that lets the 89-byte pairing request go in one write.

## Our request was never malformed

Two things checked against the capture rather than assumed:

- the captured frame matches our `0x70 01 || salt(7) || challenge(16) || pubkey(64)` layout **byte for byte** (89 bytes)
- both peers' public keys land on the P-256 curve **only** when read as little-endian `X||Y` — which is exactly what `build_pair_req()` sends (big-endian fails the curve equation)

What we never did was keep the key. Every session started with `is_bonding=True` and asked to pair; outside the `-P-` window that is answered with `0xff26`. That is what got read as *"the device rejects ECDH"*, and why the profile was moved to the plaintext token path — which works exactly once, right after pairing, while the cuff is still permissive. That single-read-then-nothing pattern is the whole symptom in #92.

`SecureSession` has supported reconnect mode via `stored_ltk` since it was written. Nothing ever supplied one.

## Field result: the CCCD order was it

2.8.0-beta.1 on a real HEM-7188T1-LEO ([#92](https://github.com/eigger/hass-omron/issues/92#issuecomment-5384622831)) got further than any build ever has:

```
Sending Pairing Request (len=89): 7001aba5...
Received Pairing Response (len=89): f081eb31...     <-- first time, ever
Key exchange complete
Sending Encryption Start Request (len=46): 7005cec0...
Received Encryption Response (len=46): f0855c76...  <-- also a first
Sending Challenge Request (len=46): 700662b3...
ERROR ... Bluetooth GATT Error handle=27 error=133
```

Before this branch, `0x70 01` had been sent four times across 2.5.15–2.5.23 and refused with `0xff26` every time — **all four with the CCCD subscriptions taken in the wrong order for this family**. The catalog's "real devices reject the pairing request" was our own ordering, not a device policy.

**The failure has moved.** `0xff26` was an application-level refusal; `error=133` is the write itself breaking before any response — what a dropped link looks like from here. The capture cannot explain it: nothing sits between `0xf0 85` and `0x70 06` but 12 ms, and the ATT opcode is the same Write Request we use (checked for `0x70 01`, `0x70 05`, `0x70 06` and `0xc0`). `0x70 06` is also the first frame carrying our own CCM ciphertext, so a cuff that cannot decrypt it and hangs up would look identical. Both remain open, so nothing speculative goes in front of that write — no CCCD rewrite, no sleep — and a test pins that. What this build adds instead is the elapsed time, the link state and the proxy the write actually used.

Two things the same log corrected:

- **The key was committed too early.** Storing it right after the key exchange left us holding an LTK the cuff never committed to when `0x70 06` broke; the next session opened as a reconnect, was refused, and discarded it — the `-P-` press wasted anyway, one session later. It now waits for `0xf0 86`.
- **The fallback crashed.** With the secure session left in place, the first command after falling back to plaintext tried to encrypt through a handshake that never reached PAIRED, raising and taking the session down instead of reading. Guards now ask the state, not whether an object exists.

Still to come, visible in the capture but not yet implemented: the app re-enables the unlock CCCD before **67 of its 79** `0xc0` data writes. That will matter the moment `0x70 06` is past.

## The missing half

| | |
|---|---|
| `SecureBondStore` | holds the key; no Home Assistant imports, so the driver stays testable |
| `PersistentSecureBondStore` | persists it in Home Assistant's own storage. Not the config entry: writing there fires the update listener, which reloads the integration — and `save()` runs mid-handshake, so the reload would tear down the session that just paired |
| config flow | there is no entry id to store under until the entry exists, so the flow leaves its first key on the entry; setup adopts it once and writes it through, and the store is the only source after that. A cleared key is not resurrected on restart |
| `_secure_unlock` | opens at `0x70 05` when a key is stored, and stores a derived one only **after** `0xf0 86`. An earlier draft saved right after the key exchange; the field log showed that leaves us holding an LTK the cuff never committed to when `0x70 06` breaks, so the next session opens as a reconnect, is refused, and discards it — the `-P-` press wasted anyway |
| rejected keys | discarded only when a secure stage answers with an error frame. A token-prelude timeout or a link blip retries with the same key: it cost a button press |
| subscriptions | a successful handshake keeps them, and the RX channel runs through a dispatcher whose handler the memory session swaps — re-subscribing would drop the CCCD and re-add it, which is what the capture shows the app never doing |
| `HEM-7188T1` | `unlock_mode=SECURE_SESSION`, `token_key_fallback=True` |

## Why this is scoped to one profile

The four btsnoops in the issues do **not** show one protocol:

| capture | device | application layer |
|---|---|---|
| [#92](https://github.com/eigger/hass-omron/issues/92) | HEM-7188T1-LEO (WLD4.0) | token handshake **then secure session**, encrypted data |
| [#67](https://github.com/eigger/hass-omron/issues/67) | HEM-7155T-ESLI | token handshake **only** — no `0x70` frames at all |
| [#91](https://github.com/eigger/hass-omron/issues/91) | — | `btsnooz` from a bugreport; carries no ACL data, unusable |

So HEM-7155T-ESLI and the HEM-7142T2 family are already on the right path and are untouched here. HEM-7382T1-AZAZ (#91) may or may not belong with HEM-7188T1 — a full btsnoop would settle it, and until one exists it stays as it is.

## What this means for the other open work

[#129](https://github.com/eigger/hass-omron/pull/129) gates polls on the cuff advertising a window, on the reading that these devices cannot reconnect without pairing mode. If this branch is right, they *can* — they just need the key we were throwing away. #129's other fixes stand on their own; its gate may turn out to be unnecessary for HEM-7188T1. Neither should merge before the other is retested.

## Test plan
- [x] `pytest tests -q` — 144 passed (38 in `tests/test_secure_bond_persistence.py`), plus `ruff check` from the suite
- [x] Frame layout and curve/endianness verified against the captured bytes, not assumed
- [x] Each guard verified by reintroducing the defect and watching the suite fail (always pairing, ignoring the stored key, keeping a refused key)
- [ ] **Real HEM-7188T1: pair in `-P-` mode, confirm the first read, then a later poll with the cuff idle** — the whole point
- [x] **Does pairing now succeed at all?** Yes — `0x70 01` and `0x70 05` both answered for the first time
- [ ] **Get past `0x70 06`**: is `error=133` the link dropping (retry on a single dedicated proxy) or the cuff refusing our ciphertext? The new log line reports elapsed time, link state and proxy
- [ ] Confirm a rejected key does not come back after a Home Assistant restart
- [ ] Confirm `Secure session ... reconnecting with the stored bond key` appears on the second session
- [ ] Confirm a HEM-7142T2 / HEM-7155T-ESLI still reads (untouched, but they share the driver)

Refs #92, #91, #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)


