### PR TITLE
feat: expose when a poll last decoded a record

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -28,7 +28,7 @@ from homeassistant.const import Platform, CONF_SCAN_INTERVAL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH
-from datetime import timedelta
+from datetime import datetime, timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     CONF_DEVICE_MODEL,
@@ -341,10 +341,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
         _LOGGER,
         name=f"{DOMAIN}_duration_{address}",
     )
+    readout_coordinator = DataUpdateCoordinator[datetime | None](
+        hass,
+        _LOGGER,
+        name=f"{DOMAIN}_readout_{address}",
+    )
     connection_coordinator.async_set_updated_data(False)
     duration_coordinator.async_set_updated_data(None)
+    readout_coordinator.async_set_updated_data(None)
     hass.data[DOMAIN][entry.entry_id]["connection_coordinator"] = connection_coordinator
     hass.data[DOMAIN][entry.entry_id]["duration_coordinator"] = duration_coordinator
+    hass.data[DOMAIN][entry.entry_id]["readout_coordinator"] = readout_coordinator
 
     async def _async_poll_data(hass: HomeAssistant, entry: OmronConfigEntry) -> SensorUpdate:
         entry_data = hass.data[DOMAIN][entry.entry_id]
@@ -390,6 +397,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                         result = await coordinator.device_data.async_poll(
                             device, preconnected_session=preconnected_session
                         )
+                readout_coordinator.async_set_updated_data(
+                    coordinator.device_data.last_readout_at
+                )
                 prev_data = poll_coordinator.data
                 if prev_data is not None:
                     result = _merge_poll_sensor_update(prev_data, result)

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -76,6 +76,7 @@ class OmronBluetoothDeviceData(BluetoothData):
         self._driver = OmronDeviceDriver(self._device_config)
         self._user_aliases: dict[int, str] = _normalize_user_aliases(user_aliases)
         self._last_record_signature: tuple[Any, ...] | None = None
+        self._last_readout_at: dt.datetime | None = None
         self._last_record_signatures_by_user: dict[int, tuple[Any, ...]] = {}
         self._bp_char_unavailable = False
         self._bls_racp_unavailable_logged = False
@@ -827,6 +828,11 @@ class OmronBluetoothDeviceData(BluetoothData):
             except Exception:
                 pass
 
+    @property
+    def last_readout_at(self) -> dt.datetime | None:
+        """When a poll last decoded a record, or None if none ever has."""
+        return self._last_readout_at
+
     def _setup_device_info(self, service_info: BluetoothServiceInfoBleak) -> None:
         """Set up device metadata from advertisement."""
         model = self._device_config.model
@@ -954,6 +960,14 @@ class OmronBluetoothDeviceData(BluetoothData):
                     if "user" not in merged:
                         merged["user"] = 1
                     record = merged
+
+        # Reached only once a record has been decoded, so it separates "the
+        # cuff had nothing new" from "nothing got through". The poll swallows
+        # its own failures by design -- an asleep cuff must not flip every
+        # entity to unavailable -- which leaves a run where the memory session
+        # never opened looking exactly like a quiet one (issue #91).
+        if latest_by_user or record:
+            self._last_readout_at = dt.datetime.now(dt.timezone.utc)
 
         if multi_user_mode:
             if latest_by_user:

--- a/custom_components/omron/sensor.py
+++ b/custom_components/omron/sensor.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import datetime as dt
 from typing import Any
 from .omron_ble import SensorDeviceClass as OmronSensorDeviceClass, SensorUpdate, Units
