### PR TITLE
fix: match a memory reply to the command that asked for it

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -37,6 +37,10 @@ _NOTIFY_SUBSCRIBE_MAX_RETRIES: int = 3
 # sporadic "Characteristic not found" or silently-dropped CCCD writes.  An
 # explicit short wait gives the stack a stable starting point before the
 # follow-up service-cache refresh below.
+# The device answers 0x8f00 for the session-close ack and for a rejected
+# command alike, so it is accepted whatever was asked for.
+END_OF_TRANSMISSION_PACKET_TYPE = bytes([0x8F, 0x00])
+
 _POST_CONNECT_BOND_SETTLE_SEC: float = 1.5
 
 # setups: connection routed through a proxy that did not bond the device),
@@ -630,6 +634,7 @@ class OmronDeviceSession:
         self._last_reply_memory_address: bytes | None = None
         self._last_reply_payload: bytes | None = None
         self._expected_reply_packet_type: bytes | None = None
+        self._expected_reply_frame_head: bytes | None = None
         self._reply_ready = asyncio.Event()
         self._channel_fragments: list[bytes | None] = [None] * 4
         self._notify_handle_to_channel: dict[int, int] = {}
@@ -1053,6 +1058,7 @@ class OmronDeviceSession:
         self._memory_session_active = False
         self._channel_fragments = [None] * 4
         self._expected_reply_packet_type = None
+        self._expected_reply_frame_head = None
         self._reply_ready.clear()
         self._debug_ble_link("reset_session_state")
 
@@ -1155,19 +1161,40 @@ class OmronDeviceSession:
         memory_address = bytes(frame_bytes[3:5])
         expected_data_len = frame_bytes[5]
 
-        # If a specific reply packet type is expected, discard late or unrelated frames,
-        # but always accept 0x8f00 (end-of-transmission / device error frame).
-        if (
-            self._expected_reply_packet_type is not None
-            and packet_type != self._expected_reply_packet_type
-            and packet_type != b"\x8f\x00"
-        ):
-            _LOGGER.debug(
-                "Ignoring unexpected or late reply packet type %s (expected %s)",
-                _hex(packet_type),
-                _hex(self._expected_reply_packet_type),
-            )
-            return
+        # If a specific reply is expected, discard late or unrelated frames, but
+        # always accept 0x8f00 (end-of-transmission / device error frame).
+        #
+        # Type alone cannot tell replies apart: every memory read answers 0x8100
+        # and only the address differs. A late reply to the previous command used
+        # to pass this gate, satisfy the wait, and fail the address check in
+        # read_memory_block afterwards -- by which point the wait was spent, the
+        # real reply arrived with nobody listening, and every following command
+        # consumed the one before it. The address and declared length come
+        # straight out of the command in flight, so a stale frame is dropped here
+        # and the wait continues until the right one lands or the timeout fires.
+        if packet_type != END_OF_TRANSMISSION_PACKET_TYPE:
+            if (
+                self._expected_reply_packet_type is not None
+                and packet_type != self._expected_reply_packet_type
+            ):
+                _LOGGER.debug(
+                    "Ignoring unexpected or late reply packet type %s (expected %s)",
+                    _hex(packet_type),
+                    _hex(self._expected_reply_packet_type),
+                )
+                return
+            head = bytes(frame_bytes[1:6])
+            if (
+                self._expected_reply_frame_head is not None
+                and head != self._expected_reply_frame_head
+            ):
+                _LOGGER.debug(
+                    "Ignoring a late reply meant for another request: got %s, "
+                    "waiting for %s",
+                    _hex(head),
+                    _hex(self._expected_reply_frame_head),
+                )
+                return
 
         self._last_reply_packet_type = packet_type
         self._last_reply_memory_address = memory_address
@@ -1202,6 +1229,14 @@ class OmronDeviceSession:
             self._expected_reply_packet_type = bytes([command[1] | 0x80, command[2]])
         else:
             self._expected_reply_packet_type = None
+        # type(2) + address(2) + declared length(1), all of which a reply echoes
+        # from the command that asked for it.
+        if len(command) >= 6:
+            self._expected_reply_frame_head = (
+                bytes([command[1] | 0x80]) + bytes(command[2:6])
+            )
+        else:
+            self._expected_reply_frame_head = None
 
         if self._config.unlock_mode == UnlockMode.SECURE_SESSION and self._secure_session is not None:
             try:
@@ -1316,6 +1351,7 @@ class OmronDeviceSession:
             )
         finally:
             self._expected_reply_packet_type = None
+            self._expected_reply_frame_head = None
 
     @property
     def memory_session_active(self) -> bool:

