### PR TITLE
fix: restore the two settings that shipped with the CCCD change

### DIFF
--- a/custom_components/omron/omron_ble/const.py
+++ b/custom_components/omron/omron_ble/const.py
@@ -10,6 +10,10 @@ FIRMWARE_REVISION_UUID = "00002a26-0000-1000-8000-00805f9b34fb"
 HARDWARE_REVISION_UUID = "00002a27-0000-1000-8000-00805f9b34fb"
 MANUFACTURER_NAME_UUID = "00002a29-0000-1000-8000-00805f9b34fb"
 MODEL_NUMBER_UUID = "00002a24-0000-1000-8000-00805f9b34fb"
+# Service Changed, the only characteristic of the Generic Attribute service.
+# Indicate-only, and its client configuration is one the peer keeps per bonded
+# client — see OmronDeviceSession.subscribe_service_changed.
+SERVICE_CHANGED_UUID = "00002a05-0000-1000-8000-00805f9b34fb"
 LOCAL_TIME_INFO_UUID = "00002a0f-0000-1000-8000-00805f9b34fb"
 
 BP_MEASUREMENT_CHAR_UUID = "00002a35-0000-1000-8000-00805f9b34fb"

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -95,6 +95,11 @@ class TimeSyncLayout(StrEnum):
     AT_8_SWAPPED = "eeprom_time_at_8_swapped"
 
 
+# How long to wait for the peer to hang up before closing the link ourselves.
+# The #91 capture shows the cuff taking about three seconds; this covers it.
+_PEER_CLOSES_SESSION_SEC: float = 5.0
+
+
 @dataclass
 class DeviceConfig:
     """Configuration for a specific Omron device model."""
@@ -144,6 +149,34 @@ class DeviceConfig:
     # avoided the churn, its comment recording that this family rejects a
     # pairing request (0xff 0x26) when the unlock CCCD is dropped and re-added.
     keep_notify_subscriptions: bool = False
+
+    @property
+    def subscribe_service_changed(self) -> bool:
+        """Whether to subscribe to Service Changed while pairing, as the app does.
+
+        Service Changed is a CCCD like the vendor ones, so this is the same
+        mechanism ``keep_notify_subscriptions`` exists for and follows it
+        rather than being a knob of its own. The phone writes 0x0002 to handle
+        0x000B in both pairing sessions of the #67 capture and in neither
+        reconnect; we wrote every other CCCD and never that one.
+        """
+        return self.keep_notify_subscriptions
+
+    @property
+    def peer_closes_session_sec(self) -> float:
+        """Seconds to stay idle at session end, letting the cuff drop the link.
+
+        In the #91 phone capture the app goes quiet after its last read and the
+        cuff hangs up about three seconds later; there is no HCI Disconnect
+        command from the phone, and reason 0x13 is "remote terminated". We
+        closed in the same millisecond as the final notification, so our
+        sessions ended 0x16 — closed by us.
+
+        Tied to ``keep_notify_subscriptions`` because both are about leaving
+        per-bond state as the app leaves it. Zero elsewhere keeps the immediate
+        close for every other profile.
+        """
+        return _PEER_CLOSES_SESSION_SEC if self.keep_notify_subscriptions else 0.0
 
     # Record layout key -> parser in parse_record()
     record_parser: RecordParser = RecordParser.CLASSIC_VITAL_14

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -15,6 +15,7 @@ from bleak_retry_connector import establish_connection
 
 from .const import (
     MODEL_NUMBER_UUID,
+    SERVICE_CHANGED_UUID,
     UNLOCK_CHARACTERISTIC_UUID,
 )
 from .devices import DeviceConfig, HostPairingMode, UnlockMode
