### PR TITLE
fix: correct record fields against reference memory-map data

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.9-beta.1"
+  "version": "2.7.8-beta.14"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.7"
+  "version": "2.7.9-beta.1"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -33,6 +33,7 @@ _MODERN_OS_BONDING_BASE = {
 CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     "HEM-6320T": DeviceConfig(
         model="HEM-6320T",
+        connect_type=ConnectType.WLB1_0,
         endianness=Endianness.BIG,
         user_start_addresses=[0x0370],
         per_user_records_count=[100],
@@ -61,6 +62,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-6321T": DeviceConfig(
         model="HEM-6321T",
+        connect_type=ConnectType.WLB1_0,
         endianness=Endianness.BIG,
         user_start_addresses=[0x0370, 0x08E8],
         per_user_records_count=[100, 100],
@@ -87,6 +89,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-6401T": DeviceConfig(
         model="HEM-6401T",
+        connect_type=ConnectType.WLB1_0,
         endianness=Endianness.LITTLE,
         # HEM-6401T exposes multiple data types; only the BP data_5 area is mapped here.
         user_start_addresses=[0x1350],
@@ -113,6 +116,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-6410T": DeviceConfig(
         model="HEM-6410T",
+        connect_type=ConnectType.WLB1_0,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x5590],
         per_user_records_count=[100],
@@ -140,6 +144,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7320T": DeviceConfig(
         model="HEM-7320T",
+        connect_type=ConnectType.WLB1_0,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02AC, 0x05F4],
         per_user_records_count=[60, 60],
@@ -287,6 +292,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7600T": DeviceConfig(
         model="HEM-7600T",
+        connect_type=ConnectType.WLB1_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02AC],
@@ -400,6 +406,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7325T": DeviceConfig(
         model="HEM-7325T",
+        connect_type=ConnectType.WLB1_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02AC],
@@ -422,6 +429,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-6232T": DeviceConfig(
         model="HEM-6232T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8, 0x0860],
@@ -481,6 +489,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7530T": DeviceConfig(
         model="HEM-7530T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
