### PR TITLE
fix: only clear a bond that exists

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -446,6 +446,51 @@ async def _bluez_remove_device(client: BleakClient | BLEDevice) -> bool:
         bus.disconnect()
 
 
+async def _bluez_is_paired(client: BleakClient | BLEDevice) -> bool | None:
+    """Whether BlueZ currently holds a bond for this device.
+
+    ``None`` when it cannot be determined -- no dbus_fast, no device path, or
+    the property read failed -- so a caller can keep its previous behaviour
+    rather than act on a guess.
+    """
+    try:
+        from dbus_fast.aio.message_bus import MessageBus
+        from dbus_fast.constants import BusType, MessageType
+        from dbus_fast.message import Message
+    except ImportError:
+        return None
+
+    device_path = _bluez_device_path(client)
+    if not device_path or "/dev_" not in device_path:
+        return None
+
+    try:
+        bus = await MessageBus(bus_type=BusType.SYSTEM).connect()
+    except Exception as exc:
+        _LOGGER.debug("BlueZ Paired: cannot connect to system bus: %s", exc)
+        return None
+    try:
+        reply = await bus.call(
+            Message(
+                destination="org.bluez",
+                path=device_path,
+                interface="org.freedesktop.DBus.Properties",
+                member="Get",
+                signature="ss",
+                body=["org.bluez.Device1", "Paired"],
+            )
+        )
+        if reply.message_type != MessageType.METHOD_RETURN or not reply.body:
+            _LOGGER.debug("BlueZ Paired(%s) -> %s", device_path, reply)
+            return None
+        return bool(reply.body[0].value)
+    except Exception as exc:
+        _LOGGER.debug("BlueZ Paired read failed for %s: %s", device_path, exc)
+        return None
+    finally:
+        bus.disconnect()
+
+
 def _is_non_fatal_os_pairing_error(exc: BaseException) -> bool:
     """Whether an OS-level BLE pairing exception can be safely ignored.
 
@@ -1750,19 +1795,45 @@ class OmronDeviceSession:
                 # Stale bond → AuthenticationFailed. Remove it and raise; the
                 # next connection re-pairs from a clean slate.
                 if _is_stale_bond_auth_error(exc) and not stale_bond_cleared:
-                    stale_bond_cleared = True
+                    # Only a bond that exists can be stale. On a first pairing
+                    # there is none, and the same AuthenticationFailed just
+                    # means the cuff refused -- removing nothing and abandoning
+                    # the attempt spends the pairing window the user opened by
+                    # pressing the button, and the "retry the poll" this used to
+                    # raise lands after that window has closed (#92).
+                    had_bond = await _bluez_is_paired(self._client)
+                    if had_bond is not False:
+                        stale_bond_cleared = True
+                        _LOGGER.warning(
+                            "OS-level bonding rejected (%s) for %s — removing stale "
+                            "bond so the next connection can re-pair cleanly",
+                            type(exc).__name__,
+                            self._config.model,
+                        )
+                        if not await _bluez_remove_device(self._client):
+                            await self.unpair()
+                        raise ConnectionError(
+                            "Stale BLE bond removed after AuthenticationFailed; "
+                            "retry the poll to re-pair"
+                        ) from exc
                     _LOGGER.warning(
-                        "OS-level bonding rejected (%s) for %s — removing stale "
-                        "bond so the next connection can re-pair cleanly",
+                        "OS-level bonding rejected (%s) for %s and no bond exists "
+                        "to be stale — the peer refused. Attempt %d/%d",
                         type(exc).__name__,
                         self._config.model,
+                        attempt,
+                        max_attempts,
                     )
-                    if not await _bluez_remove_device(self._client):
-                        await self.unpair()
-                    raise ConnectionError(
-                        "Stale BLE bond removed after AuthenticationFailed; "
-                        "retry the poll to re-pair"
-                    ) from exc
+                    if attempt < max_attempts:
+                        # Retry on this link, while the cuff is still in its
+                        # pairing window. Falling through would hit the
+                        # non-fatal branch below, which treats
+                        # AuthenticationFailed as "no bond needed" and returns
+                        # on the first refusal.
+                        continue
+                    # Out of attempts: leave the existing non-fatal handling to
+                    # decide, so profiles that genuinely do not need a bond are
+                    # unaffected.
                 if _is_non_fatal_os_pairing_error(exc):
                     _LOGGER.warning(
                         "OS-level bonding returned non-fatal error on attempt %d/%d: %s (%r)",

--- a/tests/test_stale_bond_guard.py
+++ b/tests/test_stale_bond_guard.py
@@ -1,0 +1,102 @@
+"""본드가 없으면 "오래된 본드"도 없다 (#92).
+
+AuthenticationFailed 는 두 가지를 뜻할 수 있다.
+
+- 로컬에 본드가 있는데 기기가 그걸 잊었다 → 지우고 다음 연결에서 다시 맺는
+  것이 맞다 (#83).
+- 본드가 아예 없는데 상대가 페어링을 거절했다 → 지울 것이 없고, 여기서
+  포기하면 사용자가 버튼을 눌러 연 페어링 창을 그대로 버린다. 예전 코드가
+  안내하던 "retry the poll" 은 그 창이 닫힌 뒤에 도착한다.
+
+둘을 구분하지 않으면 후자가 전자로 처리된다. BlueZ 에 Paired 를 직접 물어서
+가른다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 실제로 돌릴 수 없어
+(test_poll_deadline.py 와 같은 이유) AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+
+_DRIVER = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components" / "omron" / "omron_ble" / "omron_driver.py"
+)
+
+
+def _find_function(tree: ast.AST, name: str):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} 을(를) 찾지 못했다 — 이름을 바꿨다면 이 테스트도 갱신할 것")
+
+
+def _enclosing_ifs(fn: ast.AST, target_lineno: int) -> list[ast.If]:
+    """해당 줄을 몸통에 품고 있는 if 문들."""
+    found = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.If) and node.lineno < target_lineno:
+            end = getattr(node, "end_lineno", node.lineno)
+            if target_lineno <= end:
+                found.append(node)
+    return found
+
+
+def test_the_bond_is_only_removed_when_one_exists():
+    tree = ast.parse(_DRIVER.read_text(encoding="utf-8"))
+    fn = _find_function(tree, "_pair_os_bonding")
+
+    removals = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "_bluez_remove_device"
+    ]
+    assert removals, "_pair_os_bonding 이 본드를 지우지 않는다 — 테스트가 낡았다"
+
+    for call in removals:
+        guards = " ".join(ast.unparse(node.test) for node in _enclosing_ifs(fn, call.lineno))
+        assert "had_bond" in guards, (
+            "본드 제거가 had_bond 검사 안에 있지 않다. 본드가 없는데 지우면 "
+            "페어링 창을 버린다 (#92)."
+        )
+
+
+def test_the_bond_state_is_read_before_removing():
+    tree = ast.parse(_DRIVER.read_text(encoding="utf-8"))
+    fn = _find_function(tree, "_pair_os_bonding")
+
+    def _first_lineno(name: str) -> int:
+        lines = [
+            node.lineno
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call) and getattr(node.func, "id", None) == name
+        ]
+        assert lines, f"{name} 호출이 없다"
+        return min(lines)
+
+    assert _first_lineno("_bluez_is_paired") < _first_lineno("_bluez_remove_device"), (
+        "본드 존재 여부를 묻기 전에 지운다"
+    )
+
+
+def test_a_refused_first_pairing_retries_inside_the_window():
+    """거절이 곧 포기가 되면 -P- 창을 한 번밖에 못 쓴다."""
+    source = _DRIVER.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    fn = _find_function(tree, "_pair_os_bonding")
+    assert any(isinstance(node, ast.Continue) for node in ast.walk(fn)), (
+        "거절 경로에 continue 가 없다 — 아래 비치명 분기가 첫 거절에서 "
+        "성공으로 반환해 버린다"
+    )
+
+
+def test_the_probe_answers_none_when_it_cannot_tell():
+    """모르면 모른다고 해야 예전 동작으로 안전하게 떨어진다."""
+    tree = ast.parse(_DRIVER.read_text(encoding="utf-8"))
+    fn = _find_function(tree, "_bluez_is_paired")
+    returns = {
+        ast.unparse(node.value) if node.value is not None else "None"
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Return)
+    }
+    assert "None" in returns, "판단 불가를 None 으로 돌려주지 않는다"


