### PR TITLE
fix: match a memory reply on its address, not its declared length

### DIFF
--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.0"
+  "version": "2.8.1"
 }

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -638,7 +638,7 @@ class OmronDeviceSession:
         self._last_reply_memory_address: bytes | None = None
         self._last_reply_payload: bytes | None = None
         self._expected_reply_packet_type: bytes | None = None
-        self._expected_reply_frame_head: bytes | None = None
+        self._expected_reply_memory_address: bytes | None = None
         self._reply_ready = asyncio.Event()
         self._channel_fragments: list[bytes | None] = [None] * 4
         self._notify_handle_to_channel: dict[int, int] = {}
@@ -1054,7 +1054,7 @@ class OmronDeviceSession:
         self._memory_session_active = False
         self._channel_fragments = [None] * 4
         self._expected_reply_packet_type = None
-        self._expected_reply_frame_head = None
+        self._expected_reply_memory_address = None
         self._reply_ready.clear()
         self._debug_ble_link("reset_session_state")
 
@@ -1162,8 +1162,15 @@ class OmronDeviceSession:
         # anything. Type alone cannot tell replies apart -- every memory read
         # answers 0x8100 and only the address differs -- and accepting the wrong
         # one spends the wait, leaving the real reply to be consumed by the next
-        # command in turn. Address and declared length come from the command in
-        # flight, so a stale frame is dropped and the wait simply continues.
+        # command in turn. Matching the address as well is what keeps a stale
+        # frame from doing that, and the wait then simply continues.
+        #
+        # The declared length is deliberately not matched. Only two device
+        # families have ever been captured, so what every other one puts in that
+        # byte is unknown, and a device that answers with anything but the
+        # requested length would have every reply dropped and every poll fall
+        # back to cached data. The address alone separates the replies that can
+        # be in flight at once.
         if packet_type != END_OF_TRANSMISSION_PACKET_TYPE:
             if (
                 self._expected_reply_packet_type is not None
@@ -1175,16 +1182,15 @@ class OmronDeviceSession:
                     _hex(self._expected_reply_packet_type),
                 )
                 return
-            head = bytes(frame_bytes[1:6])
             if (
-                self._expected_reply_frame_head is not None
-                and head != self._expected_reply_frame_head
+                self._expected_reply_memory_address is not None
+                and memory_address != self._expected_reply_memory_address
             ):
                 _LOGGER.debug(
-                    "Ignoring a late reply meant for another request: got %s, "
+                    "Ignoring a late reply meant for another address: got %s, "
                     "waiting for %s",
-                    _hex(head),
-                    _hex(self._expected_reply_frame_head),
+                    _hex(memory_address),
+                    _hex(self._expected_reply_memory_address),
                 )
                 return
 
@@ -1221,14 +1227,11 @@ class OmronDeviceSession:
             self._expected_reply_packet_type = bytes([command[1] | 0x80, command[2]])
         else:
             self._expected_reply_packet_type = None
-        # type(2) + address(2) + declared length(1), all of which a reply echoes
-        # from the command that asked for it.
-        if len(command) >= 6:
-            self._expected_reply_frame_head = (
-                bytes([command[1] | 0x80]) + bytes(command[2:6])
-            )
+        # The address a reply must echo back from the command asking for it.
+        if len(command) >= 5:
+            self._expected_reply_memory_address = bytes(command[3:5])
         else:
-            self._expected_reply_frame_head = None
+            self._expected_reply_memory_address = None
 
         if self._config.unlock_mode == UnlockMode.SECURE_SESSION and self._secure_session is not None:
             try:
@@ -1343,7 +1346,7 @@ class OmronDeviceSession:
             )
         finally:
             self._expected_reply_packet_type = None
-            self._expected_reply_frame_head = None
+            self._expected_reply_memory_address = None
 
     @property
     def memory_session_active(self) -> bool:

--- a/tests/test_reply_matching.py
+++ b/tests/test_reply_matching.py
@@ -47,7 +47,7 @@ class _Session:
         self._notify_handle_to_channel = {}
         self._secure_session = None
         self._expected_reply_packet_type = None