@@ -522,6 +531,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # Single-user 30-slot variant of the 7530T EEPROM family (0x260/0x2E8).
     "HEM-6161T": DeviceConfig(
         model="HEM-6161T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
@@ -552,6 +562,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # Single-user 60-slot variant of the 7530T EEPROM family (0x260/0x2E8).
     "HEM-7136T": DeviceConfig(
         model="HEM-7136T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
@@ -581,6 +592,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # Single-user 100-slot variant of the 7530T EEPROM family (0x260/0x2E8).
     "HEM-6231T": DeviceConfig(
         model="HEM-6231T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
@@ -607,6 +619,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # Single-user 90-slot variant of the 7530T EEPROM family (0x260/0x2E8).
     "HEM-6231T_Z": DeviceConfig(
         model="HEM-6231T_Z",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.BIG,
         user_start_addresses=[0x02E8],
@@ -630,6 +643,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # HEM-7153JT: same layout as HEM-7150T but has 30 record slots
     "HEM-7153JT": DeviceConfig(
         model="HEM-7153JT",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
@@ -655,6 +669,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7150T": DeviceConfig(
         model="HEM-7150T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
@@ -687,6 +702,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # HEM-7157T / HEM-7158T: same layout as HEM-7150T but has 100 record slots
     "HEM-7157T": DeviceConfig(
         model="HEM-7157T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
@@ -715,6 +731,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     # HEM-7151T: same layout as HEM-7150T but has 80 record slots
     "HEM-7151T": DeviceConfig(
         model="HEM-7151T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098],
@@ -936,6 +953,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
     ),
     "HEM-7342T": DeviceConfig(
         model="HEM-7342T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x06D8],
@@ -977,16 +995,11 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7347T2-AJC32",
             "HEM-7347T2-AJE32",
             "HEM-7349T_ABR",
-            "HEM-7361T-ALRU",
-            "HEM-7361T-AP",
-            "HEM-7361T-D",
-            "HEM-7361T-EBK",
-            "HEM-7361T1-BS",
-            "HEM-7361T_ESL",
         ),
     ),
     "HEM-7361T": DeviceConfig(
         model="HEM-7361T",
+        connect_type=ConnectType.WLS3_0,
         aggressive_gatt_timing=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x0098, 0x06D8],
@@ -1007,6 +1020,20 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,
+        equivalent_model_ids=(
+            # These all used to sit on the HEM-7342T profile.  The two profiles
+            # carry identical settings today, so nothing changes behaviourally,
+            # but HEM-7361T is an AFib model and carries extra AFib/validity
+            # fields in the record (byte 12 bits 1-2) that HEM-7342T does not
+            # have — decoding those later requires them to resolve here.
+            # HEM-7361T1-BS shares the HEM-7361T memory map exactly.
+            "HEM-7361T-ALRU",
+            "HEM-7361T-AP",
+            "HEM-7361T-D",
+            "HEM-7361T-EBK",
+            "HEM-7361T1-BS",
+            "HEM-7361T_ESL",
+        ),
     ),
     # HEM-7191T1 family ("M3 Comfort AFib" / "X3 Comfort AFib") —
     # 1-user, 60 records (data_1=0x01C4) on WLD4.0 transport with token-key unlock.

--- a/custom_components/omron/omron_ble/record_parsers.py
+++ b/custom_components/omron/omron_ble/record_parsers.py
@@ -42,9 +42,9 @@ def parse_classic_vital_14_bitpacked(
     hour = _bytearray_bits_to_int(data, endianness, 43, 47)
     minute = _bytearray_bits_to_int(data, endianness, 52, 57)
     second = min(_bytearray_bits_to_int(data, endianness, 58, 63), 59)
-    # BE mappings derived from standard bit packing
+    # BE mappings derived from standard bit packing.  Bit 50 (byte 7 bit 5) is
+    # deliberately left undecoded: see parse_classic_vital_14.
     record["pos"] = _bytearray_bits_to_int(data, endianness, 48, 49)
-    record["battery"] = _bytearray_bits_to_int(data, endianness, 50, 50)
     record["cuff"] = _bytearray_bits_to_int(data, endianness, 51, 51)
     record["datetime"] = datetime.datetime(year, month, day, hour, minute, second)
     return record
@@ -67,9 +67,9 @@ def parse_classic_vital_14_6232_family(
     hour = _bytearray_bits_to_int(data, endianness, 43, 47)
     minute = _bytearray_bits_to_int(data, endianness, 52, 57)
     second = min(_bytearray_bits_to_int(data, endianness, 58, 63), 59)
-    # BE mappings derived from standard bit packing
+    # BE mappings derived from standard bit packing.  Bit 50 (byte 7 bit 5) is
+    # deliberately left undecoded: see parse_classic_vital_14.
     record["pos"] = _bytearray_bits_to_int(data, endianness, 48, 49)
-    record["battery"] = _bytearray_bits_to_int(data, endianness, 50, 50)
     record["cuff"] = _bytearray_bits_to_int(data, endianness, 51, 51)
     record["datetime"] = datetime.datetime(year, month, day, hour, minute, second)
     return record
@@ -84,7 +84,8 @@ def parse_classic_vital_14(data: bytes | bytearray, endianness: str) -> dict[str
       [2]   bpm
       [3]   year - 2000 (lower 6 bits)
       [4:5] flags1 (hour, day, month, ihb, mov)
-      [6:7] flags2 (second, minute)
+      [6:7] flags2 (second, minute, cuff, position)
+      [10:11] sequenceNo (_record_id)
     """
     # NOTE:
     # This format is byte/bit packed in a fixed little-endian on-wire layout.
@@ -110,9 +111,11 @@ def parse_classic_vital_14(data: bytes | bytearray, endianness: str) -> dict[str
     record["mov"] = (flags1 >> 15) & 0x01
     second = min(flags2 & 0x3F, 59)
     minute = min((flags2 >> 6) & 0x3F, 59)
-    # Modern stack flags2 bits: bit 12=Cuff, bit 13=Battery, bits 14-15=Position
+    # flags2 bits: 12=Cuff, 14-15=Position.  Bit 13 is NOT a battery flag —
+    # no known model defines a field there, and on the AFib cuffs
+    # (7191T1/7196T1/7376T1/7380T1/7386T1) it is one of the AFib/validity bits.
+    # Left undecoded rather than reported as "battery".
     record["cuff"] = (flags2 >> 12) & 0x01
-    record["battery"] = (flags2 >> 13) & 0x01
     record["pos"] = (flags2 >> 14) & 0x03
 
     # Devices may return partially initialized entries that are not 0xFF-filled.
@@ -126,10 +129,12 @@ def parse_classic_vital_14(data: bytes | bytearray, endianness: str) -> dict[str
     ):
         raise ValueError("record slot is empty")
 
-    # 714x family records appear to carry a trailing record sequence/id field.
-    # Keep it for latest-record selection heuristics.
-    if len(data) >= 2:
-        record["_record_id"] = int.from_bytes(bytes(data[-2:]), "little")
+    # Record sequence number.  It sits at offset 10, size 2 for every model on
+    # this layout (0x0E and 0x10 slots alike) — not at the end of the slot,
+    # which is where a previous guess read it from.  Kept for latest-record
+    # selection heuristics.
+    if len(data) >= 12:
+        record["_record_id"] = int.from_bytes(bytes(data[10:12]), "little")
 
     try:
         record["datetime"] = datetime.datetime(year, month, day, hour, minute, second)

--- a/tests/test_record_parsers.py
+++ b/tests/test_record_parsers.py
@@ -34,6 +34,31 @@ class TestParseClassicVital14:
         assert record["bpm"] == 67
         assert record["datetime"] == datetime.datetime(2026, 5, 19, 19, 48, 22)
 
+    def test_record_id_reads_official_sequence_no_offset(self):
+        # The record sequence number sits at offset 10, size 2. On the two real
+        # HEM-7142T2 slots above that yields 70 (slot 7) and 76 (slot 13) —
+        # monotonic with the slot index, as a sequence number must be. Reading
+        # the last two bytes instead gives 25 and 186.
+        slot7 = parse_classic_vital_14(
+            bytes.fromhex("6457431a7316161c000046001900"), endianness="little"
+        )
+        slot13 = parse_classic_vital_14(
+            bytes.fromhex("6558541a331ade1800004c00ba00"), endianness="little"
+        )
+        assert slot7["_record_id"] == 70
+        assert slot13["_record_id"] == 76
+        assert slot13["_record_id"] - slot7["_record_id"] == 13 - 7
+
+    def test_no_battery_field(self):
+        # flags2 bit 13 is not a battery flag on any model — no known memory map
+        # defines a field there, so the parser must not invent one.
+        record = parse_classic_vital_14(
+            bytes.fromhex("6558541a331ade1800004c00ba00"), endianness="little"
+        )
+        assert "battery" not in record
+        assert record["cuff"] == 1
+        assert record["pos"] == 0
+
     def test_empty_slot_all_ff_raises(self):
         raw = bytes.fromhex("ff" * 14)
         with pytest.raises(ValueError):
@@ -62,6 +87,17 @@ class TestParseClassicVital14Bitpacked:
         assert record["sys"] == 145
         assert record["dia"] == 91
         assert record["bpm"] == 72
+        assert "battery" not in record
+
+    def test_no_battery_field_6232_family(self):
+        from custom_components.omron.omron_ble.record_parsers import (
+            parse_classic_vital_14_6232_family,
+        )
+
+        record = parse_classic_vital_14_6232_family(
+            bytes.fromhex("5b781a4819d71b42000014006996"), endianness="big"
+        )
+        assert "battery" not in record
 
 
 class TestParseClassicVital24Heartguide:


### PR DESCRIPTION
Cross-checked the device catalog against reference memory-map data covering **244 model variants**.

Result: every EEPROM address, record size, record count and index cursor/unread offset we ship was already correct. These are the four places where the record decoders and the catalog were not.

## Changes

**1. Drop the `battery` field from the three 14-byte record parsers**

No known model defines a field at `flags2` bit 13 (`data[7]` bit 5). The only models that use that bit at all are the AFib cuffs (7191T1 / 7196T1 / 7376T1 / 7377T1 / 7380T1 / 7386T1), where it is one of the AFib/validity flags — never a battery level. Nothing consumed the value, so no sensor or entity changes.

**2. Read `_record_id` from bytes `[10:12]`, not the last two bytes of the slot**

The record sequence number sits at offset 10, size 2 on this layout for every model, 0x0E and 0x10 slots alike. On the two real HEM-7142T2 records already in the test suite:

| | slot 7 | slot 13 |
|---|---|---|
| `data[10:12]` (fixed) | **70** | **76** |
| `data[-2:]` (before) | 25 | 186 |

Monotonic with the slot index across a 6-slot gap, as a sequence number must be. The old offset returned unrelated bytes. The value is currently unused, so this is a latent-correctness fix.

`parse_classic_vital_24_heartguide` already used offset 10 and is correct; `parse_classic_vital_16_6401_family` does not emit the field. Both untouched.

**3. Move the six `HEM-7361T*` model ids from the HEM-7342T profile to HEM-7361T**

The two profiles carry identical settings today, so **nothing changes behaviourally**, and stored config entries keep resolving (`MODEL_VARIANT_MAP` looks up by id). But HEM-7361T is an AFib model and carries extra AFib/validity fields in the record — byte 12 bits 1–2 — that HEM-7342T does not have, and decoding those later requires these ids to land on the 7361T profile.

`HEM-7361T1-BS` (Boots) is included: it shares the HEM-7361T memory map exactly.

**4. Fill in `connect_type` on 19 profiles that had it unset** (7× WLB1.0, 12× WLS3.0)

Descriptive metadata only — `connect_type` gates WLD3.0/WLD4.0 behaviour and none of these are in that family. This also confirms the existing WLB1.0 values on HEM-7322T / 7511T / 8732T / 8732K were already right: those models support a USB cradle as well, which had made their BLE transport type look ambiguous.

## Verification

Built an independent reference decoder from the field-map data (bit fields, arithmetic ops, conditional/validity gates) and diffed it against `parse_record` for 11 profiles — HEM-7361T, 7342T, 7142T2, 7146T, 7150T, 7155T, 7188T1, 7380T1, 7386T1, 1026T2, 9601T:

**440,000 records, zero mismatches** on `sys`/`dia`/`bpm`/`ihb`/`mov`/`cuff`/`pos`/`datetime`/`_record_id`.

One benign difference found and deliberately not changed: WLD3.0/WLD4.0 models declare the year field as 8 bits wide while classic models use 6. `parse_classic_vital_14` masks to 6 bits for all of them, which is identical for any year before 2064.

Also re-ran the full catalog cross-check after the patch: mismatches dropped from 95 to 9, and all 9 remaining are HEM-6401T/6410T, where our profile deliberately targets data type #5 while the checker compares data type #1 (the type-5 block matches our config exactly, `write_cursor_mask=0x3FFF` included).

`119 passed`, `ruff` clean. Three new tests cover the corrected `_record_id` offset and the absence of `battery`.

## What this does not fix

Related to #132: this does **not** explain the scrambled HEM-7361T readings reported there. The verification above shows the profile and the decoder were already correct for that model, so the cause lies further up — in the read or slot-selection path — and still needs the reporter's `Index block ... raw=` / `User1|User2 ... slot=N raw=<hex>` debug lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