@@ -26,6 +27,10 @@ _MEMORY_PROTOCOL_REPLY_TIMEOUT_SEC: float = 5.0
 _MEMORY_PROTOCOL_TX_MAX_RETRIES: int = 4
 _MEMORY_PROTOCOL_RETRY_BACKOFF_SEC: float = 0.25
 _NOTIFY_SUBSCRIBE_SETTLE_SEC: float = 0.75
+
+# How often to check whether the peer has hung up during the idle window at
+# the end of a session (see _await_peer_close).
+_PEER_CLOSE_POLL_STEP_SEC: float = 0.25
 _NOTIFY_SUBSCRIBE_MAX_RETRIES: int = 3
 
 # Wait between establish_connection() returning and the first GATT operation.
@@ -731,14 +736,46 @@ class OmronDeviceSession:
                 except Exception:
                     pass
             if self._owns_connection and client.is_connected:
-                await client.disconnect()
-                disconnected = True
+                await self._await_peer_close(client, addr)
+                if client.is_connected:
+                    await client.disconnect()
+                    disconnected = True
         except Exception:
             pass
         finally:
             self._client = None
             if disconnected:
                 _LOGGER.debug("BLE link closed for %s", addr)
+
+    async def _await_peer_close(self, client: BleakClient, addr: str) -> None:
+        """Stay idle at the end of a session so the cuff can end it itself.
+
+        In the #91 phone capture the app sends nothing after its last read and
+        the cuff hangs up about three seconds later. The phone's host issues no
+        HCI Disconnect for that link, and the Disconnection Complete carries
+        reason 0x13 -- remote terminated. We used to close in the same
+        millisecond as the final notification, which is why our sessions ended
+        0x16, closed by us.
+
+        No-op unless the profile keeps its notify subscriptions; see
+        ``DeviceConfig.peer_closes_session_sec``.
+        """
+        window = self._config.peer_closes_session_sec
+        if window <= 0:
+            return
+        waited = 0.0
+        while waited < window and client.is_connected:
+            await asyncio.sleep(_PEER_CLOSE_POLL_STEP_SEC)
+            waited += _PEER_CLOSE_POLL_STEP_SEC
+        if client.is_connected:
+            _LOGGER.debug(
+                "%s still up %.1fs after the session ended; closing it here",
+                addr, waited,
+            )
+        else:
+            _LOGGER.debug(
+                "%s ended the session itself after %.2fs", addr, waited
+            )
 
     async def __aenter__(self) -> "OmronDeviceSession":
         return await self.connect()
@@ -1928,6 +1965,34 @@ class OmronDeviceSession:
 
         _LOGGER.debug("Device paired successfully with new key")
         await asyncio.sleep(_PAIRING_SETTLE_DEFAULT_SEC)
+
+    async def subscribe_service_changed(self) -> bool:
+        """Subscribe to Service Changed, as the app does when pairing.
+
+        The #67 capture writes 0x0002 to handle 0x000B in both pairing sessions
+        and in neither reconnect. It is a CCCD like the vendor ones, and the
+        spec has a peripheral keep that configuration per bonded client.
+
+        Best effort: a device without the characteristic, or a backend that
+        refuses the subscribe, must not fail the pairing.
+        """
+        def _on_service_changed(_handle: int, data: bytearray) -> None:
+            _LOGGER.debug(
+                "Service Changed indication from %s: %s", self.address, _hex(data)
+            )
+
+        try:
+            await self._client.start_notify(
+                SERVICE_CHANGED_UUID, _on_service_changed
+            )
+        except Exception as exc:
+            _LOGGER.debug(
+                "Could not subscribe to Service Changed on %s (continuing): %s",
+                self.address, exc,
+            )
+            return False
+        _LOGGER.debug("Subscribed to Service Changed on %s", self.address)
+        return True
 
     async def pair(self, key: bytearray | None = None) -> None:
         """Program pairing credentials according to ``host_pairing_mode``."""

--- a/custom_components/omron/omron_ble/setup.py
+++ b/custom_components/omron/omron_ble/setup.py
@@ -79,6 +79,10 @@ async def async_pair_and_sync_device(
             session.address,
         )
 
