### PR TITLE
fix: show the HEM designation rather than a retail carton name

### DIFF
--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -234,6 +234,27 @@ class DeviceConfig:
             )
 
     @property
+    def display_model(self) -> str:
+        """Model name for the UI, kept in the HEM- form.
+
+        A profile can be reached by a retail carton name -- BP5465 is the only
+        one in the catalog -- and that is also what the cuff answers with over
+        GATT, so it can end up in the device registry as the model. Show the
+        profile key instead: it is a real HEM designation and the one thing we
+        know maps to this device. There is no retail-to-variant table to do
+        better with, and inventing one would be a guess.
+
+        An unrecognised name is left alone rather than replaced with the
+        fallback profile, which would name a device we did not identify. Logs
+        keep ``model`` either way, so a report still shows what was resolved.
+        """
+        if self.model.upper().startswith("HEM-"):
+            return self.model
+        if self.model in CANONICAL_DEVICE_PROFILES or self.model in MODEL_VARIANT_MAP:
+            return resolve_profile_model_id(self.model)
+        return self.model
+
+    @property
     def num_users(self) -> int:
         """Return the number of users this device supports."""
         return len(self.user_start_addresses)

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -835,7 +835,7 @@ class OmronBluetoothDeviceData(BluetoothData):
 
     def _setup_device_info(self, service_info: BluetoothServiceInfoBleak) -> None:
         """Set up device metadata from advertisement."""
-        model = self._device_config.model
+        model = self._device_config.display_model
         manufacturer = "Omron"
         normalized_address = service_info.address.replace(":", "")
         identifier = normalized_address[-4:] if len(normalized_address) >= 4 else normalized_address

--- a/tests/test_display_model.py
+++ b/tests/test_display_model.py
@@ -1,0 +1,71 @@
+"""기기 이름에 소매 모델명이 새어나가지 않게 한다 (이슈 #91).
+
+BP5465 는 카탈로그에서 유일하게 HEM- 규칙 밖에 있는 이름이고, 커프가 GATT
+Model Number String 으로 답하는 값이기도 하다. 모델명으로 프로파일을 고를 수
+있게 된 뒤(#137) 그 이름이 그대로 기기 등록부까지 흘러가 ``BP5465 D5BB`` 로
+표시됐다.
+
+소매명 -> HEM 변형 대응표는 없다. ``equivalent_model_ids`` 는 평평한 목록이라
+BP5465 가 HEM-7382T1-AZAZ 인지 HEM-7388T1-AJF3 인지 카탈로그는 모른다. 그래서
+추측하지 않고 프로파일 키를 쓴다 — 실제로 아는 사실이고, 진짜 HEM 표기다.
+"""
+from custom_components.omron.omron_ble.device_catalog import (
+    CANONICAL_DEVICE_PROFILES,
+)
+from custom_components.omron.omron_ble.devices import (
+    MODEL_VARIANT_MAP,
+    get_device_config,
+)
+
+
+def test_the_retail_name_is_shown_as_its_profile():
+    config = get_device_config("BP5465")
+
+    assert config.model == "BP5465", "로그에는 실제로 해석된 이름이 남아야 한다"
+    assert config.display_model == "HEM-7386T1"
+
+
+def test_hem_names_are_left_exactly_as_chosen():
+    """사용자가 고른 변형은 프로파일 키보다 정확하다 — 뭉개면 안 된다."""
+    for model in ("HEM-7382T1-AZAZ", "HEM-7386T1", "HEM-7142T2", "HEM-7380T1"):
+        assert get_device_config(model).display_model == model, model
+
+
+def test_an_unknown_name_is_not_renamed_to_the_fallback_profile():
+    """모르는 기기에 HEM-7142T2 라는 이름을 붙이면 거짓말이 된다."""
+    config = get_device_config("SOME-UNLISTED-THING")
+
+    assert config.model == "SOME-UNLISTED-THING"
+    assert config.display_model == "SOME-UNLISTED-THING"
+
+
+def test_every_catalog_name_displays_as_hem():
+    """카탈로그에서 고를 수 있는 이름은 전부 HEM- 로 표시돼야 한다."""
+    off_convention = []
+    for name in sorted(set(CANONICAL_DEVICE_PROFILES) | set(MODEL_VARIANT_MAP)):
+        shown = get_device_config(name).display_model
+        if not shown.upper().startswith("HEM-"):
+            off_convention.append((name, shown))
+    assert not off_convention, off_convention
+
+
+def test_the_device_name_path_reads_display_model():
+    """표시 경로가 실제로 그 값을 쓰는지 — 여기서 갈라지면 설정만 고친 셈이다.
+
+    소스 텍스트를 보는 이유: conftest 가 ``BluetoothData`` 를 MagicMock 으로
+    갈아끼우기 때문에 ``OmronBluetoothDeviceData`` 는 클래스 객체조차 만들어지지
+    않는다(그 자체가 Mock 이다). 인스턴스화도, 메서드 리플렉션도 불가능하므로
+    이 하네스에서 이 배선을 지킬 방법은 이것뿐이다.
+    """
+    import pathlib
+
+    source = pathlib.Path(
+        "custom_components/omron/omron_ble/parser.py"
+    ).read_text(encoding="utf-8")
+    head = source.split("def _setup_device_info(")[1]
+    body = head.split("self.pending = False")[0]
+
+    assert "self._device_config.display_model" in body
+    assert "self._device_config.model" not in body, (
+        "설정 필드를 그대로 읽으면 소매명이 다시 새어나간다"
+    )


