### PR TITLE
feat: resolve the model number a cuff actually answers with

### DIFF
--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -15,6 +15,7 @@ from .const import (
     CLASSIC_STACK_TX_CHARACTERISTIC_UUIDS,
     DEFAULT_DEVICE_MODEL,
 )
+from .model_aliases import MODEL_NUMBER_ALIASES
 from .record_parsers import (
     parse_classic_vital_14,
     parse_classic_vital_14_6232_family,
@@ -250,6 +251,9 @@ class DeviceConfig:
         """
         if self.model.upper().startswith("HEM-"):
             return self.model
+        alias = MODEL_NUMBER_ALIASES.get(self.model)
+        if alias:
+            return alias
         if self.model in CANONICAL_DEVICE_PROFILES or self.model in MODEL_VARIANT_MAP:
             return resolve_profile_model_id(self.model)
         return self.model
@@ -415,6 +419,11 @@ def get_device_config(model: str) -> DeviceConfig:
     if variant_profile:
         config = CANONICAL_DEVICE_PROFILES[variant_profile]
         return replace(config, model=model)
+    alias = MODEL_NUMBER_ALIASES.get(model)
+    if alias:
+        # The name the device answers with is kept, so logs show what it said;
+        # display_model turns it into the HEM designation for the UI.
+        return replace(get_device_config(alias), model=model)
     _LOGGER.warning(
         "Unknown device model '%s', falling back to %s",
         model, DEFAULT_DEVICE_MODEL,
@@ -494,5 +503,8 @@ def resolve_profile_model_id(model: str) -> str:
     variant_profile = MODEL_VARIANT_MAP.get(model)
     if variant_profile:
         return variant_profile
+    alias = MODEL_NUMBER_ALIASES.get(model)
+    if alias:
+        return resolve_profile_model_id(alias)
     return DEFAULT_DEVICE_MODEL
 

--- a/custom_components/omron/omron_ble/model_aliases.py
+++ b/custom_components/omron/omron_ble/model_aliases.py
@@ -1,0 +1,82 @@
+"""Model Number Strings that need mapping to a catalog id.
+
+A cuff answers the GATT Model Number String with whatever its carton says, and
+that is often neither the profile key nor one of the variants already listed:
+a BP5465 is a HEM-7382T1-AZAZ, and a cuff calling itself HEM-7140T1 is really a
+HEM-7140T1-AP. Without a mapping such a name matches nothing and falls back to
+the default profile, which then reads the wrong EEPROM layout.
+
+Taken from the OMRON connect Android app's own device list, which carries both
+names for every device it supports, and kept only where the target already
+resolves in this catalog.
+
+Three names are deliberately absent. BP5350, BP7350 and BP7350CAN each cover two
+hardware revisions that speak different protocols -- HEM-7155T is WLS3.0 with
+four RX/TX channels and custom-key pairing, HEM-7155T-K4 is WLD2.0 with one
+channel and OS bonding -- so a wrong guess reads the device through the wrong
+stack entirely. The app separates them too, by a group id that lands in a range
+this catalog already classifies the same way, so the split is real rather than
+an artefact of how these profiles were once divided here.
+
+They are resolvable in principle: the two stacks expose different parent service
+UUIDs, which is visible on connect. Doing that needs the device in hand rather
+than a model string, so it is left for later.
+
+Resolution aliases only: get_supported_models does not offer them in the
+config-flow dropdown, which stays on the HEM designations.
+"""
+from __future__ import annotations
+
+MODEL_NUMBER_ALIASES: dict[str, str] = {
+    "BP300": "HEM-7320T-ZV",
+    "BP4350": "HEM-6232T-Z",
+    "BP5150": "HEM-7142T2-ZAZ",
+    "BP5250": "HEM-7151T-Z",
+    "BP5255": "HEM-716BT2-ZAZ",
+    "BP5360": "HEM-7377T1-ZAZ",  # WLD3.0/4.0 family
+    "BP5450": "HEM-7343T-Z",
+    "BP5465": "HEM-7382T1-AZAZ",  # WLD3.0/4.0 family
+    "BP6001": "HEM-6402T-Z",
+    "BP6350": "HEM-6231T_Z",
+    "BP653": "HEM-6321T-Z",
+    "BP654": "HEM-6320T-Z",
+    "BP7000": "HEM-7600T-Z",
+    "BP7150": "HEM-7142T2-Z",
+    "BP7250": "HEM-7150T-Z",
+    "BP7250CAN": "HEM-7150T-CA",
+    "BP7255": "HEM-716CT2-Z",
+    "BP7360": "HEM-7376T1-Z",  # WLD3.0/4.0 family
+    "BP7365CAN": "HEM-7376T1-ACACD6",  # WLD3.0/4.0 family
+    "BP7450": "HEM-7342T-Z",
+    "BP7450CAN": "HEM-7342T-CA",
+    "BP7455CAN": "HEM-7342T1-ACACD6",
+    "BP7465": "HEM-7381T1-AZ",  # WLD3.0/4.0 family
+    "BP761CANN": "HEM-7320T-CA",
+    "BP761N": "HEM-7320T-ZV",
+    "BP761|CAN": "HEM-7320T_TI-Z",
+    "BP769CAN": "HEM-7320T-CACS",
+    "BP786CANN": "HEM-7321T-CA",
+    "BP786N": "HEM-7321T-ZV",
+    "BP786|CAN": "HEM-7321T_TI-Z",
+    "BP7900": "HEM-7530T-Z",
+    "BP8000": "HEM-6410T-Z",
+    "HCR-1901T2": "HEM-1026T2-AJC",
+    "HCR-1902T2": "HEM-1026T2-AJE",
+    "HCR-7206T2": "HEM-7146T2-JD",
+    "HCR-7308T2": "HEM-7146T2-JF",
+    "HCR-7608T2": "HEM-7600T2-JF",
+    "HCR-7612T2": "HEM-7346T2-AJE32",
+    "HCR-761AT2": "HEM-7346T2-AJC32",
+    "HCR-7711T2": "HEM-7347T2-AJC32",
+    "HCR-7712T2": "HEM-7347T2-AJE32",
+    "HEM-6161T-D/E": "HEM-6161T-E",
+    "HEM-6232T-D/E": "HEM-6232T-D",
+    "HEM-7140T1": "HEM-7140T1-AP",
+    "HEM-7142T1": "HEM-7142T1-AP",
+    "HEM-7143T1-EBK": "HEM-7143T1-E",
+    "HEM-7143T2-ESL": "HEM-7143T2-E",
+    "HEM-7155T-AP": "HEM-7155T_AP",
+    "HEM-7156T": "HEM-7156T_AP",
+    "HEM-7156T-AAP": "HEM-7156T_AAP",
+    "HEM-9601T-E3": "HEM-9601T_E3",
+}

--- a/tests/test_display_model.py
+++ b/tests/test_display_model.py
@@ -18,11 +18,20 @@ from custom_components.omron.omron_ble.devices import (
 )
 
 
-def test_the_retail_name_is_shown_as_its_profile():
+def test_the_retail_name_is_shown_in_hem_form():
+    """앱 자체 데이터가 대응을 알려주므로 프로파일 키가 아니라 정확한 변형이다."""
     config = get_device_config("BP5465")
 
     assert config.model == "BP5465", "로그에는 실제로 해석된 이름이 남아야 한다"
-    assert config.display_model == "HEM-7386T1"
+    assert config.display_model == "HEM-7382T1-AZAZ"
+
+
+def test_a_name_with_no_mapping_at_all_is_left_alone():
+    """모르는 이름에 프로파일명을 붙이면 식별하지 못한 기기에 이름을 지어주는 셈이다."""
+    from dataclasses import replace
+
+    unmapped = replace(get_device_config("HEM-7386T1"), model="BP-UNMAPPED")
+    assert unmapped.display_model == "BP-UNMAPPED"
 
 
 def test_hem_names_are_left_exactly_as_chosen():

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -1,0 +1,72 @@
+"""GATT Model Number String 을 카탈로그 id 로 잇는 별칭 (이슈 #91).
+
+커프는 자기 카톤에 적힌 이름을 Model Number String 으로 답한다. 그 이름이
+프로파일 키도, 이미 등록된 변형도 아닌 경우가 많다 — BP5465 는
+HEM-7382T1-AZAZ 이고, 스스로를 HEM-7140T1 이라 부르는 기기는 HEM-7140T1-AP 다.
+매핑이 없으면 아무것도 안 걸려 기본 프로파일로 폴백하고, 그러면 EEPROM 을 엉뚱한
+레이아웃으로 읽는다.
+
+표는 OMRON connect 안드로이드 앱이 들고 있는 기기 목록에서 뽑았다.
+"""
+from custom_components.omron.omron_ble.device_catalog import (
+    CANONICAL_DEVICE_PROFILES,
+)
+from custom_components.omron.omron_ble.devices import (
+    MODEL_VARIANT_MAP,
+    get_device_config,
+    get_supported_models,
+    resolve_profile_model_id,
+)
+from custom_components.omron.omron_ble.model_aliases import MODEL_NUMBER_ALIASES
+
+
+def test_the_reported_cuff_shows_its_hem_designation():
+    """이슈 #91 의 기기. 앱 자체 데이터가 BP5465 = HEM-7382T1-AZAZ 라고 한다."""
+    config = get_device_config("BP5465")
+
+    assert config.display_model == "HEM-7382T1-AZAZ"
+    assert config.model == "BP5465", "로그에는 기기가 답한 이름이 남아야 한다"
+    assert resolve_profile_model_id("BP5465") == "HEM-7386T1"
+
+
+def test_a_retail_name_we_could_not_resolve_now_lands_on_the_right_profile():
+    """전에는 어느 것도 안 걸려 기본 프로파일로 갔다 — 레코드 레이아웃이 다르다."""
+    assert resolve_profile_model_id("BP7360") == "HEM-7376T1"
+    assert resolve_profile_model_id("BP7465") == "HEM-7386T1"
+    assert resolve_profile_model_id("BP7900") == "HEM-7530T"
+
+    config = get_device_config("BP7360")
+    assert config.model == "BP7360"
+    assert config.display_model == "HEM-7376T1-Z"
+
+
+def test_a_short_hem_form_also_resolves():
+    """소매 코드만의 문제가 아니다 — 짧은 HEM 표기도 카탈로그에 없을 수 있다."""
+    assert resolve_profile_model_id("HEM-7140T1") == "HEM-7142T2"
+    # 이미 HEM 표기이므로 표시는 건드리지 않는다.
+    assert get_device_config("HEM-7140T1").display_model == "HEM-7140T1"
+
+
+def test_the_ambiguous_names_are_left_out():
+    """같은 소매명이 두 하드웨어 리비전에 걸치면 고를 수 없다.
+
+    BP5350 / BP7350 / BP7350CAN 은 HEM-7155T 와 HEM-7155T-K4 를 함께 가리킨다.
+    레코드 포맷이 다르므로 하나를 찍으면 틀린 쪽을 읽는다.
+    """
+    for name in ("BP5350", "BP7350", "BP7350CAN"):
+        assert name not in MODEL_NUMBER_ALIASES, name
+
+
+def test_every_alias_points_at_something_the_catalog_knows():
+    """표가 낡으면 조용히 기본 프로파일로 흘러간다 — 대상은 실재해야 한다."""
+    known = set(CANONICAL_DEVICE_PROFILES) | set(MODEL_VARIANT_MAP)
+    dangling = {a: t for a, t in MODEL_NUMBER_ALIASES.items() if t not in known}
+    assert not dangling, dangling
+
+
+def test_aliases_do_not_grow_the_dropdown():
+    """설정 화면은 HEM 표기로 유지한다 — 별칭은 해석용이다."""
+    added = set(MODEL_NUMBER_ALIASES) & set(get_supported_models())
+
+    # BP5465 는 원래 카탈로그 변형으로 등록돼 있어 예외다.
+    assert added <= {"BP5465"}, added


### PR DESCRIPTION
A cuff answers the GATT Model Number String with whatever its carton says, and that is often neither a profile key nor one of the variants already listed. A `BP5465` is a `HEM-7382T1-AZAZ`; a cuff calling itself `HEM-7140T1` is really a `HEM-7140T1-AP`.

Neither matched anything, so both fell back to the default profile and read the wrong EEPROM layout — **silently**, because a fallback still produces a config.

## The table

`MODEL_NUMBER_ALIASES` adds 51 names, taken from the OMRON connect Android app's own device list, which carries both names for every device it supports. Kept only where the target already resolves here, so nothing points at a profile this integration does not have.

| | before | after |
| --- | --- | --- |
| `BP7360` | fell back to `HEM-7142T2` | `HEM-7376T1` |
| `BP7465` | fell back to `HEM-7142T2` | `HEM-7386T1` |
| `BP7900` | fell back to `HEM-7142T2` | `HEM-7530T` |
| `HEM-7140T1` | fell back to `HEM-7142T2` | `HEM-7142T2` — same, now for the right reason |

## Three left out on purpose

`BP5350`, `BP7350` and `BP7350CAN` each cover two hardware revisions that speak **different protocols**:

| | HEM-7155T | HEM-7155T-K4 |
| --- | --- | --- |
| family | WLS3.0 | WLD2.0 |
| parent service | `ecbe3980-…` | `0000fe4a-…` |
| RX/TX channels | 4 | 1 |
| pairing | custom key | OS bonding |

Picking either would read the device through the wrong stack, so no mapping is better than a guess.

That split is not an artefact of how these profiles were once divided here — **the app draws the same line.** Its `deviceGroupIncludedGroupIDKey` gives the K4 revisions 175/176/177 against 339/350/353 for the others, and grouping every app entry by the family this catalog assigns shows no overlap at all between families:

```
WLD2.0  161 162 175 176 177 180 181 193
WLD3.0  207 208 209 210 211 212 265
WLD4.0  222 225 235 241
WLS3.0  ... 339 340 350 351 352 353 ...
```

They are resolvable in principle: the two stacks expose different parent service UUIDs, visible on connect. That needs the device rather than a model string, so it is left for later.

## Display

`display_model` uses the table too, so the device in issue #91 now reads **`HEM-7382T1-AZAZ`** rather than the profile key `HEM-7386T1` — the same designation the reporter picked by hand.

`config.model` still keeps the name the device answered with, so logs show what was actually seen.

The config-flow dropdown is unchanged: these are resolution aliases, not selectable models. `BP5465` appears there anyway, as it already did.

## A side confirmation

The app's `deviceSeries` field marks nine devices `ppw`, and every one is a profile already classified WLD3.0 or WLD4.0 here — with no WLD3.0 outside that set. The family boundaries this integration arrived at by reverse engineering match the vendor's own grouping.

That list is also exactly the set of devices the CCCD fix in #136 applies to: HEM-7380T1-EOSL and HEM-7380T1-EBK (issues #20, #133), BP5465 / HEM-7382T1-AZAZ (issue #91), BP7465 / HEM-7381T1-AZ, BP5360 / HEM-7377T1-ZAZ, BP7360 / HEM-7376T1-Z, BP7365CAN / HEM-7376T1-ACACD6 (issue #62), and HEM-7196T1-FLE / -FLEO (issue #45).

## Provenance

Extracted from the app's asset list and reduced to the mapping. No vendor file is vendored into the repo.