--- a/tests/test_reply_matching.py
+++ b/tests/test_reply_matching.py
@@ -1,0 +1,140 @@
+"""응답 짝짓기 회귀 테스트 (이슈 #91, beta.15 실행에서 드러난 결함).
+
+벤더 메모리 프로토콜에는 요청-응답 식별자가 없다. 명령을 쓰고, 알림이 오면
+그것을 답으로 쓴다. 그래서 어떤 프레임을 받아들일지 고르는 것이 전부다.
+
+예전 필터는 **패킷 타입만** 봤다. 그런데 모든 EEPROM 읽기 응답은 타입이 똑같이
+``0x8100`` 이고 주소만 다르다. 직전 명령의 늦은 응답이 그 관문을 통과해 대기를
+끝내 버리고, 주소 검사는 ``read_memory_block`` 이 그 뒤에 하므로 이미 늦는다.
+대기를 소진한 뒤라 진짜 응답은 기다리는 사람 없이 도착하고, 그것이 다시 다음
+명령의 답으로 소비된다 — 한 번 어긋나면 계속 어긋난다.
+
+리포터 로그(2.7.8-beta.15): ``Memory attempt 1/2/3 failed with late/
+address-mismatched replies``. 재시도해도 매번 이전 응답을 소비했다.
+"""
+import asyncio
+
+from custom_components.omron.omron_ble.devices import get_device_config
+from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+
+
+def _crc(frame: bytearray) -> bytearray:
+    """마지막 바이트를 XOR 체크섬으로 채운다 — 수신부가 이것부터 본다."""
+    x = 0
+    for b in frame[:-1]:
+        x ^= b
+    frame[-1] = x
+    return frame
+
+
+def _read_cmd(address: int, length: int) -> bytearray:
+    cmd = bytearray([8, 0x01, 0x00]) + address.to_bytes(2, "big") + bytes([length, 0x00, 0x00])
+    return _crc(cmd)
+
+
+def _read_reply(address: int, length: int) -> bytearray:
+    frame = bytearray([length + 8, 0x81, 0x00]) + address.to_bytes(2, "big")
+    frame += bytes([length]) + bytes(length) + bytes([0x00, 0x00])
+    return _crc(frame)
+
+
+class _Session:
+    """수신 경로만 떼어낸 최소 세션."""
+
+    def __init__(self):
+        self._config = get_device_config("HEM-7386T1")
+        self._channel_fragments = [None] * 4
+        self._notify_handle_to_channel = {}
+        self._secure_session = None
+        self._expected_reply_packet_type = None
+        self._expected_reply_frame_head = None
+        self._last_reply_packet_type = None
+        self._last_reply_memory_address = None
+        self._last_reply_payload = None
+        self._reply_ready = asyncio.Event()
+
+    def expect(self, command: bytearray) -> None:
+        """_write_command_and_wait_reply 가 전송 직전에 세우는 기대값."""
+        self._expected_reply_packet_type = bytes([command[1] | 0x80, command[2]])
+        self._expected_reply_frame_head = bytes([command[1] | 0x80]) + bytes(command[2:6])
+
+    def feed(self, frame: bytearray) -> None:
+        OmronDeviceSession._on_notify_channel_data(self, object(), bytearray(frame))
+
+    _on_notify_channel_data = OmronDeviceSession._on_notify_channel_data
+
+
+def _fed(session, frame):
+    session.feed(frame)
+    return session._reply_ready.is_set()
+
+
+def test_the_reply_to_the_command_in_flight_is_accepted():
+    s = _Session()
+    s.expect(_read_cmd(0x0E3C, 16))
+
+    assert _fed(s, _read_reply(0x0E3C, 16)) is True
+    assert s._last_reply_memory_address == (0x0E3C).to_bytes(2, "big")
+
+
+def test_a_late_reply_for_another_address_does_not_end_the_wait():
+    """같은 타입, 다른 주소. 예전에는 이것이 통과해 대기를 끝냈다."""
+    s = _Session()
+    s.expect(_read_cmd(0x0E3C, 16))
+
+    assert _fed(s, _read_reply(0x0010, 16)) is False, "직전 명령의 응답을 소비하면 안 된다"
+    assert s._last_reply_memory_address is None
+
+
+def test_the_real_reply_still_lands_after_a_late_one():
+    """늦은 프레임을 버렸으면 대기는 그대로 살아 있어야 한다 — 그게 회복의 전부다."""
+    s = _Session()
+    s.expect(_read_cmd(0x0E3C, 16))
+
+    s.feed(_read_reply(0x0010, 16))
+    assert s._reply_ready.is_set() is False
+
+    assert _fed(s, _read_reply(0x0E3C, 16)) is True
+    assert s._last_reply_memory_address == (0x0E3C).to_bytes(2, "big")
+
+
+def test_a_reply_of_the_right_address_but_the_wrong_length_is_refused():
+    """주소만 맞고 길이가 다르면 다른 요청의 답이다."""
+    s = _Session()
+    s.expect(_read_cmd(0x0E3C, 16))
+
+    assert _fed(s, _read_reply(0x0E3C, 28)) is False
+
+
+def test_the_desync_cascade_cannot_start():
+    """리포터가 본 모양: 늦은 응답 하나가 이후 모든 명령을 한 칸씩 밀어냈다.
+
+    명령 세 개를 연달아 보내면서 매번 '한 명령 뒤처진' 응답만 주면, 예전 필터는
+    세 번 다 받아들여 세 번 다 주소 불일치로 실패했다. 이제는 한 건도 받지 않고
+    각 명령의 대기가 유지된다.
+    """
+    addresses = [0x0010, 0x0E3C, 0x0E4C]
+    stale = None
+    for address in addresses:
+        s = _Session()
+        s.expect(_read_cmd(address, 16))
+        if stale is not None:
+            assert _fed(s, stale) is False, hex(address)
+        stale = _read_reply(address, 16)
+
+
+def test_the_end_of_transmission_frame_is_still_accepted():
+    """0x8f00 은 세션 종료 ack 이자 거부 응답이다 — 무엇을 물었든 받아야 한다."""
+    s = _Session()
+    s.expect(_read_cmd(0x0E3C, 16))
+
+    frame = _crc(bytearray([8, 0x8F, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]))
+    assert _fed(s, frame) is True
+    assert s._last_reply_packet_type == bytes([0x8F, 0x00])
+
+
+def test_no_expectation_accepts_anything():
+    """기대값이 없으면 예전처럼 통과시킨다 — 이 변경은 대기 중일 때만 좁힌다."""
+    s = _Session()
+
+    assert _fed(s, _read_reply(0x0010, 16)) is True


