### PR TITLE
fix: put both WLD families on the bond settings that were confirmed

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.7.8-beta.16"
+  "version": "2.8.0"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -13,15 +13,29 @@ from .devices import (
     UnlockMode,
 )
 
-# Bond strategy for the whole WLD3.0 family (HEM-7380T1 / 7382T1 / 7386T1 /
-# 7188T1 / 7155T-MW3). These cuffs serve data during the pairing session and
-# then reject later connections, which fits a device that does not keep its
-# side of the bond; PER_SESSION drops ours to match, so every connection
-# bonds from scratch instead of offering a key the device has forgotten.
+# Bond strategy for the WLD3.0 and WLD4.0 families.
 #
-# Set this to BondPolicy.REUSE to put the family back on a kept bond — that
-# is the only change needed, every dependent behaviour is derived from it.
-_WLD3_BOND_POLICY = BondPolicy.PER_SESSION
+# These cuffs served data during the pairing session and then refused every
+# later connection with "PIN or Key Missing", which read like a device that
+# does not keep its side of the bond -- so the family ran on PER_SESSION,
+# dropping ours to match and bonding from scratch each time.
+#
+# That reading was wrong twice over. The cuff was dropping its side because we
+# disabled the notify CCCDs at session close (see
+# _WLD_KEEP_NOTIFY_SUBSCRIPTIONS); once we stopped, a BP5465 resumed the same
+# bond across four consecutive reconnects with no pairing at all, confirmed on
+# the wire in issue #91. And PER_SESSION could never have worked here anyway:
+# issue #133 caught the cuff answering a fresh pair request with
+# AuthenticationCanceled outside its -P- window, so deleting the bond leaves
+# nothing able to make another one.
+#
+# pair_only_when_pairing keeps the connect-time pair request for the sessions
+# that have to create a bond and off every ordinary poll, which is what the
+# phone capture shows the app doing.
+_WLD_BOND_SETTINGS = {
+    "bond_policy": BondPolicy.REUSE,
+    "pair_only_when_pairing": True,
+}
 
 # Whether WLD3.0/WLD4.0 profiles leave their notify CCCDs enabled at session
 # close instead of writing 0x0000 to them.
@@ -44,52 +58,6 @@ _WLD3_BOND_POLICY = BondPolicy.PER_SESSION
 # its own a fix for a profile still on PER_SESSION -- that path deletes the bond
 # deliberately -- but it stops the divergence either way.
 _WLD_KEEP_NOTIFY_SUBSCRIPTIONS = True
-
-# Bond strategy for HEM-7386T1 alone, split out of _WLD3_BOND_POLICY to test
-# one device without moving the rest of the WLD3.0 family.
-#
-# A phone HCI capture of BP5465 (HEM-7382T1-AZAZ, under this profile) reported
-# in issue #91 shows the official app doing no pairing at all on a normal sync:
-# the cuff raises an SMP Security Request ~53 ms after connect, the phone
-# answers with LE Start Encryption from the bond it already holds, and the data
-# then flows over the same vendor path this integration uses — writes on GATT
-# handle 0x001E (db5b55e0) with notifications on 0x0020 (49123040). No pairing
-# request, no key distribution.
-#
-# PER_SESSION removes exactly that credential after every session, which would
-# leave the next normal-mode connection with nothing to resume encryption from.
-#
-# Not a re-run of the WLD4.0 experiment: that one moved HEM-7188T1 and came
-# back negative, but 7188T1 speaks the application-layer secure session and
-# this profile does not. And this profile has never been tried on REUSE *with*
-# pair_on_connect — it kept its bond via os_bond_once until 2.6.0, in builds
-# where pair_on_connect did not exist yet.
-#
-# On a proxy, pair_on_connect stays true and is what should resume encryption:
-# ESPHome's pair request on an already-bonded peer starts encryption from the
-# stored key rather than re-pairing, which is the phone's behaviour above. The
-# open risk is multi-proxy setups, where the reconnect has to reach the proxy
-# that owns the bond — hence the connect-path logging that ships with this.
-_WLD3_EXPERIMENT_BOND_POLICY = BondPolicy.REUSE
-
-# Send the connect-time pair request only when a bond has to be created.
-#
-# On an ESP32 proxy a pair request that does not complete is not free: ESP-IDF
-# routes SMP_CONN_TOUT (102) through the default branch of
-# ``btc_dm_ble_auth_cmpl_evt`` and deletes the stored bond from flash. Proxy
-# logs from issue #91 show a bond present right after pairing
-# ("bonded=YES (1 bond(s) stored)") and gone minutes later, after which every
-# connection re-pairs from scratch and the cuff — no longer in pairing mode —
-# drops the link.
-#
-# So one failed request costs the credential permanently. Polls now connect
-# plain and let the cuff raise its own Security Request, which is what the
-# phone capture shows the official app doing: Security Request 16-36 ms after
-# connect, then encryption resumed from the retained bond, no pairing.
-#
-# The attempt count comes down with it: with the bond at stake, one poll
-# should be one observation rather than three chances to lose it.
-_WLD3_EXPERIMENT_PAIR_ONLY_WHEN_PAIRING = True
 
 # Let the cuff end its own session instead of hanging up on it.
 #
