### PR TITLE
Report why the cuff dropped the link during pairing

### DIFF
--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -244,12 +244,9 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
         models = get_supported_models()
         model_dict = {m: m for m in models}
         stats = get_supported_model_stats()
-        # No default until something identifies the device. The placeholder is a
-        # real profile (HEM-7142T2) and pre-selecting it is indistinguishable
-        # from a successful probe: the form looks answered, the user confirms,
-        # and the cuff is read through another model's EEPROM map for good --
-        # wrong record size, wrong addresses, wrong user count, no error. That
-        # is issue #45, where a HEM-7196T1 ran as a HEM-7142T2 for months.
+        # No default until something identifies the device: the fallback is a
+        # real profile, so confirming it reads the cuff through the wrong
+        # EEPROM map with no error anywhere (#45).
         inferred_model: str | None = None
         probed_name: str | None = None
 
@@ -280,9 +277,8 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
                         if inferred:
                             inferred_model = inferred
 
-        # A name several stacks share cannot be resolved by anything read over
-        # the air -- the app itself goes by a group id the device never sends.
-        # Naming the candidates beats a bare "could not identify".
+        # Nothing read over the air separates a shared name, so name the
+        # candidates instead of saying "could not identify".
         candidates: tuple[str, ...] = ()
         if inferred_model is None:
             for name in (probed_name, getattr(self._discovery_info, "name", None)):
@@ -315,13 +311,11 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             "variant_count": str(stats["extra_variants"]),
             "probed_model": probed_name or "",
             "candidate_count": str(len(candidates)),
-            # A markdown list, so the models land on their own lines rather
-            # than buried in a sentence.
+            # Markdown list: one model per line.
             "candidates": "\n".join(f"- **{c}**" for c in candidates),
         }
 
-        # Three steps rather than one sentence assembled here: what to say
-        # about the probe differs, and only a step id gets it translated.
+        # Three step ids, because only a step id gets its wording translated.
         if candidates:
             step_id = "select_model_ambiguous"
         elif inferred_model is None and probed_name:
