### PR TITLE
docs: trim the investigation narrative out of the comments

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -13,88 +13,43 @@ from .devices import (
     UnlockMode,
 )
 
-# Bond strategy for the WLD3.0 and WLD4.0 families.
-#
-# These cuffs served data during the pairing session and then refused every
-# later connection with "PIN or Key Missing", which read like a device that
-# does not keep its side of the bond -- so the family ran on PER_SESSION,
-# dropping ours to match and bonding from scratch each time.
-#
-# That reading was wrong twice over. The cuff was dropping its side because we
-# disabled the notify CCCDs at session close (see
-# _WLD_KEEP_NOTIFY_SUBSCRIPTIONS); once we stopped, a BP5465 resumed the same
-# bond across four consecutive reconnects with no pairing at all, confirmed on
-# the wire in issue #91. And PER_SESSION could never have worked here anyway:
-# issue #133 caught the cuff answering a fresh pair request with
-# AuthenticationCanceled outside its -P- window, so deleting the bond leaves
-# nothing able to make another one.
-#
-# pair_only_when_pairing keeps the connect-time pair request for the sessions
-# that have to create a bond and off every ordinary poll, which is what the
-# phone capture shows the app doing.
+# Bond strategy for the WLD3.0 and WLD4.0 families. REUSE because the cuff does
+# keep its side of the bond, and because PER_SESSION cannot work here: the cuff
+# refuses a fresh pair request outside its -P- window (#133), so deleting the
+# bond leaves nothing able to make another one.
 _WLD_BOND_SETTINGS = {
     "bond_policy": BondPolicy.REUSE,
     "pair_only_when_pairing": True,
 }
 
-# Whether WLD3.0/WLD4.0 profiles leave their notify CCCDs enabled at session
-# close instead of writing 0x0000 to them.
+# Leave the notify CCCDs enabled at session close instead of writing 0x0000.
 #
-# Counted across every ATT write in both phone captures we have -- issue #91
-# (BP5465) and issue #67 (HEM-7155T), four sessions, pairing and retained-bond
-# alike -- the official app writes 0x0100 to the vendor CCCDs and 0x0002 to
-# Service Changed, and never writes 0x0000 to any CCCD. It just disconnects.
-# Disables: zero. This integration writes six CCCD values per session, the last
-# of them after the session-close command, as the final GATT operation before
-# the link drops.
+# Disabling them was why the cuff dropped its side of the bond and answered
+# every reconnect with "PIN or Key Missing" (#91). The app never writes 0x0000
+# to a CCCD in either phone capture; the spec has a peripheral keep CCCD
+# configuration per bonded client (Vol 3 Part G, 3.3.3.3) and small stacks
+# store it inside the bond record.
 #
-# The spec has a peripheral keep CCCD configuration per bonded client (Vol 3
-# Part G, 3.3.3.3) and small stacks commonly store it inside the bond record,
-# which would make that last write the one thing we do to persistent per-bond
-# state that the app never does.
-#
-# Family-wide rather than per profile because it only ever removes a write, and
-# because the evidence spans two device families rather than one. It is not on
-# its own a fix for a profile still on PER_SESSION -- that path deletes the bond
-# deliberately -- but it stops the divergence either way.
+# Family-wide because it only ever removes a write and the evidence spans both
+# families.
 _WLD_KEEP_NOTIFY_SUBSCRIPTIONS = True
 
-# Let the cuff end its own session instead of hanging up on it.
+# Stay idle at session end so the cuff can close the link itself.
 #
-# A phone HCI capture of BP5465 in issue #91 shows the official app going
-# quiet after its last read and the cuff dropping the link about three
-# seconds later (HCI 0x13, remote user terminated). This integration
-# disconnected in the same millisecond as the final notification, so every
-# session ended 0x16 - closed by us.
-#
-# Two symptoms fit a cuff that finalises a transfer at its own session end:
-# the unread-records counter that only grows across sessions whose data was
-# read fine (1 -> 4 over the 24 August captures), and the bond it does not
-# honour on the next connection even though both sides now complete key
-# distribution. Five seconds covers the phone's three with margin.
+# Unconfirmed, and the capture reading behind it was wrong: the phone sends
+# HCI Disconnect with reason 0x13 and the controller answers 0x16, which is the
+# phone hanging up, not the cuff. Kept on the two profiles it shipped on rather
+# than removed blind -- it costs five seconds a poll, so it is worth settling.
 _WLD3_EXPERIMENT_PEER_CLOSES_SESSION_SEC = 5.0
 
-# Subscribe to Service Changed while pairing, the way the official app does.
-#
-# The phone capture in issue #67 (same WLD3.0 profile family) writes 0x0002 to
-# handle 0x000B in both of its pairing sessions and in neither of its
-# reconnects. The capture's own service discovery places that handle in the
-# Generic Attribute service (0x0008-0x000B, uuid 0x1801), whose only
-# characteristic is Service Changed - so the write is that characteristic's
-# client configuration, enabling indications.
-#
-# The spec has a peripheral keep that configuration per bonded client. A
-# client that writes none may leave it with nothing worth committing, which
-# is what a cuff refusing a resumed connection ("PIN or Key Missing") after a
-# complete key distribution looks like.
+# Subscribe to Service Changed while pairing, as the app does: the #67 capture
+# writes 0x0002 to handle 0x000B in both pairing sessions and neither reconnect.
+# Unconfirmed; the CCCD fix landed without it.
 _WLD3_EXPERIMENT_SUBSCRIBE_SERVICE_CHANGED = True
 