@@ -121,12 +89,14 @@ _WLD3_EXPERIMENT_PEER_CLOSES_SESSION_SEC = 5.0
 # complete key distribution looks like.
 _WLD3_EXPERIMENT_SUBSCRIBE_SERVICE_CHANGED = True
 
-# The settings above as one set, so the profiles under test cannot drift apart.
-# Spread into a profile with ``**_WLD3_BOND_EXPERIMENT``; every other profile
-# keeps _WLD3_BOND_POLICY and the dataclass defaults.
+# The two settings that are still only on the profiles that were taken apart:
+# the idle window at session end and the Service Changed subscription. Neither
+# is part of the confirmed fix, so they stay where they were rather than
+# spreading to devices nobody has captured. Spread with
+# ``**_WLD3_BOND_EXPERIMENT``; every other profile takes _WLD_BOND_SETTINGS and
+# the dataclass defaults.
 _WLD3_BOND_EXPERIMENT = {
-    "bond_policy": _WLD3_EXPERIMENT_BOND_POLICY,
-    "pair_only_when_pairing": _WLD3_EXPERIMENT_PAIR_ONLY_WHEN_PAIRING,
+    **_WLD_BOND_SETTINGS,
     "connect_settle_attempts": 1,
     "peer_closes_session_sec": _WLD3_EXPERIMENT_PEER_CLOSES_SESSION_SEC,
     "subscribe_service_changed": _WLD3_EXPERIMENT_SUBSCRIBE_SERVICE_CHANGED,
@@ -980,7 +950,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD3_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x02E8, 0x06A8],
         per_user_records_count=[60, 60],
@@ -1153,7 +1123,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD4_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[60],
@@ -1185,7 +1155,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD4_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0584],
         per_user_records_count=[60, 60],
@@ -1258,7 +1228,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD3_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0BCC],
         per_user_records_count=[60, 60],
@@ -1294,7 +1264,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD3_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0D0C],
         per_user_records_count=[80, 80],
@@ -1372,7 +1342,7 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD4_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY_SUBSCRIPTIONS,
         unlock_mode=UnlockMode.TOKEN_KEY,
-        bond_policy=_WLD3_BOND_POLICY,
+        **_WLD_BOND_SETTINGS,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[30],

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -21,6 +21,7 @@ from custom_components.omron.omron_ble.device_catalog import (
 )
 from custom_components.omron.omron_ble.devices import (
     BondPolicy,
+    ConnectType,
     get_device_config,
     resolve_profile_model_id,
 )
@@ -53,11 +54,20 @@ def test_variants_inherit_it(variant):
     assert config.unpair_after_session is False
 
 
-def test_wld4_experiment_is_not_repeated_here():
-    """7188T1 은 secure session 을 쓴다 — 그 음성 결과는 여기 적용되지 않는다."""
-    assert (
-        CANONICAL_DEVICE_PROFILES["HEM-7188T1"].bond_policy == BondPolicy.PER_SESSION
-    )
+def test_both_families_are_on_the_confirmed_bond_settings():
+    """실험이 끝났으므로 계열 전체가 같은 설정을 쓴다.
+
+    원인이 CCCD 로 확정되고(#91) PER_SESSION 이 이 계열에서 성립 불가임이
+    확인된 뒤(#133 의 AuthenticationCanceled — 커프는 -P- 밖에서 새 페어링을
+    거부한다) 두 프로필에만 걸려 있던 본드 설정을 WLD3.0/WLD4.0 전체로 옮겼다.
+    """
+    for name, config in CANONICAL_DEVICE_PROFILES.items():
+        if config.connect_type not in (ConnectType.WLD3_0, ConnectType.WLD4_0):
+            continue
+        assert config.bond_policy is BondPolicy.REUSE, name
+        assert config.unpair_after_session is False, name
+        assert config.pair_only_when_pairing is True, name
+        assert config.keep_notify_subscriptions is True, name
 
 
 def test_connect_logs_the_path_that_owns_the_bond():