@@ -333,8 +327,7 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id=step_id,
             data_schema=vol.Schema(
                 {
-                    # Required with no default when nothing identified the
-                    # device, so the choice has to be made rather than confirmed.
+                    # No default, so the choice is made rather than confirmed.
                     (
                         vol.Required(CONF_DEVICE_MODEL, default=inferred_model)
                         if inferred_model is not None

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -453,20 +453,15 @@ def get_supported_model_stats() -> dict[str, int]:
 
 
 _HEM_MODEL_CODE_RE = re.compile(r"(HEM-[A-Z0-9_.-]+)", re.IGNORECASE)
-# Trailing decoration the carton carries but the alias table does not: a
-# HEM-7188T1-LEO reports "X2+ Connect" where the app lists it as "X2+", and the
-# Japanese models append a parenthesised region.
+# Decoration the carton adds over the app's own listing: a HEM-7188T1-LEO
+# reports "X2+ Connect" where the app says "X2+".
 _NAME_DECORATION_RE = re.compile(
     r"\s*\((?:Japan|China|US|EU)[^)]*\)\s*$|\s+Connect$", re.IGNORECASE
 )
 
 
 def normalise_reported_name(name: str) -> str:
-    """Strip the decoration a reported model name carries over the app's own.
-
-    Exact matching only -- substrings would be a disaster here, because the app
-    uses display names as short as "Gold" and "Silver".
-    """
+    """Strip a reported name down to the spelling the alias table uses."""
     stripped = name.replace("™", "").replace("®", "")
     stripped = _NAME_DECORATION_RE.sub("", stripped)
     return " ".join(stripped.split())
@@ -475,11 +470,8 @@ def normalise_reported_name(name: str) -> str:
 def ambiguous_model_candidates(name: str | None) -> tuple[str, ...]:
     """Catalog ids a reported name covers, when it covers more than one.
 
-    Some names identify two different stacks: the app ships HEM-7155T_ESL and
-    HEM-7155T_K4-ESL with identical name, Bluetooth settings name and display
-    name, telling them apart by a group id the device never transmits. Nothing
-    read over the air can resolve those, so the config flow names the
-    candidates instead of guessing one.
+    See AMBIGUOUS_MODEL_NAMES: nothing sent over the air separates these, so
+    the config flow names them rather than guessing one.
     """
     if not name or not str(name).strip():
         return ()
@@ -502,17 +494,12 @@ def _name_candidates(token: str) -> tuple[str, ...]:
 
 
 def _exact_catalog_model_id(token: str) -> str | None:
-    """Catalog model id for an exact name, ignoring case and inner spaces.
-
-    Aliases count: a Model Number String is exactly where a carton name shows
-    up, and MODEL_NUMBER_ALIASES exists to turn those into catalog ids.
-    """
+    """Catalog model id for an exact name, ignoring case and inner spaces."""
     supported = set(CANONICAL_DEVICE_PROFILES.keys()) | set(MODEL_VARIANT_MAP.keys())
     candidates = _name_candidates(token)
+    # Before the catalog lookup: HEM-7155T_ESL is itself a catalog id and also
+    # what its K4 sibling reports.
     if any(cand in AMBIGUOUS_MODEL_NAMES for cand in candidates):
-        # Covers several stacks; the caller asks for the candidate list. This
-        # is checked before the catalog, because a name like HEM-7155T_ESL is
-        # itself a catalog id and also what its K4 sibling reports.
         return None
     for cand in candidates:
         if cand in supported:

--- a/custom_components/omron/omron_ble/model_aliases.py
+++ b/custom_components/omron/omron_ble/model_aliases.py
@@ -13,18 +13,13 @@ target already resolves in this catalog. Firmware answers with any of the
 three.
 
 Some names cannot be mapped at all, and those live in AMBIGUOUS_MODEL_NAMES.
-"X4 Smart" is the clearest case: the app carries HEM-7155T_ESL and
-HEM-7155T_K4-ESL with identical name, Bluetooth settings name and display name,
-and separates them only by a group id the device never transmits. One is WLS3.0
-with four RX/TX channels and custom-key pairing, the other WLD2.0 with one
-channel and OS bonding, so guessing reads the device through the wrong stack
-entirely. The app cannot tell them apart by name either -- it knows which is
-which because the user picked the model during setup. Neither can we, so the
-config flow names the candidates and lets the user choose.
+The app ships HEM-7155T_ESL and HEM-7155T_K4-ESL with all three names identical
+-- WLS3.0 with custom-key pairing against WLD2.0 with OS bonding -- and tells
+them apart by a group id the device never transmits. It knows which is which
+only because the user picked the model, and so must we.
 
-They are resolvable in principle: the two stacks expose different parent service
-UUIDs, which is visible on connect. Doing that needs the device in hand rather
-than a model string, so it is left for later.
+Resolvable in principle: the two stacks expose different parent service UUIDs,
+visible on connect. That needs the device in hand, so it is left for later.
 
 Resolution aliases only: get_supported_models does not offer them in the
 config-flow dropdown, which stays on the HEM designations.

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1948,12 +1948,8 @@ class OmronDeviceSession:
             unlock_attempts, unlock_retry_delay = _PAIR_UNLOCK_ATTEMPTS_DEFAULT, _PAIRING_SETTLE_DEFAULT_SEC
             key_max_retries = 5
 
-        # This subscribe is what triggers SMP: the RX characteristic needs
-        # encryption, so the cuff answers it with a pairing request. Failing
-        # here is often harmless (already subscribed), but when the link dies
-        # a moment later this is the only record of why -- issue #2 arrived as
-        # a bare "Not connected" from the unlock subscribe below, three steps
-        # downstream of the actual event.
+        # This subscribe triggers SMP; its failure is the only record of why
+        # the link dies a moment later (#2).
         _LOGGER.debug("Enabling RX notification to trigger BLE pairing")
         rx_notify_error: str | None = None
         try:
@@ -1967,8 +1963,7 @@ class OmronDeviceSession:
         await self._apply_pairing_settle_delay(aggressive_timing)
 
         if not getattr(self._client, "is_connected", True):
-            # Gone before the unlock subscribe is even attempted. Say so now
-            # rather than sleeping through ten retries against a dead link.
+            # Dead already: no point retrying the unlock subscribe ten times.
             raise ConnectionError(
                 "The cuff dropped the link right after the pairing request"
                 + (f" ({rx_notify_error})" if rx_notify_error else "")

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1948,15 +1948,33 @@ class OmronDeviceSession:
             unlock_attempts, unlock_retry_delay = _PAIR_UNLOCK_ATTEMPTS_DEFAULT, _PAIRING_SETTLE_DEFAULT_SEC
             key_max_retries = 5
 
+        # This subscribe is what triggers SMP: the RX characteristic needs
+        # encryption, so the cuff answers it with a pairing request. Failing
+        # here is often harmless (already subscribed), but when the link dies
+        # a moment later this is the only record of why -- issue #2 arrived as
+        # a bare "Not connected" from the unlock subscribe below, three steps
+        # downstream of the actual event.
         _LOGGER.debug("Enabling RX notification to trigger BLE pairing")
+        rx_notify_error: str | None = None
         try:
             await self._client.start_notify(
                 self._config.rx_channel_uuids[0], lambda h, d: None
             )
         except Exception as exc:
+            rx_notify_error = f"{type(exc).__name__}: {exc}"
             _LOGGER.debug("Ignored error starting RX notify: %s", exc)
 
         await self._apply_pairing_settle_delay(aggressive_timing)
+
+        if not getattr(self._client, "is_connected", True):
+            # Gone before the unlock subscribe is even attempted. Say so now
+            # rather than sleeping through ten retries against a dead link.
+            raise ConnectionError(
+                "The cuff dropped the link right after the pairing request"
+                + (f" ({rx_notify_error})" if rx_notify_error else "")
+                + ". Make sure it shows the blinking -P- symbol and that no "
+                "phone is connected to it."
+            )
 
         prog_event = asyncio.Event()
         response_holder: list[bytes | None] = [None]
@@ -1987,9 +2005,15 @@ class OmronDeviceSession:
                     raise ConnectionError(
                         "Device disconnected while subscribing to "
                         f"{UNLOCK_CHARACTERISTIC_UUID} during pairing "
-                        f"({type(exc).__name__}: {exc}). The cuff dropped the "
-                        "link — make sure it shows the blinking -P- symbol and "
-                        "that no phone is connected to it."
+                        f"({type(exc).__name__}: {exc})."
+                        + (
+                            " The pairing request that preceded it also failed"
+                            f" ({rx_notify_error})."
+                            if rx_notify_error
+                            else ""
+                        )
+                        + " The cuff dropped the link — make sure it shows the "
+                        "blinking -P- symbol and that no phone is connected to it."
                     ) from exc
                 if aggressive_timing:
                     await _bleak_refresh_services(self._client)

--- a/tests/test_custom_key_pairing.py
+++ b/tests/test_custom_key_pairing.py
@@ -159,11 +159,13 @@ def test_unlock_subscribe_reports_disconnect_instead_of_missing_characteristic(
         asyncio.run(session._pair_custom_key(bytearray(16)))
 
     message = str(excinfo.value)
-    assert "disconnected" in message
+    assert "dropped the link" in message
     assert "was not found" not in message
+    # The SMP trigger's own failure, which used to go only to a debug log and
+    # left issue #2 with a bare "Not connected" three steps downstream.
     assert "Not Connected" in message
-    # RX notify 1회 + 언락 구독 1회. 죽은 링크를 10회 두드리지 않는다.
-    assert len(client.start_notify_calls) == 2
+    # RX notify만 1회. 죽은 링크에는 언락 구독을 시도하지도 않는다.
+    assert len(client.start_notify_calls) == 1
 
 
 def test_unlock_subscribe_still_retries_while_connected(monkeypatch):
@@ -207,3 +209,32 @@ def test_bluez_device_path_cannot_identify_a_link_from_the_client_alone():
         == "/org/bluez/hci0/dev_00_5F_BF_F4_43_D1"
     )
     assert omron_driver._bluez_device_path(FakeBLEDevice(PROXY_DEVICE_DETAILS)) is None
+
+
+def test_pairing_error_names_both_failures(monkeypatch):
+    """링크가 언락 구독 도중에 죽으면 SMP 촉발 실패까지 함께 보고한다."""
+    monkeypatch.setattr(omron_driver, "_bleak_refresh_services", _noop_refresh)
+    monkeypatch.setattr(asyncio, "sleep", _noop_sleep)
+
+    class _DiesOnUnlock(FakeClient):
+        """RX notify 는 실패하되 링크는 살아있고, 언락 구독에서 끊긴다."""
+
+        async def start_notify(self, uuid, callback):
+            self.start_notify_calls.append(uuid)
+            if len(self.start_notify_calls) > 1:
+                self.is_connected = False
+            raise Exception(
+                "rx failed"
+                if len(self.start_notify_calls) == 1
+                else "unlock failed"
+            )
+
+    client = _DiesOnUnlock(connected=True)
+    session = _custom_key_session(FakeBLEDevice(LOCAL_BLUEZ_DEVICE_DETAILS), client)
+
+    with pytest.raises(ConnectionError) as excinfo:
+        asyncio.run(session._pair_custom_key(bytearray(16)))
+
+    message = str(excinfo.value)
+    assert "unlock failed" in message
+    assert "rx failed" in message, "the SMP trigger's failure was swallowed again"


### PR DESCRIPTION
[#2](https://github.com/eigger/hass-omron/issues/2) reported this, and it cannot be diagnosed:

```
ConnectionError: Device disconnected while subscribing to b305b680-... during
pairing (BleakError: Not connected). The cuff dropped the link — make sure it
shows the blinking -P- symbol and that no phone is connected to it.
```

That is the symptom, not the event. In `_pair_custom_key` the step that actually triggers SMP is the RX subscribe — the RX characteristic needs encryption, so subscribing makes the cuff send a pairing request. Its failure was swallowed:

```python
except Exception as exc:
    _LOGGER.debug("Ignored error starting RX notify: %s", exc)
```

So the only record of why the link died went to a debug log the reporter did not have on, and the visible error came from the unlock subscribe three steps downstream — after a settle delay and, on `aggressive_gatt_timing` profiles like HEM-7150T, two service refreshes.

## Changes

- Keep the SMP trigger's error and name it in the `ConnectionError`, so the default log carries it.
- When the link is already gone after the settle delay, raise there instead of hammering a dead link with ten unlock-subscribe retries.

## Tests

`tests/test_custom_key_pairing.py` — the existing disconnect test now expects one `start_notify` call rather than two (the dead link is not touched again) and asserts the trigger's error text is present; a new test covers the link surviving the RX subscribe and dying during the unlock subscribe, where both failures must be named.

🤖 Generated with [Claude Code](https://claude.com/claude-code)