### PR TITLE
Let a BleakClient answer whether its link is BlueZ

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -1796,7 +1796,7 @@ class OmronDeviceSession:
                 if attempt > 1:
                     await asyncio.sleep(_OS_BOND_RETRY_DELAY_SEC)
                     await _bleak_refresh_services(self._client)
-                agent_paired = await _bluez_agent_pair(self._client)
+                agent_paired = await _bluez_agent_pair(self._bluez_target())
                 if not agent_paired:
                     try:
                         await self._client.pair()

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -258,8 +258,12 @@ def _bluez_device_path(obj: BleakClient | BLEDevice) -> str | None:
         details = getattr(getattr(obj, "_device", None), "details", None)
     if isinstance(details, dict) and (path := details.get("path")):
         return str(path)
-    # Older bleak versions expose the device on the backend instead.
     backend = getattr(obj, "_backend", None)
+    # A BleakClient carries no .details; its BlueZ backend keeps the path as a
+    # string. Reading it is what lets a client answer at all (#92).
+    if path := getattr(backend, "_device_path", None):
+        return str(path)
+    # Older bleak versions expose the device on the backend instead.
     return getattr(getattr(backend, "_device", None), "path", None)
 
 
@@ -827,6 +831,17 @@ class OmronDeviceSession:
 
     async def __aexit__(self, *exc_info: object) -> None:
         await self.aclose()
+
+    def _bluez_target(self) -> "BleakClient | BLEDevice":
+        """Whichever of the client and the BLEDevice carries a BlueZ path.
+
+        Both can answer, and neither always does: a proxy link has no path on
+        either. Asking only the client left every BlueZ bond check unanswered
+        (#92).
+        """
+        if self._client is not None and _bluez_device_path(self._client):
+            return self._client
+        return self._ble_device
 
     def _require_connected(self, context: str) -> None:
         """Raise if the Bleak client is not connected (avoids opaque service-cache errors)."""
@@ -1801,7 +1816,7 @@ class OmronDeviceSession:
                     # the attempt spends the pairing window the user opened by
                     # pressing the button, and the "retry the poll" this used to
                     # raise lands after that window has closed (#92).
-                    had_bond = await _bluez_is_paired(self._client)
+                    had_bond = await _bluez_is_paired(self._bluez_target())
                     if had_bond is not False:
                         stale_bond_cleared = True
                         _LOGGER.warning(
@@ -1810,7 +1825,7 @@ class OmronDeviceSession:
                             type(exc).__name__,
                             self._config.model,
                         )