### PR DESCRIPTION
`BP5465` is the one name in the catalog outside the HEM- convention, and it is also what that cuff answers with over the GATT Model Number String. Once a probed model number could select a profile (#137), the name reached the device registry too — so the device showed up as **`BP5465 D5BB`**. Reported in [#91](https://github.com/eigger/hass-omron/issues/91).

## The change

A new `display_model` on `DeviceConfig` falls back to the profile key when the model is not in HEM- form:

| selected / probed | `config.model` | device name |
| --- | --- | --- |
| `BP5465` | `BP5465` | ~~`BP5465 D5BB`~~ → **`HEM-7386T1 D5BB`** |
| `HEM-7382T1-AZAZ` | `HEM-7382T1-AZAZ` | `HEM-7382T1-AZAZ D5BB` — unchanged |
| unrecognised name | as given | as given — unchanged |

## Why the profile key and not the matching variant

`equivalent_model_ids` is a flat list. Under `HEM-7386T1` it holds `HEM-7381T1-AZ`, `HEM-7382T1`, `HEM-7382T1-AZAZ`, `HEM-7386T1-AJF3`, `HEM-7388T1-AJF3` and `BP5465` — nothing there says which HEM variant `BP5465` is. The reporter picked `HEM-7382T1-AZAZ` by hand; the catalog does not know that. Building a retail-to-variant table would mean guessing for the other 243 variants.

The profile key is a real HEM designation and the one mapping we do know.

## Display only

`config.model` keeps the resolved name, so logs still say what the device answered with or what the user picked — `Poll failed model=BP5465 profile=HEM-7386T1` is unchanged. That is the more useful thing to have in a bug report.

Two cases are deliberately left alone:

- **A HEM- name stays exactly as chosen.** `HEM-7382T1-AZAZ` is more precise than its profile key and should not be flattened to it.
- **An unrecognised name stays as given** rather than being renamed to the fallback profile, which would put `HEM-7142T2` on a device we did not identify.

## Tests

`tests/test_display_model.py`, five cases including a sweep asserting every selectable catalog name displays in HEM- form.

The last one checks the wiring by reading `parser.py` as text, which needs a word of explanation: conftest replaces `BluetoothData` with a `MagicMock`, so `OmronBluetoothDeviceData` never becomes a real class — instantiation and method reflection are both unavailable. A source check is the only guard this harness allows, and it does catch the regression: reverting that one line fails exactly that test.