### PR DESCRIPTION
From #92: two pairing-mode attempts five minutes apart, both refused at the bonding step, both ending with

```
WARNING  OS-level bonding rejected (BleakDBusError) — removing stale bond
         Removed OS bond ... after session
ERROR    Auto pairing failed: Stale BLE bond removed after AuthenticationFailed
```

and `bluetoothctl info` confirming afterwards that no bond had existed either time.

## The problem

`AuthenticationFailed` was read as a stale bond unconditionally. It has two causes, and only one of them is a stale bond:

- **A bond exists and the device has forgotten it.** Removing it is right — that is #83.
- **No bond exists and the peer refused.** There is nothing to remove.

Treating the second as the first does three unhelpful things: it tells the user a stale bond was removed when none existed, it skips the retry loop that exists precisely because this step is flaky, and it raises *"retry the poll to re-pair"* — which lands well after the pairing window the user opened by pressing the button has closed. That window is the one moment a bond can be made on these cuffs.

## The change

`_bluez_is_paired()` asks BlueZ over the same DBus path the removal already uses, and returns `None` when it cannot tell, so anything that cannot answer keeps the previous behaviour.

| state | behaviour |
| --- | --- |
| bond exists | unchanged — remove and raise |
| no bond | retry on this link, while the cuff is still in its window |
| out of attempts | fall through to the existing non-fatal handling |

That last row matters: `_is_non_fatal_os_pairing_error()` counts `AuthenticationFailed` as non-fatal, on the grounds that some profiles negotiate security without an explicit bond. Falling straight through would return success on the first refusal, so the no-bond path uses `continue` to reach the retries and only defers to that branch once attempts run out. Profiles that genuinely do not need a bond are unaffected.

Four AST tests pin the guard, the ordering, the retry, and the `None` fallback.

Independent of #159, and only changes a path that is already failing: if the Service Changed ordering was what made bonding get refused, this branch stops being reached at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