@@ -112,11 +122,25 @@ def test_per_session_profiles_cannot_opt_out_of_the_pair_request():
 
     2.6.0 이전에 그 회귀가 실제로 있었다: 세션이 끝나며 본드를 지우고, 다음
     연결은 재연결할 게 없어서 매번 settle 에서 떨어졌다.
+
+    카탈로그에는 이제 PER_SESSION + OS_BONDING 프로필이 하나도 남지 않았으므로
+    (두 계열이 전부 REUSE), 카탈로그를 훑는 대신 속성을 직접 확인한다 — 가드는
+    프로필이 있든 없든 성립해야 한다.
     """
-    for model in ("HEM-7376T1", "HEM-7155T-MW3", "HEM-7188T1"):
-        config = get_device_config(model)
-        assert config.bond_policy is BondPolicy.PER_SESSION, model
-        assert config.pair_on_connect_for(pairing_session=False) is True, model
+    from dataclasses import replace
+
+    base = get_device_config("HEM-7386T1")
+    per_session = replace(
+        base, bond_policy=BondPolicy.PER_SESSION, pair_only_when_pairing=True
+    )
+
+    assert per_session.unpair_after_session is True
+    assert per_session.pair_on_connect_for(pairing_session=False) is True, (
+        "pair_only_when_pairing 이 PER_SESSION 을 무장해제하면 안 된다"
+    )
+    # REUSE 에서는 같은 플래그가 실제로 폴의 pair 요청을 끈다.
+    assert base.pair_on_connect_for(pairing_session=False) is False
+    assert base.pair_on_connect_for(pairing_session=True) is True
 
 
 def test_one_poll_is_one_connection_attempt_on_the_profile_under_test():
@@ -284,10 +308,17 @@ def test_both_profiles_under_test_run_the_identical_experiment():
     assert b.pair_on_connect_for(pairing_session=True) is True
 
 
-def test_the_rest_of_the_wld3_family_is_untouched():
-    """실험은 두 프로필에만 걸린다 — 계열 전체를 옮긴 적이 없다."""
+def test_the_two_unconfirmed_settings_did_not_spread():
+    """세션 끝 대기와 Service Changed 구독은 확정된 수정이 아니다.
+
+    본드 설정은 계열 전체로 갔지만 이 둘은 캡처가 있는 두 프로필에만 남는다 —
+    특히 5초 대기는 매 폴에 그만큼을 더한다.
+    """
     for model in ("HEM-7376T1", "HEM-7377T1", "HEM-7155T-MW3", "HEM-7191T1", "HEM-7196T1"):
         config = get_device_config(model)
-        assert config.bond_policy is BondPolicy.PER_SESSION, model
         assert config.subscribe_service_changed is False, model
         assert config.peer_closes_session_sec == 0.0, model
+    for model in ("HEM-7386T1", "HEM-7380T1"):
+        config = get_device_config(model)
+        assert config.subscribe_service_changed is True, model
+        assert config.peer_closes_session_sec == 5.0, model


### PR DESCRIPTION
The reconnect fix in #136 was family-wide, but the bond policy that makes it usable was not. Six of the eight WLD3.0/WLD4.0 profiles were still `PER_SESSION`: they stopped disabling the CCCDs, and then deleted the bond at session close anyway, so nothing survived to resume with and the symptom stayed.

| | before | now |
| --- | --- | --- |
| HEM-7386T1, HEM-7380T1 | reuse | reuse |
| HEM-7376T1, HEM-7377T1, HEM-7155T-MW3 | **per_session** | **reuse** |
| HEM-7188T1, HEM-7191T1, HEM-7196T1 | **per_session** | **reuse** |

That split existed because the settings were an experiment on one device. They are not any more. The cause is confirmed on the wire (#91: one pairing, four reconnects resuming the same bond, no `PIN or Key Missing`), and `PER_SESSION` turns out to be unusable for this family regardless — #133 caught the cuff answering a fresh pair request with `AuthenticationCanceled` outside its `-P-` window, so deleting the bond leaves nothing able to make another one.

So `bond_policy=REUSE` and `pair_only_when_pairing` move to all eight, as `_WLD_BOND_SETTINGS`. `unpair_after_session` follows from the policy.

The other two experiment settings stay where they were: the five-second idle window at session end and the Service Changed subscription are not part of the confirmed fix, and the idle window adds its five seconds to every poll. No reason to spread either to devices nobody has captured.

Three tests encoded the old split and now check the new invariant instead. One of them scanned the catalog for a `PER_SESSION` OS-bonding profile to prove `pair_only_when_pairing` cannot disarm it; no such profile is left, so it builds one and tests the property directly.

Version to **2.8.0** — the first stable since 2.7.7, carrying #135, #136, #137, #138 and #140.

Refs