-        self._expected_reply_frame_head = None
+        self._expected_reply_memory_address = None
         self._last_reply_packet_type = None
         self._last_reply_memory_address = None
         self._last_reply_payload = None
@@ -56,7 +56,7 @@ class _Session:
     def expect(self, command: bytearray) -> None:
         """_write_command_and_wait_reply 가 전송 직전에 세우는 기대값."""
         self._expected_reply_packet_type = bytes([command[1] | 0x80, command[2]])
-        self._expected_reply_frame_head = bytes([command[1] | 0x80]) + bytes(command[2:6])
+        self._expected_reply_memory_address = bytes(command[3:5])
 
     def feed(self, frame: bytearray) -> None:
         OmronDeviceSession._on_notify_channel_data(self, object(), bytearray(frame))
@@ -98,12 +98,19 @@ def test_the_real_reply_still_lands_after_a_late_one():
     assert s._last_reply_memory_address == (0x0E3C).to_bytes(2, "big")
 
 
-def test_a_reply_of_the_right_address_but_the_wrong_length_is_refused():
-    """주소만 맞고 길이가 다르면 다른 요청의 답이다."""
+def test_a_reply_with_an_unexpected_length_is_still_accepted():
+    """선언 길이는 일부러 비교하지 않는다.
+
+    캡처가 있는 기기 계열은 둘뿐이라 나머지가 그 바이트에 무엇을 싣는지 모른다.
+    요청 길이와 다르게 답하는 기기가 있으면 모든 응답이 버려지고 폴이 매번
+    캐시로 떨어진다 — 이슈 #45(HEM-7196T1, WLD4.0)의 2.8.0 증상이 그 모양이었다.
+    동시에 떠 있을 수 있는 응답을 가르는 데는 주소로 충분하다.
+    """
     s = _Session()
     s.expect(_read_cmd(0x0E3C, 16))
 
-    assert _fed(s, _read_reply(0x0E3C, 28)) is False
+    assert _fed(s, _read_reply(0x0E3C, 28)) is True
+    assert s._last_reply_memory_address == (0x0E3C).to_bytes(2, "big")
 
 
 def test_the_desync_cascade_cannot_start():


### PR DESCRIPTION
The reply matcher added in #140 required a frame to echo three things from the command in flight: packet type, address, and declared length.

**The length was a mistake.** Only two device families have ever been captured, so what every other one puts in that byte is unknown. A device that answers with anything but the requested length has every reply dropped, every command time out after four retries, and every poll fall back to cached data.

## The report

Issue #45, HEM-7196T1 (WLD4.0) over an ESP proxy, where `2.7.8-beta.7` had worked:

> After measurement, got proxy connected automatically, but nothing was synced.
> 1st manual refresh data also did not return anything.
> 2nd manual refresh returned some old measurement, not the one displayed on the device
> 3rd manual refresh did not change anything
> all three manual refreshes shows BT indicator on the device for short time

The Bluetooth indicator lights on every attempt, so the link is fine and security is up — this is not a bond problem. Nothing new decodes, and once there is a cached reading the coordinator keeps serving it, which is what "some old measurement" is.

That profile is otherwise unchanged between the two builds. Diffing it gives two lines, both behaviour flags, and its EEPROM addresses, record size and parser are identical. What is left is the matcher.

## The change

Match the address, not the length.

The address alone separates the replies that can be in flight at once, which was the whole point of #140: every memory read answers `0x8100` and only the address differs. Dropping the length keeps the fix for the desync cascade and stops requiring a header field no capture justifies.

```diff
-            head = bytes(frame_bytes[1:6])          # type + address + length
-            if head != self._expected_reply_frame_head:
+            if memory_address != self._expected_reply_memory_address:
```

## Tests

The case that pinned the old behaviour now pins the new one: a reply carrying an unexpected declared length is accepted as long as the address matches. The desync-cascade test — three commands each fed the previous one's reply — still passes, and disabling the address check still fails three of the seven.

Version to 2.8.1.
