### PR TITLE
Name the device the same way on both paths

### DIFF
--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -19,6 +19,7 @@ from .ble_session import (
 )
 from .omron_ble import OmronBluetoothDeviceData, SensorUpdate
 from .omron_ble.const import DEFAULT_DEVICE_MODEL
+from .omron_ble.devices import get_device_config
 from homeassistant.components.bluetooth import (
     BluetoothScanningMode,
     BluetoothServiceInfoBleak,
@@ -310,13 +311,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     # Ensure device registry entry exists even before first successful poll.
     device_registry = dr.async_get(hass)
     identifier = address.replace(":", "")[-4:].upper()
-    device_name = f"{device_model} {identifier}"
+    # display_model, to match what the advertisement path names the device
+    # (parser._setup_device_info). A cuff configured as BP5465 was showing that
+    # here and HEM-7382T1-AZAZ there (#91).
+    display_model = get_device_config(device_model).display_model
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
         connections={(CONNECTION_BLUETOOTH, address)},
         manufacturer="Omron",
-        model=device_model,
-        name=device_name,
+        model=display_model,
+        name=f"{display_model} {identifier}",
     )
 
     bt_coordinator = OmronBluetoothProcessorCoordinator(

--- a/tests/test_display_model.py
+++ b/tests/test_display_model.py
@@ -9,6 +9,7 @@ Model Number String 으로 답하는 값이기도 하다. 모델명으로 프로
 BP5465 가 HEM-7382T1-AZAZ 인지 HEM-7388T1-AJF3 인지 카탈로그는 모른다. 그래서
 추측하지 않고 프로파일 키를 쓴다 — 실제로 아는 사실이고, 진짜 HEM 표기다.
 """
+from pathlib import Path
 from custom_components.omron.omron_ble.device_catalog import (
     CANONICAL_DEVICE_PROFILES,
 )
@@ -78,3 +79,22 @@ def test_the_device_name_path_reads_display_model():
     assert "self._device_config.model" not in body, (
         "설정 필드를 그대로 읽으면 소매명이 다시 새어나간다"
     )
+
+
+def test_both_naming_paths_agree() -> None:
+    """설정 시점과 광고 처리 시점이 같은 이름을 써야 한다 (#91).
+
+    __init__.py 는 device registry 항목을 만들 때, parser 는 광고를 받을 때
+    기기 이름을 짓는다. 한쪽만 HEM 표기로 정규화하면 BP5465 로 설정한 커프가
+    한 화면에서는 BP5465, 다른 화면에서는 HEM-7382T1-AZAZ 로 보인다.
+    """
+    component = Path(__file__).resolve().parent.parent / "custom_components" / "omron"
+    init_src = (component / "__init__.py").read_text(encoding="utf-8")
+    parser_src = (component / "omron_ble" / "parser.py").read_text(encoding="utf-8")
+
+    assert "display_model" in parser_src
+    assert "display_model" in init_src, (
+        "the device registry entry is named from the raw model id again"
+    )
+    assert 'model=display_model' in init_src
+    assert 'name=f"{display_model} {identifier}"' in init_src


### PR DESCRIPTION
Reported in [#91](https://github.com/eigger/hass-omron/issues/91): a cuff configured as `BP5465` still showed `BP5465` after 2.8.3, even though the catalog maps it to `HEM-7382T1-AZAZ`.

Two code paths name the device and only one normalised the model:

- `parser._setup_device_info` (advertisement) used `config.display_model` → `HEM-7382T1-AZAZ`
- `__init__.async_setup_entry` (registry entry, created before the first poll) used the raw `entry.data[CONF_DEVICE_MODEL]` → `BP5465`

So which name you saw depended on which path had run. Both now use `display_model`.

Test: a guard that both files go through `display_model`, so the registry entry cannot go back to the raw id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)