-                        if not await _bluez_remove_device(self._client):
+                        if not await _bluez_remove_device(self._bluez_target()):
                             await self.unpair()
                         raise ConnectionError(
                             "Stale BLE bond removed after AuthenticationFailed; "
@@ -2075,16 +2090,7 @@ class OmronDeviceSession:
             raise ConnectionError("Pairing is disabled for this device profile")
         if self._config.host_pairing_mode != HostPairingMode.CUSTOM_KEY:
             raise ConnectionError("Pairing is not supported for this device")
-        # Ask the BLEDevice first: only its details reliably carry the DBus
-        # path (bleak's own BlueZ backend reads ble_device.details["path"]),
-        # which is why this tests the BLEDevice and not the client.
-        # A BleakClient exposes no .details at all and its BlueZ backend keeps
-        # a _device_path string rather than a _device object, so asking the
-        # client alone answers "not BlueZ" for every local adapter too.
-        if (
-            _bluez_device_path(self._ble_device) is None
-            and _bluez_device_path(self._client) is None
-        ):
+        if _bluez_device_path(self._bluez_target()) is None:
             # Proxy link: there is no local SMP confirmation to answer, and the
             # agent registers as the system *default*, so putting one up here
             # would take over pairing confirmation for unrelated local devices.

--- a/tests/test_custom_key_pairing.py
+++ b/tests/test_custom_key_pairing.py
@@ -225,16 +225,6 @@ def test_bluez_target_falls_back_to_the_device():
     assert omron_driver._bluez_device_path(proxy._bluez_target()) is None
 
 
-def test_the_bond_check_goes_through_the_target():
-    """본드 조회/삭제가 클라이언트만 보면 #92 로 돌아간다."""
-    import inspect
-
-    source = inspect.getsource(omron_driver.OmronDeviceSession._pair_os_bonding)
-    assert "_bluez_is_paired(self._bluez_target())" in source
-    assert "_bluez_remove_device(self._bluez_target())" in source
-    assert "_bluez_is_paired(self._client)" not in source
-
-
 def test_pairing_error_names_both_failures(monkeypatch):
     """링크가 언락 구독 도중에 죽으면 SMP 촉발 실패까지 함께 보고한다."""
     monkeypatch.setattr(omron_driver, "_bleak_refresh_services", _noop_refresh)

--- a/tests/test_custom_key_pairing.py
+++ b/tests/test_custom_key_pairing.py
@@ -191,23 +191,48 @@ async def _noop_sleep(delay, *args, **kwargs):
     return None
 
 
-def test_bluez_device_path_cannot_identify_a_link_from_the_client_alone():
-    """링크 판별을 클라이언트로만 하면 안 되는 이유를 못박는다.
+def test_bluez_device_path_reads_the_client_and_the_device():
+    """로컬 BlueZ 링크는 클라이언트로도, BLEDevice 로도 판별돼야 한다.
 
-    실물 ``BleakClient`` 에는 ``details`` 가 없고, BlueZ 백엔드는 ``_device``
-    객체가 아니라 ``_device_path`` 문자열을 들고 있다. 따라서
-    ``_bluez_device_path(client)`` 는 로컬 BlueZ 연결에서도 None 을 돌려준다 —
-    이걸 게이트로 쓰면 에이전트가 필요한 바로 그 경우에 등록되지 않는다.
+    실물 ``BleakClient`` 에는 ``details`` 가 없고 BlueZ 백엔드가 ``_device``
+    객체가 아니라 ``_device_path`` 문자열을 들고 있다. 그 문자열을 안 읽으면
+    클라이언트는 로컬 링크에서도 None 을 돌려주고, 본드 조회가 통째로
+    "판단 불가"가 된다 (#92).
     """
-    local_client = FakeClient(device_path="/org/bluez/hci0/dev_00_5F_BF_F4_43_D1")
-
-    assert omron_driver._bluez_device_path(local_client) is None
-    # BLEDevice 쪽에는 남아 있으므로 이쪽을 봐야 한다.
+    path = "/org/bluez/hci0/dev_00_5F_BF_F4_43_D1"
+    assert omron_driver._bluez_device_path(FakeClient(device_path=path)) == path
     assert (
         omron_driver._bluez_device_path(FakeBLEDevice(LOCAL_BLUEZ_DEVICE_DETAILS))
-        == "/org/bluez/hci0/dev_00_5F_BF_F4_43_D1"
+        == path
     )
+    # 프록시 링크에는 어느 쪽에도 경로가 없다.
+    assert omron_driver._bluez_device_path(FakeClient()) is None
     assert omron_driver._bluez_device_path(FakeBLEDevice(PROXY_DEVICE_DETAILS)) is None
+
+
+def test_bluez_target_falls_back_to_the_device():
+    """클라이언트가 경로를 못 내면 BLEDevice 로 넘어간다."""
+    path = "/org/bluez/hci0/dev_00_5F_BF_F4_43_D1"
+    device = FakeBLEDevice(LOCAL_BLUEZ_DEVICE_DETAILS)
+
+    with_path = _custom_key_session(device, FakeClient(device_path=path))
+    assert with_path._bluez_target() is with_path._client
+
+    without = _custom_key_session(device, FakeClient())
+    assert without._bluez_target() is device
+
+    proxy = _custom_key_session(FakeBLEDevice(PROXY_DEVICE_DETAILS), FakeClient())
+    assert omron_driver._bluez_device_path(proxy._bluez_target()) is None
+
+
+def test_the_bond_check_goes_through_the_target():
+    """본드 조회/삭제가 클라이언트만 보면 #92 로 돌아간다."""
+    import inspect
+
+    source = inspect.getsource(omron_driver.OmronDeviceSession._pair_os_bonding)
+    assert "_bluez_is_paired(self._bluez_target())" in source
+    assert "_bluez_remove_device(self._bluez_target())" in source
+    assert "_bluez_is_paired(self._client)" not in source
 
 
 def test_pairing_error_names_both_failures(monkeypatch):

--- a/tests/test_stale_bond_guard.py
+++ b/tests/test_stale_bond_guard.py
@@ -100,3 +100,44 @@ def test_the_probe_answers_none_when_it_cannot_tell():
         if isinstance(node, ast.Return)
     }
     assert "None" in returns, "판단 불가를 None 으로 돌려주지 않는다"
+
+
+def test_the_bluez_calls_ask_the_target_not_the_client():
+    """클라이언트만 물으면 경로를 못 찾아 가드가 통째로 무력해진다 (#92).
+
+    ``BleakClient`` 에는 ``details`` 가 없고 bleak 3 의 BlueZ 백엔드는
+    ``_device_path`` 문자열을 든다. ``_bluez_target()`` 이 클라이언트와
+    BLEDevice 중 경로가 있는 쪽을 고른다.
+    """
+    tree = ast.parse(_DRIVER.read_text(encoding="utf-8"))
+    fn = _find_function(tree, "_pair_os_bonding")
+
+    watched = {"_bluez_is_paired", "_bluez_remove_device", "_bluez_agent_pair"}
+    seen = set()
+    for node in ast.walk(fn):
+        if not isinstance(node, ast.Call):
+            continue
+        name = getattr(node.func, "id", None)
+        if name not in watched or not node.args:
+            continue
+        seen.add(name)
+        arg = ast.unparse(node.args[0])
+        assert arg == "self._bluez_target()", f"{name}({arg})"
+    assert seen == watched, f"호출이 사라졌다: {sorted(watched - seen)}"
+
+
+def test_the_path_probe_reads_the_backend_string():
+    """bleak 3 백엔드는 ``_device`` 객체가 아니라 ``_device_path`` 문자열을 든다."""
+    tree = ast.parse(_DRIVER.read_text(encoding="utf-8"))
+    fn = _find_function(tree, "_bluez_device_path")
+    attrs = {
+        node.args[1].value
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call)
+        and getattr(node.func, "id", None) == "getattr"
+        and len(node.args) >= 2
+        and isinstance(node.args[1], ast.Constant)
+    }
+    assert "_device_path" in attrs, (
+        "클라이언트가 로컬 BlueZ 링크에서도 None 을 돌려준다"
+    )