### PR DESCRIPTION
The second defect from the `2.7.8-beta.15` run in #91, after the bond fix in #136.

## What went wrong

The vendor memory protocol carries no request identifier. We write a command and treat the next notification as its answer, so **which frames we accept is the whole of the matching** — and the filter looked at the packet type alone.

Every EEPROM read answers `0x8100`. Only the address differs.

So a late reply to the *previous* command passed the gate, satisfied the wait, and only then failed the address check inside `read_memory_block`. By that point the wait was already spent: the real reply arrived with nobody listening and became the late reply that the *next* command consumed. One slipped frame desynchronised everything after it, which is why retrying did not help — each retry consumed the previous one's answer in turn.

The reporter's log shows it directly:

```
15:20:24  First memory attempt encountered late/address-mismatched reply
15:20:41  Retry decoded existing latest records
...
15:23:29  Memory attempt 1 failed with late/address-mismatched replies
15:23:42  Memory attempt 2 failed with late/address-mismatched replies
15:23:56  Memory attempt 3 failed with late/address-mismatched replies
```

That last poll decoded no record at all, while Home Assistant still logged `success: True`.

## The change

Every reply echoes the packet type, the address and the declared length from the command that asked for it, so all three now form the expectation, set from the plaintext command before the write:

```python
if len(command) >= 6:
    self._expected_reply_frame_head = bytes([command[1] | 0x80]) + bytes(command[2:6])
```

and the check moves to where the frame arrives. A stale frame is dropped there and **the wait stays alive**, so it continues until the right reply lands or the timeout fires — which is recoverable, unlike consuming the wrong one.

`0x8f00` stays unconditionally accepted: it is both the session-close ack and the rejection frame, so it can legitimately answer anything. Narrowing that without evidence would break the error path.

The now-unreachable address check in `read_memory_block` stays as an assertion.

## Tests

`tests/test_reply_matching.py` drives the real `_on_notify_channel_data` with frames built down to the XOR checksum. The central one reproduces the reporter's cascade: three commands in a row, each fed the reply that belongs to the one before it.

These test behaviour rather than implementation — disabling the address check makes 4 of the 7 fail.

## Not fixed here

Two defects from the same run remain:

- **A poll that decodes nothing still reports success.** The coordinator cannot tell a fresh decode from a cached fallback. #138's Last Readout sensor exposes it but does not change the result.
- **The setup-session read may not reach the entities.** Possibly downstream of this bug — the reporter's first post-setup poll is one of the late-reply failures above — so it is worth re-checking after this ships rather than guessing now.

Refs #91
