### PR TITLE
fix: poll bond-per-session cuffs when they signal, not when the clock says so

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -13,8 +13,11 @@ from sensor_state_data import SensorDeviceClass as SSDSensorDeviceClass
 from .ble_session import (
     adopt_handoff_session,
     discard_handoff_session,
+    has_handoff_session,
     omron_poll_ble_telemetry,
     poll_parked_session,
+    request_poll,
+    take_poll_request,
     run_post_pairing_poll,
 )
 from .omron_ble import OmronBluetoothDeviceData, SensorUpdate
@@ -356,6 +359,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     async def _async_poll_data(hass: HomeAssistant, entry: OmronConfigEntry) -> SensorUpdate:
         entry_data = hass.data[DOMAIN][entry.entry_id]
         address = entry_data["address"]
+        # Consumed here, before any path can return: a request that ends up
+        # skipped must not leave the flag armed for a later scheduled poll.
+        user_requested = take_poll_request(hass, entry.entry_id)
         preconnected_session = None
         handed_off = False
         try:
@@ -370,6 +376,40 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                 )
                 return entry.runtime_data.device_data._finish_update()
             coordinator = entry.runtime_data
+            device_data = coordinator.device_data
+            # Profiles that drop their bond every session cannot read on a
+            # timer: the cuff refuses a new bond once it leaves pairing mode,
+            # so a poll fired only because the interval elapsed spends a
+            # connect, a bond attempt and the session lock to reach a failure
+            # that was certain before it started. Let the cuff say when a read
+            # can work -- pairing_mode (a bond can be made now) or
+            # forced_transfer (a measurement is waiting) -- instead of guessing
+            # on the clock.
+            #
+            # A person pressing Refresh Data is not the clock, so their request
+            # goes through and they see the real error rather than a button
+            # that silently does nothing. A parked pairing session is exempt
+            # too: that link is already open and bonded, and skipping would
+            # strand it.
+            if (
+                not user_requested
+                and device_data.device_config.poll_requires_pairing_window
+                and not getattr(device_data, "pairing_mode", False)
+                and not getattr(device_data, "forced_transfer", False)
+                and not has_handoff_session(hass, address)
+            ):
+                _LOGGER.debug(
+                    "Skipping scheduled poll for %s (%s): the cuff is not "
+                    "advertising pairing mode or pending data, and this "
+                    "profile needs a fresh bond for every session. Put it in "
+                    "pairing mode (blinking -P-) to read now",
+                    address,
+                    device_data.device_config.model,
+                )
+                if poll_coordinator.data is not None:
+                    return poll_coordinator.data
+                return device_data._finish_update()
+
             session_lock: asyncio.Lock = entry_data["session_lock"]
 
             # Try-acquire only — if another BLE session is in flight (e.g. an

--- a/custom_components/omron/ble_session.py
+++ b/custom_components/omron/ble_session.py
@@ -92,6 +92,31 @@ def adopt_handoff_session(
     return hass.data.get(DOMAIN, {}).get("_setup_sessions", {}).pop(address, None)
 
 
+def has_handoff_session(hass: HomeAssistant, address: str) -> bool:
+    """Whether a pairing session is parked for this address, without taking it."""
+    return address in hass.data.get(DOMAIN, {}).get("_setup_sessions", {})
+
+
+def request_poll(hass: HomeAssistant, entry_id: str) -> None:
+    """Mark the next poll as asked for by a person rather than by the clock."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry_id)
+    if entry_data is not None:
+        entry_data["user_requested_poll"] = True
+
+
+def take_poll_request(hass: HomeAssistant, entry_id: str) -> bool:
+    """Consume the request flag.
+
+    Consumed whatever the poll goes on to do: a request that ends up skipped
+    for some other reason must not leave the flag armed for a later scheduled
+    poll nobody asked for.
+    """
+    entry_data = hass.data.get(DOMAIN, {}).get(entry_id)
+    if entry_data is None:
+        return False
+    return bool(entry_data.pop("user_requested_poll", False))
+
+
 async def discard_handoff_session(hass: HomeAssistant, address: str) -> None:
     """Close a parked pairing session that no poll ended up adopting.
 

--- a/custom_components/omron/button.py
+++ b/custom_components/omron/button.py
@@ -15,6 +15,7 @@ from homeassistant.exceptions import HomeAssistantError
 from .ble_session import (
     omron_poll_ble_telemetry,
     poll_parked_session,
+    request_poll,
     run_post_pairing_poll,
 )
 from .const import DOMAIN
@@ -80,6 +81,12 @@ class OmronRefreshDataButtonEntity(ButtonEntity):
 
     async def async_press(self) -> None:
         """Handle button press to poll device and refresh sensor data."""
+        # Scheduled polls for bond-per-session profiles are gated on the cuff
+        # advertising that a read can work. A person pressing this button
+        # asked for the connect, so it happens even when the gate would
+        # have skipped it. One-shot -- the next scheduled poll is gated
+        # again.
+        request_poll(self.hass, self._entry_id)
         poll_coordinator = self._entry.runtime_data.poll_coordinator
         try:
             await poll_coordinator.async_request_refresh()

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -285,6 +285,26 @@ class DeviceConfig:
         )
 
     @property