+    if session.config.subscribe_service_changed:
+        # Before any vendor traffic, matching the order in the app's capture.
+        await session.subscribe_service_changed()
+
     await session.pair()
     await async_sync_device_time(
         session.client,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -324,3 +324,26 @@ class TestNoDeadConfigSurface:
             if f".{f.name}" not in read_by and f'"{f.name}"' not in read_by
         ]
         assert not unread, f"카탈로그만 채우고 아무도 안 읽는 필드: {unread}"
+
+
+def test_the_cccd_switch_carries_the_two_settings_that_shipped_with_it():
+    """CCCD 유지를 켠 프로파일은 Service Changed 구독과 피어 종료 대기도 함께 켠다.
+
+    셋 다 "본드에 딸린 상태를 앱이 남기는 대로 남긴다"는 같은 이유에서 나왔고,
+    유일하게 재접속이 성공한 빌드(2.7.8-beta.15)에는 셋이 다 들어 있었다.
+    따로 켤 수 있게 두면 그 조합이 다시 깨질 수 있으므로 파생시킨다.
+    """
+    on = get_device_config("HEM-7386T1")
+    assert on.keep_notify_subscriptions is True
+    assert on.subscribe_service_changed is True
+    assert on.peer_closes_session_sec > 0
+
+    off = get_device_config("HEM-7142T2")
+    assert off.keep_notify_subscriptions is False
+    assert off.subscribe_service_changed is False
+    assert off.peer_closes_session_sec == 0.0
+
+
+def test_the_peer_close_window_covers_the_captured_delay():
+    """폰 캡처에서 커프는 마지막 읽기 약 3초 뒤에 끊는다 — 여유가 있어야 한다."""
+    assert get_device_config("HEM-7386T1").peer_closes_session_sec >= 3.0


### PR DESCRIPTION
#153 dropped `peer_closes_session_sec` and `subscribe_service_changed` as unconfirmed. Both were present in **2.7.8-beta.15** — the only build whose retained-bond reconnect has ever worked — and both reasons given for dropping them turn out not to hold.

## The stated reasons

> `peer_closes_session_sec` waited five seconds at the end of every poll on a reading of the capture that does not hold. It is the phone that sends HCI Disconnect 0x13 there, not the cuff.

It is not. The phone's host issues no `HCI_Disconnect` command for that link, and the Disconnection Complete carries reason `0x13` — remote terminated. The capture also shows three seconds of silence between the last notification and the hang-up:

```
+4677.0 ms  ATT Notify 0x0020        last reply
+7693.4 ms  Disconnect reason=0x13
```

A host that decides to disconnect does so immediately. Ours does — about 100 ms after closing the memory session, which is why our sessions end `0x16`:

```
07:18:22.551  Memory session closed
07:18:22.654  DISCONNECT_EVT reason=0x16
```

> `subscribe_service_changed` copied the app's pairing-time subscribe. The CCCD fix landed without it and nothing since has needed it.

It landed with it. The beta.15 wire census counts **eleven** writes of `0x000B = 0x0002`.

## Why they looked droppable

Each was tested alone, before the CCCD change existed, and neither made the bond survive on its own. That is true and was the right read at the time. But *insufficient alone* is not *unnecessary in combination*, and the combination is what worked — the A/B in #91 removed only the mirror writes, so these two were never on trial.

## The tidy-up

Restored as properties derived from `keep_notify_subscriptions` rather than as knobs of their own:

- Service Changed is a CCCD, so it is the same mechanism that switch exists for.
- The idle window is the same idea one layer up — leaving per-bond state as the app leaves it.

One switch per profile instead of three, so the combination cannot come apart again by editing one of them. Every other profile is unchanged: the window stays zero and the subscribe stays off.

Two tests pin it, including that the window covers the three seconds the capture shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
