### PR TITLE
Fail loudly when a config flow step has no chosen model

### DIFF
--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -35,6 +35,7 @@ from homeassistant.config_entries import (
     OptionsFlow,
 )
 from homeassistant.const import CONF_ADDRESS, CONF_SCAN_INTERVAL
+from homeassistant.data_entry_flow import AbortFlow
 
 from .ble_session import (
     stash_handoff_session,
@@ -42,12 +43,12 @@ from .ble_session import (
     take_probe_session,
 )
 from .const import CONF_BINDKEY, CONF_DEVICE_MODEL, CONF_USER_ALIASES, DOMAIN
+from .omron_ble.const import DEFAULT_DEVICE_MODEL
 from .omron_ble.omron_driver import OmronDeviceSession
 from .omron_ble.setup import (
     async_fetch_device_model_number,
     async_pair_and_sync_device,
 )
-from .omron_ble.const import DEFAULT_DEVICE_MODEL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -320,11 +321,23 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders=desc_ph,
         )
 
+    def _require_selected_model(self) -> str:
+        """The model chosen in select_model, which every later step depends on.
+
+        Substituting a default here would put the device on a foreign EEPROM
+        map without saying so -- the failure mode of #45. Every path into these
+        steps runs select_model first, so this only fires if that stops being
+        true.
+        """
+        if self._selected_model is None:
+            raise AbortFlow("model_not_selected")
+        return self._selected_model
+
     async def async_step_user_aliases(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
         """Collect display names for each device user slot (multi-user models only)."""
-        model = self._selected_model or DEFAULT_DEVICE_MODEL
+        model = self._require_selected_model()
         cfg = get_device_config(model)
         if cfg.num_users <= 1:
             self._user_aliases = {}
@@ -390,7 +403,7 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
                 _log_pairing_exception("Unexpected error during pairing", exc)
                 errors["base"] = "pairing_failed"
 
-        model = self._selected_model or DEFAULT_DEVICE_MODEL
+        model = self._require_selected_model()
         config = get_device_config(model)
         step_id = "pairing_os" if config.host_pairing_mode == HostPairingMode.OS_BONDING else "pairing"
 
@@ -418,7 +431,7 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
         if not self._discovery_info:
             raise ConnectionError("No device discovered")
 
-        model = self._selected_model or DEFAULT_DEVICE_MODEL
+        model = self._require_selected_model()
         config = get_device_config(model)
         profile_key = resolve_profile_model_id(model)
         if model != profile_key:

--- a/custom_components/omron/strings.json
+++ b/custom_components/omron/strings.json
@@ -50,7 +50,8 @@
       "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
       "already_in_progress": "[%key:common::config_flow::abort::already_in_progress%]",
       "already_configured": "[%key:common::config_flow::abort::already_configured_device%]",
-      "not_supported": "This device is not supported."
+      "not_supported": "This device is not supported.",
+      "model_not_selected": "The device model was not selected. Start over and pick the model from the list."
     }
   },
   "options": {

--- a/custom_components/omron/translations/en.json
+++ b/custom_components/omron/translations/en.json
@@ -50,7 +50,8 @@
       "no_devices_found": "No unconfigured devices found on the network",
       "already_in_progress": "Configuration flow is already in progress",
       "already_configured": "Device is already configured",
-      "not_supported": "This device is not supported."
+      "not_supported": "This device is not supported.",
+      "model_not_selected": "The device model was not selected. Start over and pick the model from the list."
     }
   },
   "options": {

--- a/custom_components/omron/translations/ko.json
+++ b/custom_components/omron/translations/ko.json
@@ -40,7 +40,8 @@
       "duplicate_user_aliases": "각 사용자 슬롯 이름은 서로 달라야 합니다(대소문자 구분 없음)."
     },
     "abort": {
-      "not_supported": "지원되지 않는 기기입니다."
+      "not_supported": "지원되지 않는 기기입니다.",
+      "model_not_selected": "기기 모델이 선택되지 않았습니다. 처음부터 다시 진행해 목록에서 모델을 선택하세요."
     }
   },
   "options": {

--- a/tests/test_model_selection_default.py
+++ b/tests/test_model_selection_default.py
@@ -92,3 +92,23 @@ def test_model_number_aliases_resolve_to_a_profile() -> None:
 def test_unknown_names_stay_unknown() -> None:
     for value in ("BLESmart_0000123", "", "Living Room"):
         assert infer_model_id_from_local_name(value) is None
+
+
+def _config_flow_class() -> ast.ClassDef:
+    tree = ast.parse(_CONFIG_FLOW.read_text(encoding="utf-8"))
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == "OmronConfigFlow":
+            return node
+    raise AssertionError("OmronConfigFlow not found — was it renamed?")
+
+
+def test_no_step_substitutes_a_default_for_the_chosen_model() -> None:
+    # The steps after select_model (user aliases, pairing, the pairing call
+    # itself) used to read `self._selected_model or DEFAULT_DEVICE_MODEL`,
+    # which would have paired and configured the device on the wrong profile
+    # without a word. They must fail loudly instead.
+    flow = _config_flow_class()
+    names = {n.id for n in ast.walk(flow) if isinstance(n, ast.Name)}
+    assert "DEFAULT_DEVICE_MODEL" not in names, (
+        "a config flow step fell back to the default model again (#45)"
+    )


### PR DESCRIPTION
Follow-up to #149.

`async_step_user_aliases`, `async_step_pairing` and `_async_do_pairing` each read `self._selected_model or DEFAULT_DEVICE_MODEL`. #149 stopped the *form* from pre-selecting a fallback, but these three kept one a layer down: a missing selection would pair the device and write the entry on `HEM-7142T2`'s memory map without a word — exactly the [#45](https://github.com/eigger/hass-omron/issues/45) failure.

Both entry points (`async_step_user`, `async_step_bluetooth_confirm`) route through `select_model`, and `vol.Required(CONF_DEVICE_MODEL)` now has no default, so the fallback was unreachable as well as wrong.

- `_require_selected_model()` raises `AbortFlow("model_not_selected")` instead, with an abort string in en/ko.
- The flow's `DEFAULT_DEVICE_MODEL` import is gone.
- `OmronOptionsFlowHandler` keeps its own fallback: it reads `entry.data`, where entries predating the model selector may genuinely have no model stored.

Test: an AST guard that `DEFAULT_DEVICE_MODEL` is not referenced anywhere in `OmronConfigFlow`.