+    def poll_requires_pairing_window(self) -> bool:
+        """Whether a scheduled poll needs the cuff to say a read can work.
+
+        These cuffs drop their side of the bond when the session ends, and
+        refuse to make a new one once they leave pairing mode. A poll fired
+        because the interval elapsed therefore spends a connect, a bond
+        attempt and the session lock to reach a failure that was certain
+        before it started -- and every one of those is a log line that looks
+        like a fault.
+
+        Derived from the bond policy rather than set per profile, so a profile
+        moved to a kept bond stops being gated in the same edit that changes
+        the bonding, and the two cannot drift apart.
+        """
+        return (
+            self.bond_policy == BondPolicy.PER_SESSION
+            and self.host_pairing_mode == HostPairingMode.OS_BONDING
+        )
+
+    @property
     def pair_on_connect(self) -> bool:
         """Bond during connect, before GATT discovery.
 

--- a/tests/test_poll_pairing_window_gate.py
+++ b/tests/test_poll_pairing_window_gate.py
@@ -1,0 +1,92 @@
+"""세션마다 본드를 버리는 커프의 예약 폴 게이트 (#129 에서 재작성).
+
+이 프로파일들은 세션이 끝나면 자기 쪽 본드를 버리고, 페어링 모드를 벗어나면
+새 본드를 거부한다. 그래서 "주기가 됐다"는 이유만으로 폴을 쏘면 연결 · 본딩
+시도 · 세션 락을 다 쓰고 시작 전부터 확정돼 있던 실패에 도달한다. 그 실패는
+로그에서 고장과 구별되지 않는다.
+
+커프가 스스로 말할 때만 읽는다 — pairing_mode(지금 본드를 만들 수 있음) 또는
+forced_transfer(측정값이 대기 중). 사람이 Refresh Data 를 누른 건 시계가 아니
+므로 게이트를 통과시킨다. 그러지 않으면 버튼이 아무 말 없이 아무것도 안 한다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 폴을 실제로 돌릴 수
+없어(test_poll_deadline.py 와 같은 이유) 배선은 AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+
+from custom_components.omron.omron_ble.devices import (
+    BondPolicy,
+    ConnectType,
+    get_device_config,
+)
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "omron"
+
+
+def _parse(relative_path: str) -> ast.Module:
+    return ast.parse((_COMPONENT / relative_path).read_text(encoding="utf-8"))
+
+
+class TestGateDerivation:
+    """게이트 대상은 본드 정책에서 파생된다 — 프로파일마다 따로 켜지 않는다."""
+
+    def test_per_session_profiles_are_gated(self):
+        config = get_device_config("HEM-7380T1")
+        assert config.bond_policy is BondPolicy.PER_SESSION
+        assert config.poll_requires_pairing_window is True
+
+    def test_wld4_is_gated_on_the_same_terms_as_wld3(self):
+        """WLD4.0 도 같은 본드 정책을 쓰므로 같은 게이트가 걸린다."""
+        config = get_device_config("HEM-7188T1")
+        assert config.connect_type is ConnectType.WLD4_0
+        assert config.bond_policy is BondPolicy.PER_SESSION
+        assert config.poll_requires_pairing_window is True
+
+    def test_a_kept_bond_is_not_gated(self):
+        """본드를 유지하는 프로파일은 커프의 허락 없이도 읽을 수 있다."""
+        config = get_device_config("HEM-7142T2")
+        assert config.bond_policy is BondPolicy.REUSE
+        assert config.poll_requires_pairing_window is False
+
+    def test_moving_the_bond_policy_moves_the_gate(self):
+        """두 설정이 따로 놀 수 없어야 한다 — 그래서 파생으로 둔다."""
+        from dataclasses import replace
+
+        kept = replace(get_device_config("HEM-7380T1"), bond_policy=BondPolicy.REUSE)
+        assert kept.poll_requires_pairing_window is False
+
+
+class TestGateWiring:
+    """게이트는 폴 안에 있고, 버튼은 그것을 통과할 수 있어야 한다."""
+
+    def test_the_poll_consults_the_gate(self):
+        source = (_COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        assert "poll_requires_pairing_window" in source, (
+            "_async_poll_data 가 게이트를 보지 않는다"
+        )
+        assert "has_handoff_session" in source, (
+            "주차된 페어링 세션은 게이트에서 면제돼야 한다 — 아니면 그 링크가 버려진다"
+        )
+
+    def test_the_refresh_button_arms_a_request(self):
+        source = (_COMPONENT / "button.py").read_text(encoding="utf-8")
+        assert "request_poll(" in source, (
+            "Refresh Data 가 요청을 표시하지 않으면 게이트가 버튼을 삼킨다"
+        )
+
+    def test_the_request_is_consumed_before_any_early_return(self):
+        """건너뛴 요청이 다음 예약 폴을 무장시키면 안 된다."""
+        tree = _parse("__init__.py")
+        fn = next(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "_async_poll_data"
+        )
+        body = ast.unparse(fn)
+        take = body.index("take_poll_request")
+        first_return = body.index("return ")
+        assert take < first_return, (
+            "take_poll_request 가 첫 return 뒤에 있다 — 어떤 경로로 빠져나가든 "
+            "플래그는 소비돼야 한다"
+        )


### PR DESCRIPTION
Rewritten from #129 against current master, and #129 is closed.

That stack could not be rebased: it sat on a WLD4.0 kept-bond experiment that came back negative, and four of its fixes had grown into the test file that experiment introduced. Re-deriving which of those 394 test lines belonged to which surviving fix was more work, and more guesswork, than writing the fix again. #129 stays closed as the reference for anything not carried over.

## The problem

Bond-per-session profiles drop their side of the bond when the session ends and refuse to make a new one once they leave pairing mode. A poll fired because the interval elapsed spends a connect, a bond attempt and the session lock to reach a failure that was certain before it started — and in the log that failure is indistinguishable from a real one.

## The change

The poll reads only when the cuff says it can: `pairing_mode` (a bond can be made now) or `forced_transfer` (a measurement is waiting).

Three exemptions, each for a case where skipping would be wrong:

- **Refresh Data.** A person pressing the button is not the clock. Their request goes through even when the gate would skip, so they see the real error instead of a button that silently does nothing.
- **A parked pairing session.** That link is already open and bonded; skipping would strand it.
- **Profiles that keep their bond.** They can read whenever they like.

## Where the gate comes from

`poll_requires_pairing_window` is derived from the bond policy rather than set per profile, so moving a profile to a kept bond stops gating it in the same edit and the two cannot drift.

WLD4.0 shares the WLD3 bond policy and is therefore gated on identical terms. A test pins that, because it is the part most likely to be missed if either family moves.

## Not carried over from #129

The non-connectable advertisement observer is diagnostic work for #92 and belongs with #130, not here. The MSD log throttling was a logging nicety on top of diagnostics master already has.

Seven tests: four on the derivation, three on the wiring — including that the request flag is consumed before any early return, so a request skipped for some other reason cannot leave a later scheduled poll armed.
