### PR TITLE
fix: let a probed retail model number select its profile

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1235,6 +1235,9 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7382T1-AZAZ",
             "HEM-7386T1-AJF3",
             "HEM-7388T1-AJF3",
+            # The GATT Model Number String this cuff answers with; US retail
+            # cartons carry the same name (issue #91).
+            "BP5465",
         ),
     ),
     # HEM-7188T1 / HEM-7183T1 family ("X2+ Connect" / "M2+" etc.) — dedicated single-user profile

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -394,6 +394,15 @@ def get_supported_model_stats() -> dict[str, int]:
 _HEM_MODEL_CODE_RE = re.compile(r"(HEM-[A-Z0-9_.-]+)", re.IGNORECASE)
 
 
+def _exact_catalog_model_id(token: str) -> str | None:
+    """Catalog model id for an exact name, ignoring case and inner spaces."""
+    supported = set(CANONICAL_DEVICE_PROFILES.keys()) | set(MODEL_VARIANT_MAP.keys())
+    for cand in (token, token.upper(), token.replace(" ", "").upper()):
+        if cand in supported:
+            return cand
+    return None
+
+
 def infer_model_id_from_local_name(local_name: str | None) -> str | None:
     """Return a catalog model id if the BLE local name embeds a known HEM-* code.
 
@@ -403,9 +412,15 @@ def infer_model_id_from_local_name(local_name: str | None) -> str | None:
     """
     if not local_name or not str(local_name).strip():
         return None
-    match = _HEM_MODEL_CODE_RE.search(str(local_name).strip())
+    name = str(local_name).strip()
+    match = _HEM_MODEL_CODE_RE.search(name)
     if not match:
-        return None
+        # The config flow also feeds this the GATT Model Number String, which is
+        # a different namespace: a US retail cuff answers with its carton name,
+        # like the BP5465 in issue #91, and no HEM-* code appears anywhere in
+        # it. Fall back to an exact catalog id so a name that is already one
+        # resolves; anything else still infers nothing.
+        return _exact_catalog_model_id(name)
     token = match.group(1).strip()
     candidates = {
         token,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -10,6 +10,7 @@ from custom_components.omron.omron_ble.devices import (
     UnlockMode,
     get_device_config,
     get_supported_models,
+    infer_model_id_from_local_name,
     resolve_profile_model_id,
 )
 
@@ -367,3 +368,22 @@ class TestCatalogResolution:
 
     def test_unknown_model_falls_back_to_default(self):
         assert resolve_profile_model_id("NOT-A-REAL-MODEL") == DEFAULT_DEVICE_MODEL
+
+
+def test_a_retail_model_number_resolves_to_its_profile():
+    """BP5465 은 HEM-* 코드를 담지 않아 프로브가 읽어도 버려졌다 (#91)."""
+    assert infer_model_id_from_local_name("BP5465") == "BP5465"
+    assert resolve_profile_model_id("BP5465") == "HEM-7386T1"
+    assert get_device_config("BP5465").settings_read_address == 0x0010
+
+
+def test_the_hem_code_path_is_unchanged():
+    """정규식이 맞으면 예전과 똑같이 그 코드를 쓴다."""
+    assert infer_model_id_from_local_name("Omron HEM-7382T1-AZAZ") == "HEM-7382T1-AZAZ"
+    assert infer_model_id_from_local_name("HEM-7386T1") == "HEM-7386T1"
+
+
+def test_an_unknown_name_still_infers_nothing():
+    """모르는 문자열에 억지로 프로파일을 붙이지 않는다."""
+    for value in (None, "", "   ", "BP0000", "12345", "Omron BP5465 monitor"):
+        assert infer_model_id_from_local_name(value) is None


### PR DESCRIPTION
Reported in #91: the probe reads the cuff's model correctly and the config flow ignores it.

```
09:14:50  Fetched Model Number during setup: BP5465
          ...form still offers HEM-7142T2, the placeholder
09:15:47  Catalog variant HEM-7382T1-AZAZ -> profile HEM-7386T1   ← only after picking by hand
```

## Why

`config_flow` hands the GATT Model Number String to `infer_model_id_from_local_name()`, which returns early unless an `HEM-*` code appears in it:

```python
match = _HEM_MODEL_CODE_RE.search(name)
if not match:
    return None          # "BP5465" dies here
```

A BLE local name is what that function was written for. The Model Number String is a different namespace — a US retail cuff answers with its carton name — so the answer was thrown away before the catalog was ever consulted.

## The change

`BP5465` joins `HEM-7386T1`'s `equivalent_model_ids`, the same way every other alternate id for that profile is registered, and the inference falls back to an exact catalog id when no `HEM-*` code matches.

Exact only, deliberately: a substring search over the catalog would start guessing at names like `Omron BP5465 monitor`, and a wrong profile picks the wrong EEPROM layout. A name that is already a catalog id resolves; anything else still infers nothing, as before.

`BP5450` in #39 is probably the next entry, but there the retail name comes from the reporter reading the carton rather than from a probe, so it stays out until a log shows the device reporting it.

Three tests cover it: the retail name resolves to the right profile, the `HEM-*` path is unchanged, and unknown strings still infer nothing.