@@ -218,9 +220,14 @@ async def async_setup_entry(
     duration_coordinator = (
         hass.data[DOMAIN][entry.entry_id].get("duration_coordinator")
     )
+    readout_coordinator = (
+        hass.data[DOMAIN][entry.entry_id].get("readout_coordinator")
+    )
     extra_entities: list[SensorEntity] = []
     if duration_coordinator is not None:
         extra_entities.append(OmronPollDurationSensorEntity(hass, entry, duration_coordinator))
+    if readout_coordinator is not None:
+        extra_entities.append(OmronLastReadoutSensorEntity(hass, entry, readout_coordinator))
     if extra_entities:
         async_add_entities(extra_entities)
 
@@ -420,6 +427,50 @@ class OmronPollDurationSensorEntity(
     @property
     def native_value(self) -> float | None:
         """Return wall-clock seconds for the last poll attempt (success or failure)."""
+        return self.coordinator.data
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach sensor to the same BLE device."""
+        return DeviceInfo(
+            connections={(CONNECTION_BLUETOOTH, self._address)},
+        )
+
+
+class OmronLastReadoutSensorEntity(
+    CoordinatorEntity[DataUpdateCoordinator["datetime | None"]],
+    SensorEntity,
+):
+    """Diagnostic sensor for when a poll last decoded a record.
+
+    The poll serves cached data instead of failing, so that a cuff which is
+    asleep or out of range -- its normal state between readings -- does not
+    take every entity unavailable. The cost is that a run where nothing got
+    through looks the same from the outside as a quiet one. This is the
+    difference: it only moves when a record was actually decoded.
+    """
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_icon = "mdi:cloud-check-outline"
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: OmronConfigEntry,
+        coordinator: DataUpdateCoordinator["datetime | None"],
+    ) -> None:
+        super().__init__(coordinator)
+        model = hass.data[DOMAIN][entry.entry_id]["data"].device_model
+        self._address = hass.data[DOMAIN][entry.entry_id]["address"]
+        identifier = self._address.replace(":", "")[-4:].lower()
+        model_slug = model.lower().replace("-", "_")
+        self._attr_name = f"{model} {identifier.upper()} Last Readout"
+        self._attr_unique_id = f"{model_slug}_{identifier}_last_readout"
+
+    @property
+    def native_value(self) -> "datetime | None":
+        """Return when a record was last decoded, or None if none ever was."""
         return self.coordinator.data
 
     @property

--- a/tests/test_last_readout_stamp.py
+++ b/tests/test_last_readout_stamp.py
@@ -1,0 +1,85 @@
+"""마지막 성공 판독 타임스탬프의 의미를 구조 수준에서 고정한다 (#91).
+
+폴은 실패해도 예외를 던지지 않고 캐시를 돌려주도록 설계돼 있다 — 혈압계는
+측정 사이에 대부분 꺼져 있고, 그때마다 엔티티를 unavailable 로 만들 수는 없기
+때문이다. 대가로, 아무것도 못 읽은 실행과 조용한 실행이 밖에서 보면 똑같아진다.
+이슈 #91 에서 제보자가 본 것이 정확히 그것이다: 메모리 세션 시도 3회가 전부
+실패했는데 `Finished fetching ... (success: True)` 가 찍혔다.
+
+Last Readout 센서는 그 구분을 위해 존재한다. 따라서 스탬프는 **레코드를 실제로
+디코딩한 자리에서만** 찍혀야 한다. 폴 종료 지점이나 예외 핸들러로 옮기는 순간
+센서는 "성공했다"는 거짓말을 하게 되고, 없느니만 못해진다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 실제 인스턴스를 만들 수
+없어(test_poll_deadline.py 와 같은 이유) AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "omron"
+
+_ATTR = "_last_readout_at"
+
+
+def _parse(relative_path: str) -> ast.Module:
+    return ast.parse((_COMPONENT / relative_path).read_text(encoding="utf-8"))
+
+
+def _assignments_to_attr(tree: ast.AST) -> list[ast.stmt]:
+    """__init__ 의 타입 주석 대입(AnnAssign)도 함께 센다."""
+    found: list[ast.stmt] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+        else:
+            continue
+        for target in targets:
+            if isinstance(target, ast.Attribute) and target.attr == _ATTR:
+                found.append(node)
+    return found
+
+
+def _find_function(tree: ast.AST, name: str):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} 을(를) 찾지 못했다 — 이름을 바꿨다면 이 테스트도 갱신할 것")
+
+
+class TestLastReadoutStamp:
+    def test_the_stamp_lives_in_the_readout_path(self):
+        """초기화 한 번, 그리고 판독 경로 한 번. 그 외의 자리는 허용하지 않는다."""
+        parser = _parse("omron_ble/parser.py")
+        readout = _find_function(parser, "_poll_device_readout")
+
+        in_readout = _assignments_to_attr(readout)
+        assert len(in_readout) == 1, (
+            f"_poll_device_readout 안의 {_ATTR} 대입이 {len(in_readout)}개다. "
+            "레코드를 디코딩한 자리 하나여야 한다."
+        )
+
+        everywhere = _assignments_to_attr(parser)
+        assert len(everywhere) == 2, (
+            f"parser.py 전체의 {_ATTR} 대입이 {len(everywhere)}개다. "
+            "__init__ 의 None 초기화와 판독 경로, 둘뿐이어야 한다."
+        )
+
+    def test_the_stamp_is_not_set_from_a_failure_handler(self):
+        """예외 핸들러에서 찍으면 실패한 폴이 성공으로 보인다."""
+        async_poll = _find_function(_parse("omron_ble/parser.py"), "async_poll")
+        for node in ast.walk(async_poll):
+            if isinstance(node, ast.ExceptHandler):
+                assert not _assignments_to_attr(node), (
+                    f"async_poll 의 예외 핸들러가 {_ATTR} 을 찍는다 — "
+                    "그러면 센서가 실패를 성공으로 보고한다."
+                )
+
+    def test_the_poll_publishes_it_to_its_own_coordinator(self):
+        """센서는 readout_coordinator 를 통해서만 값을 받는다."""
+        source = (_COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        assert "readout_coordinator" in source
+        assert "last_readout_at" in source, (
+            "_async_poll_data 가 파서의 last_readout_at 을 코디네이터로 넘겨야 한다"
+        )


### PR DESCRIPTION
Raised from #91, where the reporter had a poll exhaust all three memory-session attempts and still saw:

```
Poll failed model=HEM-7382T1-AZAZ ... ERROR
Finished fetching omron data in 0.436 seconds (success: True)
```

## Not a bug in the success reporting

That `success: True` is deliberate. Every failure path in `_async_poll_data` returns cached data rather than raising — device not found, session lock held, poll timeout, and any other exception — because a cuff is asleep between readings and raising would take every entity unavailable at each interval.

So this PR does not touch that. The failures are already logged, at ERROR and WARNING.

## What was missing

A signal in the UI. From the dashboard, a run where nothing got through looks exactly like a quiet one, and there is no way to tell a current reading from a stale one.

This adds a diagnostic **Last Readout** timestamp beside the existing Duration sensor, fed by its own coordinator the same way.

## Where it is stamped

At the point a record is actually decoded — not where the poll returns. The poll returning proves nothing here: the fallback memory-session readout catches its own failure and logs at debug, which is how the reporter's poll 4 finished quietly after reading nothing.

`tests/test_last_readout_stamp.py` pins that structurally: one assignment in `_poll_device_readout`, none in any exception handler. A stamp moved to the poll exit would report success for a run that read nothing, which is worse than not having the sensor at all.

The entity is diagnostic and appears for every profile.
