### PR TITLE
Recover the notify session BlueZ still holds from the last connection

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -900,12 +900,15 @@ class OmronDeviceSession:
         self._notify_subscribed = True
         self._debug_ble_link("after_rx_subscribe")
 
-    async def _start_notify_with_recovery(self, uuid: str) -> None:
+    async def _start_notify_with_recovery(
+        self, uuid: str, callback: Any | None = None
+    ) -> None:
         """Start notify with recovery for transient BlueZ/stack races."""
+        handler = callback if callback is not None else self._on_notify_channel_data
         last_exc: BaseException | None = None
         for attempt in range(_NOTIFY_SUBSCRIBE_MAX_RETRIES):
             try:
-                await self._client.start_notify(uuid, self._on_notify_channel_data)
+                await self._client.start_notify(uuid, handler)
                 return
             except BleakError as exc:
                 last_exc = exc
@@ -918,6 +921,9 @@ class OmronDeviceSession:
                     "notify acquired" in msg
                     or "notpermitted" in msg
                     or "already enabled" in msg
+                    # BlueZ's wording when it still holds the session from the
+                    # previous connection, which keep_notify never released (#92).
+                    or "register notify session" in msg
                 ):
                     _LOGGER.debug(
                         "start_notify recovery (%d/%d) for %s on %s: %s",
@@ -981,6 +987,12 @@ class OmronDeviceSession:
         the next attempt regardless.
         """
         await self._unsubscribe_notify_channels(force=True)
+        # The unlock characteristic is not an RX channel, so the loop above
+        # never covered it -- and it is the one BlueZ was still holding (#92).
+        try:
+            await self._client.stop_notify(UNLOCK_CHARACTERISTIC_UUID)
+        except Exception as exc:
+            _LOGGER.debug("unlock stop_notify during reset ignored: %s", exc)
         self._unlocked = False
         self._secure_session = None
         self._memory_session_active = False
@@ -1585,7 +1597,9 @@ class OmronDeviceSession:
             _LOGGER.debug("token unlock RX pre-notify prime skipped: %s", exc)
 
         self._debug_ble_link("token_unlock_before_notify")
-        await self._client.start_notify(UNLOCK_CHARACTERISTIC_UUID, _unlock_dispatch)
+        await self._start_notify_with_recovery(
+            UNLOCK_CHARACTERISTIC_UUID, _unlock_dispatch
+        )
         await asyncio.sleep(_NOTIFY_SUBSCRIBE_SETTLE_SEC)
         try:
             unlock_event.clear()

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -981,8 +981,9 @@ class OmronDeviceSession:
     async def reset_session_state(self) -> None:
         """Release any stale BLE notify subscriptions and reset session flags.
 
-        Call this before retrying ``open_memory_session`` when a previous attempt
-        failed with a BlueZ ``Notify acquired`` error.  The stop_notify calls are
+        Call this before retrying ``open_memory_session`` when a previous
+        attempt failed with a BlueZ ``Notify acquired`` or ``Failed to register
+        notify session`` error.  The stop_notify calls are
         best-effort; failures are silently ignored so the caller can proceed with
         the next attempt regardless.
         """
@@ -1585,7 +1586,7 @@ class OmronDeviceSession:
         # back to 0x0000 first — the very churn keep_notify exists to avoid.
         try:
             self._rebuild_notify_handle_index_map()
-            await self._client.start_notify(
+            await self._start_notify_with_recovery(
                 self._config.rx_channel_uuids[0],
                 self._on_notify_channel_data if keep_notify else (lambda _h, _d: None),
             )

--- a/tests/test_session_cccd_persistence.py
+++ b/tests/test_session_cccd_persistence.py
@@ -23,6 +23,7 @@
 import asyncio
 
 from custom_components.omron.omron_ble.devices import get_device_config
+from custom_components.omron.omron_ble.const import UNLOCK_CHARACTERISTIC_UUID
 from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
 
 
@@ -143,9 +144,12 @@ def test_reset_releases_the_subscription_on_the_profile_under_test():
 
     asyncio.run(OmronDeviceSession.reset_session_state(target))
 
+    # The unlock characteristic is released too. It is not an RX channel, so the
+    # loop over rx_channel_uuids never covered it -- and on BlueZ it is the one
+    # left holding a notify session from the previous connection (#92).
     assert target._client.stopped == list(
         get_device_config("HEM-7386T1").rx_channel_uuids
-    )
+    ) + [UNLOCK_CHARACTERISTIC_UUID]
     assert target._unlocked is False
 
 
@@ -172,3 +176,34 @@ def test_the_token_unlock_asks_for_what_the_profile_wants():
     sig = inspect.signature(OmronDeviceSession._token_unlock)
     assert sig.parameters["keep_notify"].default is False
     assert get_device_config("HEM-7386T1").keep_notify_subscriptions is True
+
+
+def test_a_held_notify_session_is_recovered_not_raised():
+    """BlueZ 가 이전 연결의 notify 세션을 붙들고 있으면 재구독이 거부된다 (#92).
+
+    keep_notify 프로파일은 언락 캐릭터리스틱을 끝내 해제하지 않으므로, BlueZ 는
+    다음 연결에서 ``Failed to register notify session`` 을 돌려준다. 복구 목록에
+    그 문구가 없으면 첫 시도가 그대로 죽고, 재시도는 이미 끊긴 링크에 쓰기를
+    시도해 ``Failed to initiate write`` 로 이어진다.
+    """
+    import inspect
+
+    from custom_components.omron.omron_ble import omron_driver
+
+    source = inspect.getsource(omron_driver.OmronDeviceSession._start_notify_with_recovery)
+    assert "register notify session" in source, (
+        "BlueZ 가 세션을 붙들고 있을 때의 문구가 복구 대상에서 빠졌다"
+    )
+
+
+def test_the_unlock_subscribe_goes_through_the_recovery_path():
+    """언락 구독이 start_notify 를 직접 부르면 위 복구가 적용되지 않는다."""
+    import inspect
+
+    from custom_components.omron.omron_ble import omron_driver
+
+    source = inspect.getsource(omron_driver.OmronDeviceSession._token_unlock)
+    assert "_start_notify_with_recovery(\n            UNLOCK_CHARACTERISTIC_UUID" in source, (
+        "토큰 언락이 복구 경로를 우회한다"
+    )
+    assert "self._client.start_notify(UNLOCK_CHARACTERISTIC_UUID" not in source

--- a/tests/test_session_cccd_persistence.py
+++ b/tests/test_session_cccd_persistence.py
@@ -237,3 +237,35 @@ def test_a_notify_session_bluez_still_holds_is_released_and_retried(monkeypatch)
     # 호출자가 준 콜백이 그대로 전달돼야 한다 — RX 핸들러로 바뀌면 언락 응답을
     # 받을 곳이 없어진다.
     assert all(cb is sentinel for _, cb in client.started)
+
+
+def test_the_unlock_subscribe_stays_on_the_recovery_path():
+    """언락 구독이 start_notify 를 직접 부르면 위 복구가 걸리지 않는다 (#92).
+
+    소스 문자열이 아니라 AST 로 본다 — 줄바꿈을 바꿔도 깨지지 않아야 한다.
+    """
+    import ast
+    import inspect
+    import textwrap
+
+    tree = ast.parse(
+        textwrap.dedent(inspect.getsource(OmronDeviceSession._token_unlock))
+    )
+    direct: list[str] = []
+    recovered: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+            continue
+        first = ast.unparse(node.args[0]) if node.args else ""
+        if node.func.attr == "start_notify":
+            direct.append(first)
+        elif node.func.attr == "_start_notify_with_recovery":
+            recovered.append(first)
+
+    assert not direct, f"복구를 우회하는 직접 호출이 남아 있다: {direct}"
+    assert "UNLOCK_CHARACTERISTIC_UUID" in recovered, (
+        "언락 구독이 복구 경로를 타지 않는다"
+    )
+    assert any("rx_channel_uuids" in arg for arg in recovered), (
+        "RX 프라임이 복구 경로를 타지 않는다"
+    )

--- a/tests/test_session_cccd_persistence.py
+++ b/tests/test_session_cccd_persistence.py
@@ -21,6 +21,7 @@
 담는 경우가 흔하다.
 """
 import asyncio
+from types import SimpleNamespace
 
 from custom_components.omron.omron_ble.devices import get_device_config
 from custom_components.omron.omron_ble.const import UNLOCK_CHARACTERISTIC_UUID
@@ -178,32 +179,61 @@ def test_the_token_unlock_asks_for_what_the_profile_wants():
     assert get_device_config("HEM-7386T1").keep_notify_subscriptions is True
 
 
-def test_a_held_notify_session_is_recovered_not_raised():
-    """BlueZ 가 이전 연결의 notify 세션을 붙들고 있으면 재구독이 거부된다 (#92).
+class _BlueZError(Exception):
+    """conftest 가 bleak 를 MagicMock 으로 치환하므로 실제 예외 클래스가 필요하다."""
 
-    keep_notify 프로파일은 언락 캐릭터리스틱을 끝내 해제하지 않으므로, BlueZ 는
-    다음 연결에서 ``Failed to register notify session`` 을 돌려준다. 복구 목록에
-    그 문구가 없으면 첫 시도가 그대로 죽고, 재시도는 이미 끊긴 링크에 쓰기를
-    시도해 ``Failed to initiate write`` 로 이어진다.
+
+class _NotifyHeldClient:
+    """첫 start_notify 를 BlueZ 가 거부하고, stop_notify 뒤에는 받아주는 클라이언트."""
+
+    def __init__(self, uuid: str) -> None:
+        self._uuid = uuid
+        self.started: list[tuple[str, object]] = []
+        self.stopped: list[str] = []
+        self._released = False
+
+    async def start_notify(self, uuid: str, callback) -> None:
+        self.started.append((uuid, callback))
+        if uuid == self._uuid and not self._released:
+            raise _BlueZError(
+                "[org.bluez.Error.Failed] Failed to register notify session"
+            )
+
+    async def stop_notify(self, uuid: str) -> None:
+        self.stopped.append(uuid)
+        if uuid == self._uuid:
+            self._released = True
+
+
+def test_a_notify_session_bluez_still_holds_is_released_and_retried(monkeypatch):
+    """이전 연결이 남긴 세션 때문에 재구독이 거부되면, 풀고 다시 걸어야 한다 (#92).
+
+    keep_notify 프로파일은 언락 캐릭터리스틱을 해제하지 않으므로 BlueZ 가
+    ``Failed to register notify session`` 을 돌려준다. 그 문구가 복구 대상에서
+    빠져 있으면 첫 시도가 그대로 죽고, 재시도는 이미 끊긴 링크에 쓰기를 시도해
+    ``Failed to initiate write`` 로 이어진다.
     """
-    import inspect
-
     from custom_components.omron.omron_ble import omron_driver
 
-    source = inspect.getsource(omron_driver.OmronDeviceSession._start_notify_with_recovery)
-    assert "register notify session" in source, (
-        "BlueZ 가 세션을 붙들고 있을 때의 문구가 복구 대상에서 빠졌다"
+    monkeypatch.setattr(omron_driver, "BleakError", _BlueZError)
+    client = _NotifyHeldClient(UNLOCK_CHARACTERISTIC_UUID)
+    target = SimpleNamespace(
+        _client=client,
+        _config=get_device_config("HEM-7188T1"),
+        _on_notify_channel_data=lambda *_: None,
+    )
+    sentinel = object()
+
+    asyncio.run(
+        OmronDeviceSession._start_notify_with_recovery(
+            target, UNLOCK_CHARACTERISTIC_UUID, sentinel
+        )
     )
 
-
-def test_the_unlock_subscribe_goes_through_the_recovery_path():
-    """언락 구독이 start_notify 를 직접 부르면 위 복구가 적용되지 않는다."""
-    import inspect
-
-    from custom_components.omron.omron_ble import omron_driver
-
-    source = inspect.getsource(omron_driver.OmronDeviceSession._token_unlock)
-    assert "_start_notify_with_recovery(\n            UNLOCK_CHARACTERISTIC_UUID" in source, (
-        "토큰 언락이 복구 경로를 우회한다"
+    assert client.stopped == [UNLOCK_CHARACTERISTIC_UUID], "구독을 풀지 않았다"
+    assert [u for u, _ in client.started] == [UNLOCK_CHARACTERISTIC_UUID] * 2, (
+        "풀고 나서 다시 걸지 않았다"
     )
-    assert "self._client.start_notify(UNLOCK_CHARACTERISTIC_UUID" not in source
+    # 호출자가 준 콜백이 그대로 전달돼야 한다 — RX 핸들러로 바뀌면 언락 응답을
+    # 받을 곳이 없어진다.
+    assert all(cb is sentinel for _, cb in client.started)


### PR DESCRIPTION
[#92](https://github.com/eigger/hass-omron/issues/92) on 2.8.7: #161 fixed the pairing — the BlueZ agent path runs for the first time, bonding completes, a real reading comes through, and the bond survives afterwards. Every unattended reconnect since then fails at the same place:

```
Memory session open attempt 1/3 failed: [org.bluez.Error.Failed] Failed to register notify session
Memory session open attempt 2/3 failed: [org.bluez.Error.Failed] Failed to initiate write
Memory session open attempt 3/3 failed: [org.bluez.Error.Failed] Failed to initiate write
```

Byte-for-byte identical on both polls. The reporter's guess was right: the notify subscription is never re-established because it was never released.

## Why

`_token_unlock` ends with:

```python
if keep_notify:
    self._debug_ble_link("token_unlock_keep_notify")   # nothing released
else:
    await self._client.stop_notify(UNLOCK_CHARACTERISTIC_UUID)
    ...
```

HEM-7188T1 sets `keep_notify_subscriptions`, so the unlock characteristic's subscription is never dropped. That is deliberate for the **RX channel** — writing CCCD `0x0000` there is what made a WLD3 cuff discard its bond ([#91](https://github.com/eigger/hass-omron/issues/91)) — but the unlock characteristic is a different concern, and BlueZ keeps its notify session across the disconnect. The next connection's `start_notify` is then refused.

Three things then failed to recover from it:

- `_start_notify_with_recovery` releases a stale subscription and retries, but matched only `notify acquired` / `notpermitted` / `already enabled`. BlueZ's wording here is `Failed to register notify session`, which fell through to `raise`.
- The unlock subscribe called `self._client.start_notify(...)` directly, so it never reached that helper at all.
- `reset_session_state` — the outer retry's recovery, documented for exactly this class of BlueZ error — calls `_unsubscribe_notify_channels(force=True)`, which iterates `rx_channel_uuids` only. The characteristic that was actually stuck was never in that loop, which is why attempts 2 and 3 got no further and degraded into `Failed to initiate write` on a link that was already gone.

## Changes

- `_start_notify_with_recovery` recognises `register notify session`, and takes an optional callback so a characteristic other than an RX channel can use it.
- The token-unlock subscribe goes through it, and so does the RX prime beside it — it was the last direct `start_notify` on a path `keep_notify` leaves subscribed.
- `reset_session_state` releases the unlock characteristic as well.

All of it is on recovery paths. The normal session close still leaves the CCCDs enabled, so #91's fix is untouched — this only changes what happens after a subscribe has already failed.

## What decides whether this is enough

The load-bearing assumption is that a **new** client's `stop_notify` releases the session BlueZ kept from the **previous** connection. When BlueZ reports the characteristic as already enabled on the same client, that holds. If instead the earlier `BleakClient` went away without releasing its `AcquireNotify` handle, the new client's `stop_notify` may be a no-op — and then recognising the message changes nothing, because `reset_session_state` calls the same `stop_notify`.

So the reporter's next log is the test, and the criterion is narrow: **does attempt 1 now get past `register notify session`?**

- If it does, this is sufficient and the teardown can stay as it is.
- If attempt 1 still fails the same way three times, the fix has to move to the close path — releasing **only** the unlock characteristic at teardown, never the RX channel, so #91 stays intact.

## Tests

`tests/test_session_cccd_persistence.py`:

- the reset test now expects the unlock characteristic among the released subscriptions
- a client that refuses the first `start_notify` the way BlueZ does and accepts it after `stop_notify`, asserting the subscription is released, re-registered, and that the caller's own callback is the one passed through — an earlier draft checked for substrings in the function source, which would have broken on a reformat while the behaviour stayed correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)