-# The two settings that are still only on the profiles that were taken apart:
-# the idle window at session end and the Service Changed subscription. Neither
-# is part of the confirmed fix, so they stay where they were rather than
-# spreading to devices nobody has captured. Spread with
-# ``**_WLD3_BOND_EXPERIMENT``; every other profile takes _WLD_BOND_SETTINGS and
-# the dataclass defaults.
+# The two settings above plus a single connect attempt, still only on the two
+# profiles that were taken apart. None is part of the confirmed fix, so they do
+# not spread to devices nobody has captured.
 _WLD3_BOND_EXPERIMENT = {
     **_WLD_BOND_SETTINGS,
     "connect_settle_attempts": 1,

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -171,24 +171,12 @@ class DeviceConfig:
     index_pointer_layout: dict[str, Any] | None = None
 
     # Enable each notify CCCD once and leave it enabled for the life of the
-    # link, the way the official app does. Off by default, because dropping the
-    # subscriptions is what every other profile has always done.
-    #
-    # Across both phone captures — issues #91 and #67, four sessions, pairing
-    # and retained-bond alike — the app writes 0x0100 to the vendor CCCDs and
-    # 0x0002 to Service Changed, and **never writes 0x0000 to any CCCD**. It
-    # just disconnects. This integration writes six CCCD values per session:
-    # the token unlock enables both and then disables both, the memory session
-    # re-enables the RX channel, and the session close disables it again — as
-    # the last GATT operation before the link drops.
-    #
-    # The spec has a peripheral keep the CCCD configuration per bonded client
-    # (Vol 3 Part G, 3.3.3.3), and small stacks commonly store it inside the
-    # bond record. That makes this the one thing we do to persistent per-bond
-    # state that the app never does. ``_secure_unlock`` already avoids the
-    # churn on its own path, with a comment recording that this device family
-    # rejects a pairing request (0xff 0x26) when the unlock CCCD is dropped and
-    # re-added; the token-key path never got the same treatment.
+    # link, the way the app does. Disabling them at session close was why the
+    # cuff dropped its side of the bond (#91): the spec has a peripheral keep
+    # CCCD configuration per bonded client (Vol 3 Part G, 3.3.3.3) and small
+    # stacks store it inside the bond record. ``_secure_unlock`` already
+    # avoided the churn, its comment recording that this family rejects a
+    # pairing request (0xff 0x26) when the unlock CCCD is dropped and re-added.
     keep_notify_subscriptions: bool = False
 
     # Record layout key -> parser in parse_record()
@@ -300,12 +288,9 @@ class DeviceConfig:
     def unpair_after_session(self) -> bool:
         """Drop the OS bond when the session closes (``BondPolicy.PER_SESSION``).
 
-        Dropping a bond is only safe because ``pair_on_connect`` bonds again
-        on the next connect. Without that, an earlier build dropped the bond
-        and then had nothing to reconnect with: HA logs (HEM-7382T1) showed
-        the post-pairing bond working, ``unpair()`` running on session close,
-        and the very next connection failing the post-connect settle on all
-        retries because the bond it needed was gone.
+        Derived rather than configurable so "drop the bond and never make
+        another" cannot be set: an earlier build did exactly that and every
+        connection after the first failed with nothing to reconnect with.
         """
         return (
             self.bond_policy == BondPolicy.PER_SESSION

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -881,18 +881,10 @@ class OmronDeviceSession:
     async def _await_peer_close(self, client: BleakClient, addr: str) -> None:
         """Stay idle at the end of a session so the device can end it itself.
 
-        A phone HCI capture of a BP5465 (issue #91) shows the official app
-        going quiet after its last read and the cuff dropping the link about
-        three seconds later — HCI 0x13, remote user terminated. This
-        integration instead disconnects in the same millisecond as the final
-        notification, so every session ends 0x16, closed by us.
-
-        On a cuff that finalises a transfer at its own session end, that
-        difference costs whatever the session was meant to commit. Two
-        symptoms fit: the unread-records counter that only ever grows across
-        sessions whose data was read successfully, and the bond the cuff does
-        not honour on the next connection even though both sides completed
-        key distribution.
+        Unconfirmed, and the capture reading behind it does not hold: in the
+        phone trace it is the phone that sends HCI Disconnect (reason 0x13) and
+        the controller that answers 0x16, so the app hangs up, not the cuff.
+        Costs its window on every poll of the two profiles that set it.
 
         No-op unless the profile asks for it.
         """
@@ -1165,17 +1157,13 @@ class OmronDeviceSession:
         memory_address = bytes(frame_bytes[3:5])
         expected_data_len = frame_bytes[5]
 
-        # If a specific reply is expected, discard late or unrelated frames, but
-        # always accept 0x8f00 (end-of-transmission / device error frame).
-        #
-        # Type alone cannot tell replies apart: every memory read answers 0x8100
-        # and only the address differs. A late reply to the previous command used
-        # to pass this gate, satisfy the wait, and fail the address check in
-        # read_memory_block afterwards -- by which point the wait was spent, the
-        # real reply arrived with nobody listening, and every following command
-        # consumed the one before it. The address and declared length come
-        # straight out of the command in flight, so a stale frame is dropped here
-        # and the wait continues until the right one lands or the timeout fires.
+        # Discard late or unrelated frames, but always accept 0x8f00: it is both
+        # the session-close ack and the rejection frame, so it can answer
+        # anything. Type alone cannot tell replies apart -- every memory read
+        # answers 0x8100 and only the address differs -- and accepting the wrong
+        # one spends the wait, leaving the real reply to be consumed by the next
+        # command in turn. Address and declared length come from the command in
+        # flight, so a stale frame is dropped and the wait simply continues.
         if packet_type != END_OF_TRANSMISSION_PACKET_TYPE:
             if (
                 self._expected_reply_packet_type is not None
@@ -2106,17 +2094,9 @@ class OmronDeviceSession:
     async def subscribe_service_changed(self) -> bool:
         """Subscribe to Service Changed, as the official app does when pairing.
 
-        A phone HCI capture of the same cuff family (issue #67) shows the app
-        writing 0x0002 to handle 0x000B — the Service Changed client
-        configuration, the sole characteristic of the Generic Attribute
-        service — in both of its pairing sessions and in neither of its
-        reconnects. This integration has never written it.
-
-        That configuration is one the spec requires a peripheral to keep per
-        bonded client, so a client that writes nothing may leave it with
-        nothing worth committing. The cuff answering a resumed connection with
-        "PIN or Key Missing" while both sides completed key distribution is
-        what that would look like.
+        The #67 capture writes 0x0002 to handle 0x000B in both pairing sessions
+        and neither reconnect. The spec has a peripheral keep that client
+        configuration per bonded client. Unconfirmed as a fix.
 
         Best effort: a device without the characteristic, or a backend that
         refuses the subscribe, must not fail the pairing.

--- a/custom_components/omron/omron_ble/setup.py
+++ b/custom_components/omron/omron_ble/setup.py
@@ -32,14 +32,10 @@ async def async_fetch_device_model_number(
 ) -> tuple[str | None, OmronDeviceSession | None]:
     """Read the model number, returning the session when asked to keep it open.
 
-    The link is not incidental. WLD3.0 cuffs raise an SMP Security Request a
-    few tens of milliseconds after connect, so this short read is where the
-    bond actually gets made — and proxy traces in issue #91 show it being cut
-    off mid key distribution: the cuff's Encryption Information (the LTK)
-    arrives, the Master Identification carrying EDIV/Rand does not, and this
-    function disconnects with SMP still in BOND_PENDING. LE legacy pairing
-    needs all three to restart encryption later, so the stored bond is
-    unusable and the first ordinary poll fails to resume with SMP_ENC_FAIL.
+    The link is not incidental: WLD3.0 cuffs raise an SMP Security Request a few
+    tens of milliseconds after connect, so this short read is where the bond
+    actually gets made. Closing it mid key distribution leaves a stored bond
+    missing the EDIV/Rand half, which legacy pairing needs to resume later.
 
     ``keep_session_open`` hands the caller the live session instead, so the
     pairing that follows continues on the link that bonded. The caller owns it


### PR DESCRIPTION
Comments only. No code changes — `git diff --stat` is 3 source files plus `setup.py`, all comment and docstring lines.

The comments grew alongside a two-month debugging thread and kept its shape: what each experiment was, which capture suggested it, what got ruled out along the way. That belongs in the issues and the git history; reading it in the source now costs more than it explains.

Cut to what a reader needs in order not to break something — the constraint, and why it exists.

| block | before | after |
| --- | --- | --- |
| catalog bond strategy + CCCD + two experiment settings | 82 | 37 |
| `keep_notify_subscriptions` field comment | 19 | 7 |
| `_await_peer_close` docstring | 17 | 9 |
| reply-matching comment | 11 | 7 |
| `subscribe_service_changed` docstring | 17 | 9 |
| `async_fetch_device_model_number` docstring | 15 | 11 |
| `unpair_after_session` docstring | 9 | 6 |

## One was wrong, not just long

`_await_peer_close` claimed the phone capture shows the cuff dropping the link three seconds after the last read. It shows the *phone* sending `HCI Disconnect` with reason `0x13` and the controller answering `0x16` — the phone hanging up. The reason byte in a Disconnect *command* is what we tell the peer; the event is what happened.

That misreading is the whole basis for `peer_closes_session_sec = 5.0`, which costs five seconds on every poll of the two profiles that set it. The docstring now says so rather than repeating the claim.

## Kept

- the post-connect settle comment — it lists what races the first GATT op, and someone will otherwise delete the sleep
- the parked-session ordering in the advertisement handler
- the token handshake frame format and its `0xff26` constraint
- EEPROM and MSD layout references

Those are reference material, not narrative.