### PR DESCRIPTION
[#92](https://github.com/eigger/hass-omron/issues/92) reports that 2.8.6 still says it removed a stale bond when `bluetoothctl info` showed `Paired: no, Bonded: no` immediately before the attempt — the case #160's guard was written for.

The guard cannot fire. It asks:

```python
had_bond = await _bluez_is_paired(self._client)
if had_bond is not False:      # None lands here too
```

and `_bluez_is_paired` returns `None` when it cannot resolve a DBus path. `_bluez_device_path` looks for `details["path"]` — a `BleakClient` has no `details`, only `BLEDevice` does — and then for `backend._device.path`. In bleak 3.0.2's BlueZ backend `self._device_path` appears 34 times and `self._device` appears **zero** times. So a client always answers `None`, on every local adapter.

Both symptoms in the report follow from that one cause:

| log line | why |
| --- | --- |
| `removing stale bond so the next connection can re-pair cleanly` | `_bluez_is_paired` → `None` → guard skipped |
| `Removed OS bond for ... after session` | `_bluez_remove_device` → `False` → `unpair()` fallback |

The file already knew this — the comment on the agent gate spelled it out and worked around it by asking the `BLEDevice` — but the helper itself was never fixed, and the bond calls pass only the client. `_connected_path` reads `backend._device_path` already, so the attribute is not in doubt.

## Changes

- `_bluez_device_path` reads `backend._device_path`.
- `OmronDeviceSession._bluez_target()` returns whichever of the client and the `BLEDevice` carries a path. The bond check, the bond removal, the pairing agent and the agent gate all go through it. A proxy link has a path on neither, so it answers `None` as before and nothing changes there.

## The behaviour change worth knowing about

`_bluez_agent_pair(self._client)` was dead code on every setup: it starts with `if not device_path: return False`, so it always fell through to `self._client.pair()`. With the helper fixed it now runs for real on a local adapter — registering the auto-confirming `KeyboardDisplay` agent and calling `Device1.Pair()`.

That is the path it was written for. On BlueZ 5.72+ a `Pair()` with no registered agent leaves the Just Works confirmation unanswered and fails with `AuthenticationFailed`, which is exactly the `BleakDBusError` #92 reports at the bonding step — so this may fix the failure and not only the misleading message. It is worth watching, because the agent registers as the *system default* for the duration of the call, which is why the code deliberately keeps it off proxy links.

## Tests

The old guard pinned the bug as intended behaviour (`assert _bluez_device_path(local_client) is None`) and is replaced: a local link now resolves from the client *and* from the device, a proxy link from neither, and `_bluez_target()` falls back.

The invariant that the three BlueZ calls go through the target moved to `test_stale_bond_guard.py`, next to the other AST checks and as an AST walk rather than a source substring — it covers all three calls in both directions, and pins that the path probe reads `_device_path`.

Not covered: whether `_bluez_is_paired` returns the right `True`/`False` over a live bus, and whether the agent path actually pairs. This repo does not mock DBus, so both need a device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)