### PR TITLE
fix: bond before service discovery on a local adapter

### DIFF
--- a/custom_components/omron/ble_session.py
+++ b/custom_components/omron/ble_session.py
@@ -95,6 +95,15 @@ async def discard_probe_session(hass: HomeAssistant, address: str) -> None:
         await _close_session(session, address)
 
 
+async def close_probe_session(session: OmronDeviceSession, address: str) -> None:
+    """Close a probe link the caller already took, never raising into the flow.
+
+    ``discard_probe_session`` looks the session up in the bucket; this is for a
+    caller holding one that ``take_probe_session`` has already removed.
+    """
+    await _close_session(session, address)
+
+
 async def _close_session(session: OmronDeviceSession, address: str) -> None:
     """Close a session that no caller adopted, never raising into the flow."""
     try:

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -40,6 +40,7 @@ from homeassistant.data_entry_flow import AbortFlow
 
 from .ble_session import (
     stash_handoff_session,
+    close_probe_session,
     stash_probe_session,
     take_probe_session,
 )
@@ -497,7 +498,24 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Continue on the probe's link when it is still up: it is the one the
         # cuff bonded over, and reconnecting is what leaves the bond half made.
+        #
+        # Except when the profile bonds at connect. The probe opened its link
+        # before the model was known, so it could not, and a link that has
+        # already run discovery cannot be made to bond before it. Adopting it
+        # would silently skip the connect-time bonding this profile asks for.
+        # The one run whose retained-bond reconnect worked (2.7.8-beta.15) did
+        # exactly this: a fresh connection with pair=True rather than the
+        # probe's. The half-made bond the handoff avoids does not survive here
+        # either, because the reconnect bonds again straight away.
         session = take_probe_session(self.hass, address)
+        if session is not None and config.pair_on_connect:
+            _LOGGER.debug(
+                "Reconnecting to %s to bond before service discovery, which the "
+                "model-number link could not do",
+                address,
+            )
+            await close_probe_session(session, address)
+            session = None
         if session is not None:
             session = OmronDeviceSession.adopt(
                 session.release_client(), config, pairing_session=True

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -46,7 +46,7 @@ from .ble_session import (
 )
 from .const import CONF_BINDKEY, CONF_DEVICE_MODEL, CONF_USER_ALIASES, DOMAIN
 from .omron_ble.const import DEFAULT_DEVICE_MODEL
-from .omron_ble.omron_driver import OmronDeviceSession
+from .omron_ble.omron_driver import OmronDeviceSession, is_local_adapter
 from .omron_ble.setup import (
     async_fetch_device_model_number,
     async_pair_and_sync_device,
@@ -507,8 +507,16 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
         # exactly this: a fresh connection with pair=True rather than the
         # probe's. The half-made bond the handoff avoids does not survive here
         # either, because the reconnect bonds again straight away.
+        #
+        # Local adapters only, matching the connect path: on a proxy no pair
+        # request follows, so dropping the probe link would discard the one the
+        # bond was being made over and replace it with an identical connect.
         session = take_probe_session(self.hass, address)
-        if session is not None and config.pair_on_connect:
+        if (
+            session is not None
+            and config.pair_on_connect
+            and is_local_adapter(ble_device)
+        ):
             _LOGGER.debug(
                 "Reconnecting to %s to bond before service discovery, which the "
                 "model-number link could not do",

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -151,6 +151,23 @@ class DeviceConfig:
     keep_notify_subscriptions: bool = False
 
     @property
+    def pair_on_connect(self) -> bool:
+        """Whether to bond before service discovery on the pairing connection.
+
+        The only run whose retained-bond reconnect has ever worked -- the
+        2.7.8-beta.15 A/B on a local BlueZ adapter -- bonded at connect time,
+        before discovery. Every build since has bonded after it, and none has
+        reproduced that result.
+
+        Says nothing about ordinary reconnects: those must not send a pair
+        request. The caller pairs only on the session that creates the bond,
+        and only over a local adapter -- an incomplete request on an ESP32
+        proxy is read as an authentication failure and ESP-IDF drops the
+        stored bond from flash (#142).
+        """
+        return self.host_pairing_mode == HostPairingMode.OS_BONDING
+
+    @property
     def subscribe_service_changed(self) -> bool:
         """Whether to subscribe to Service Changed while pairing, as the app does.
 

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -142,32 +142,46 @@ async def establish_connection_with_bond_settle(
     """
     # A bare BLEDevice is enough: BlueZ routes carry a /org/bluez/... path,
     # proxy routes do not.
-    bond_at_connect = pair_on_connect and bool(_bluez_device_path(ble_device))
-    if pair_on_connect and not bond_at_connect:
+    pair_this_attempt = pair_on_connect and bool(_bluez_device_path(ble_device))
+    bonded_at_connect = False
+    if pair_on_connect and not pair_this_attempt:
         _LOGGER.debug(
             "%s: not a local adapter, leaving the bond to pair() after discovery",
             name,
         )
     last_source = "unknown"
-    for attempt in range(1, max_attempts + 1):
+    for attempt in range(1, max_attempts + 1):  # noqa: B007
         source = _connection_source(ble_device)
         last_source = source
         _LOGGER.debug(
             "Connecting to %s [%s] via proxy/source=%s (attempt %d/%d)",
             name, model or "?", source, attempt, max_attempts,
         )
-        if bond_at_connect:
+        if pair_this_attempt:
             try:
-                client = await establish_connection(
-                    BleakClient, ble_device, name, pair=True
+                # BlueZ 5.72+ leaves the Just Works confirmation unanswered
+                # without a registered agent and fails the pair with
+                # AuthenticationFailed, so the agent is what makes this path
+                # actually bond rather than quietly fall back.
+                async with _bluez_pairing_agent():
+                    client = await establish_connection(
+                        BleakClient, ble_device, name, pair=True
+                    )
+                bonded_at_connect = True
+                _LOGGER.info(
+                    "%s bonded before service discovery via %s", name, source
                 )
-            except BleakError as pair_exc:
-                # Falling back rather than failing: a refused connect-time pair
-                # still leaves pair() after discovery, which is where every
-                # build since #142 has made the bond.
-                _LOGGER.debug(
-                    "Connect-time bonding for %s failed (%s); connecting without it",
+            except (BleakError, TimeoutError, asyncio.TimeoutError) as pair_exc:
+                # Fall back rather than fail: pair() after discovery still makes
+                # the bond, as it does on every build since #142. One shot only
+                # -- retrying the request on each attempt turns one refusal into
+                # several.
+                pair_this_attempt = False
+                _LOGGER.warning(
+                    "Connect-time bonding for %s failed (%s: %s); connecting "
+                    "without it and leaving the bond to pair()",
                     name,
+                    type(pair_exc).__name__,
                     pair_exc,
                 )
                 client = await establish_connection(BleakClient, ble_device, name)
@@ -175,13 +189,18 @@ async def establish_connection_with_bond_settle(
             client = await establish_connection(BleakClient, ble_device, name)
         # Only the radio that paired holds the bond, so report both paths.
         connected_via = _connected_path(client, ble_device)
+        # Read back by pair(): bonding again on the same link only rotates the
+        # keys the connect just made, and skipping on the config flag alone
+        # would also skip after the fallback, leaving no bond at all.
+        client._omron_bonded_at_connect = bonded_at_connect  # type: ignore[attr-defined]
         _LOGGER.debug(
             "BLE link established to %s (advertised by source=%s, connected via "
-            "%s, is_connected=%s); settling up to %.1fs "
+            "%s, bonded_this_connect=%s, is_connected=%s); settling up to %.1fs "
             "for bonding/encryption before first GATT op",
             name,
             source,
             connected_via,
+            bonded_at_connect,
             getattr(client, "is_connected", "?"),
             _POST_CONNECT_BOND_SETTLE_SEC,
         )
@@ -2131,6 +2150,17 @@ class OmronDeviceSession:
         """Program pairing credentials according to ``host_pairing_mode``."""
         pair_key = key or PAIRING_KEY
         if self._config.host_pairing_mode == HostPairingMode.OS_BONDING:
+            if getattr(self._client, "_omron_bonded_at_connect", False):
+                # connect() bonded before GATT discovery. Bonding again on the
+                # same link only rotates the keys it just made. Keyed on what
+                # actually happened rather than on the profile flag, so a
+                # connect-time pair that fell back still gets a bond here.
+                _LOGGER.debug(
+                    "Skipping explicit OS bonding for %s: already bonded during "
+                    "connect",
+                    self._config.model,
+                )
+                return
             await self._pair_os_bonding()
             return
         if self._config.host_pairing_mode == HostPairingMode.NONE:
@@ -2143,7 +2173,8 @@ class OmronDeviceSession:
             # would take over pairing confirmation for unrelated local devices.
             await self._pair_custom_key(pair_key)
             return
-        # Nothing has put an agent up for this link -- connect no longer bonds
+        # Nothing has put an agent up for this link: connect-time bonding is
+        # for OS_BONDING profiles over a local adapter, not this path
         # and _pair_os_bonding is the OS_BONDING path, not this one. Cuffs that
         # raise an SMP security request when RX notifications
         # are enabled (HEM-7155T) then drop the link because BlueZ leaves the

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -142,7 +142,7 @@ async def establish_connection_with_bond_settle(
     """
     # A bare BLEDevice is enough: BlueZ routes carry a /org/bluez/... path,
     # proxy routes do not.
-    pair_this_attempt = pair_on_connect and bool(_bluez_device_path(ble_device))
+    pair_this_attempt = pair_on_connect and is_local_adapter(ble_device)
     if pair_on_connect and not pair_this_attempt:
         _LOGGER.debug(
             "%s: not a local adapter, leaving the bond to pair() after discovery",
@@ -499,6 +499,18 @@ async def _bluez_remove_device(client: BleakClient | BLEDevice) -> bool:
         return False
     finally:
         bus.disconnect()
+
+
+def is_local_adapter(client: BleakClient | BLEDevice) -> bool:
+    """Whether this link runs on a local BlueZ adapter rather than a proxy.
+
+    BlueZ routes carry a ``/org/bluez/...`` object path; ESPHome proxy routes do
+    not. Callers that gate connect-time bonding share this so the connect path
+    and the config flow cannot drift apart -- closing the probe link on a proxy,
+    where no pair request follows, would drop the link the bond was being made
+    over and put nothing in its place.
+    """
+    return bool(_bluez_device_path(client))
 
 
 async def _bluez_is_paired(client: BleakClient | BLEDevice) -> bool | None:
@@ -2154,10 +2166,11 @@ class OmronDeviceSession:
         pair_key = key or PAIRING_KEY
         if self._config.host_pairing_mode == HostPairingMode.OS_BONDING:
             if getattr(self._client, "_omron_bonded_at_connect", False):
-                # connect() bonded before GATT discovery. Bonding again on the
-                # same link only rotates the keys it just made. Keyed on what
-                # actually happened rather than on the profile flag, so a
-                # connect-time pair that fell back still gets a bond here.
+                # Keyed on what the connect actually did rather than on the
+                # profile flag, so that a connect-time pair which fell back
+                # still gets its bond here, while one that succeeded is not
+                # bonded a second time on the same link -- which would only
+                # rotate the keys it just made.
                 _LOGGER.debug(
                     "Skipping explicit OS bonding for %s: already bonded during "
                     "connect",

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -143,20 +143,22 @@ async def establish_connection_with_bond_settle(
     # A bare BLEDevice is enough: BlueZ routes carry a /org/bluez/... path,
     # proxy routes do not.
     pair_this_attempt = pair_on_connect and bool(_bluez_device_path(ble_device))
-    bonded_at_connect = False
     if pair_on_connect and not pair_this_attempt:
         _LOGGER.debug(
             "%s: not a local adapter, leaving the bond to pair() after discovery",
             name,
         )
     last_source = "unknown"
-    for attempt in range(1, max_attempts + 1):  # noqa: B007
+    for attempt in range(1, max_attempts + 1):
         source = _connection_source(ble_device)
         last_source = source
         _LOGGER.debug(
             "Connecting to %s [%s] via proxy/source=%s (attempt %d/%d)",
             name, model or "?", source, attempt, max_attempts,
         )
+        # Per attempt: a connect that bonded and then dropped during the
+        # settle says nothing about the one that replaces it.
+        bonded_this_client = False
         if pair_this_attempt:
             try:
                 # BlueZ 5.72+ leaves the Just Works confirmation unanswered
@@ -167,7 +169,7 @@ async def establish_connection_with_bond_settle(
                     client = await establish_connection(
                         BleakClient, ble_device, name, pair=True
                     )
-                bonded_at_connect = True
+                bonded_this_client = True
                 _LOGGER.info(
                     "%s bonded before service discovery via %s", name, source
                 )
@@ -189,10 +191,11 @@ async def establish_connection_with_bond_settle(
             client = await establish_connection(BleakClient, ble_device, name)
         # Only the radio that paired holds the bond, so report both paths.
         connected_via = _connected_path(client, ble_device)
-        # Read back by pair(): bonding again on the same link only rotates the
-        # keys the connect just made, and skipping on the config flag alone
-        # would also skip after the fallback, leaving no bond at all.
-        client._omron_bonded_at_connect = bonded_at_connect  # type: ignore[attr-defined]
+        # Read back by pair(), which skips its own bonding only when this
+        # connect made the bond: doing it again on the same link rotates the
+        # keys just made, and skipping on the profile flag instead would also
+        # skip after a fallback and leave no bond at all.
+        client._omron_bonded_at_connect = bonded_this_client  # type: ignore[attr-defined]
         _LOGGER.debug(
             "BLE link established to %s (advertised by source=%s, connected via "
             "%s, bonded_this_connect=%s, is_connected=%s); settling up to %.1fs "
@@ -200,7 +203,7 @@ async def establish_connection_with_bond_settle(
             name,
             source,
             connected_via,
-            bonded_at_connect,
+            bonded_this_client,
             getattr(client, "is_connected", "?"),
             _POST_CONNECT_BOND_SETTLE_SEC,
         )

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -403,6 +403,18 @@ async def _bluez_pairing_agent() -> AsyncIterator[Any]:
         bus.disconnect()
 
 
+def is_local_adapter(client: BleakClient | BLEDevice) -> bool:
+    """Whether this link runs on a local BlueZ adapter rather than a proxy.
+
+    BlueZ routes carry a ``/org/bluez/...`` object path; ESPHome proxy routes do
+    not. Callers that gate connect-time bonding share this so the connect path
+    and the config flow cannot drift apart -- closing the probe link on a proxy,
+    where no pair request follows, would drop the link the bond was being made
+    over and put nothing in its place.
+    """
+    return bool(_bluez_device_path(client))
+
+
 async def _bluez_agent_pair(client: BleakClient) -> bool:
     """Pair via BlueZ DBus with a registered KeyboardDisplay agent.
 
@@ -499,18 +511,6 @@ async def _bluez_remove_device(client: BleakClient | BLEDevice) -> bool:
         return False
     finally:
         bus.disconnect()
-
-
-def is_local_adapter(client: BleakClient | BLEDevice) -> bool:
-    """Whether this link runs on a local BlueZ adapter rather than a proxy.
-
-    BlueZ routes carry a ``/org/bluez/...`` object path; ESPHome proxy routes do
-    not. Callers that gate connect-time bonding share this so the connect path
-    and the config flow cannot drift apart -- closing the probe link on a proxy,
-    where no pair request follows, would drop the link the bond was being made
-    over and put nothing in its place.
-    """
-    return bool(_bluez_device_path(client))
 
 
 async def _bluez_is_paired(client: BleakClient | BLEDevice) -> bool | None:
@@ -2189,12 +2189,11 @@ class OmronDeviceSession:
             # would take over pairing confirmation for unrelated local devices.
             await self._pair_custom_key(pair_key)
             return
-        # Nothing has put an agent up for this link: connect-time bonding is
-        # for OS_BONDING profiles over a local adapter, not this path
-        # and _pair_os_bonding is the OS_BONDING path, not this one. Cuffs that
-        # raise an SMP security request when RX notifications
-        # are enabled (HEM-7155T) then drop the link because BlueZ leaves the
-        # Just Works confirmation unanswered.
+        # Nothing has put an agent up for this link: connect-time bonding and
+        # _pair_os_bonding both belong to OS_BONDING profiles, and this is the
+        # custom-key path. Cuffs that raise an SMP security request when RX
+        # notifications are enabled (HEM-7155T) then drop the link, because
+        # BlueZ leaves the Just Works confirmation unanswered without one.
         async with _bluez_pairing_agent():
             await self._pair_custom_key(pair_key)
 

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -126,15 +126,28 @@ async def establish_connection_with_bond_settle(
     *,
     model: str = "",
     max_attempts: int = _CONNECT_SETTLE_ATTEMPTS,
+    pair_on_connect: bool = False,
 ) -> BleakClient:
     """Connect, let bonding/encryption settle, then refresh the GATT cache.
 
     Retries if the device drops during the settle (common on multi-proxy setups).
 
-    Nothing here asks to bond: the cuff raises its own SMP Security Request and
-    both host stacks answer it. Ours only cost the stored bond on an ESP32
-    proxy (#142). A bond is made by ``pair()`` after discovery.
+    ``pair_on_connect`` bonds before service discovery, which is what the one
+    run with a working retained-bond reconnect did (2.7.8-beta.15, local
+    BlueZ). It is honoured only over a local adapter: on an ESP32 proxy a pair
+    request that does not complete is read as an authentication failure and
+    ESP-IDF drops the stored bond from flash (#142), and the same flag brought
+    no benefit there when 2.8.3 carried it. Ordinary reconnects never set it --
+    the cuff raises its own Security Request and both stacks answer it.
     """
+    # A bare BLEDevice is enough: BlueZ routes carry a /org/bluez/... path,
+    # proxy routes do not.
+    bond_at_connect = pair_on_connect and bool(_bluez_device_path(ble_device))
+    if pair_on_connect and not bond_at_connect:
+        _LOGGER.debug(
+            "%s: not a local adapter, leaving the bond to pair() after discovery",
+            name,
+        )
     last_source = "unknown"
     for attempt in range(1, max_attempts + 1):
         source = _connection_source(ble_device)
@@ -143,7 +156,23 @@ async def establish_connection_with_bond_settle(
             "Connecting to %s [%s] via proxy/source=%s (attempt %d/%d)",
             name, model or "?", source, attempt, max_attempts,
         )
-        client = await establish_connection(BleakClient, ble_device, name)
+        if bond_at_connect:
+            try:
+                client = await establish_connection(
+                    BleakClient, ble_device, name, pair=True
+                )
+            except BleakError as pair_exc:
+                # Falling back rather than failing: a refused connect-time pair
+                # still leaves pair() after discovery, which is where every
+                # build since #142 has made the bond.
+                _LOGGER.debug(
+                    "Connect-time bonding for %s failed (%s); connecting without it",
+                    name,
+                    pair_exc,
+                )
+                client = await establish_connection(BleakClient, ble_device, name)
+        else:
+            client = await establish_connection(BleakClient, ble_device, name)
         # Only the radio that paired holds the bond, so report both paths.
         connected_via = _connected_path(client, ble_device)
         _LOGGER.debug(
@@ -678,6 +707,9 @@ class OmronDeviceSession:
             self.address,
             model=self._config.model,
             max_attempts=self._config.connect_settle_attempts,
+            # Only the connection that creates the bond; a reconnect that sends
+            # a pair request is what cost the bond on a proxy (#142).
+            pair_on_connect=self._pairing_session and self._config.pair_on_connect,
         )
         return self
 

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -111,7 +111,7 @@ def test_connect_time_bonding_is_fenced_to_a_local_adapter_and_the_pairing_sessi
     )
 
     source = inspect.getsource(establish_connection_with_bond_settle)
-    assert "_bluez_device_path" in source, (
+    assert "is_local_adapter" in source, (
         "로컬 어댑터 여부를 확인하지 않는다 — 프록시에서 pair 요청이 나가면 "
         "본드를 잃는다"
     )
@@ -316,24 +316,46 @@ def test_the_probe_link_is_not_adopted_when_the_profile_bonds_at_connect():
     ).read_text(encoding="utf-8")
     tree = ast.parse(source)
 
-    adopts = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
+    assert any(
+        isinstance(node, ast.Call)
         and isinstance(node.func, ast.Attribute)
         and node.func.attr == "adopt"
-    ]
-    assert adopts, "프로브 링크를 adopt 하는 곳이 없다 — 테스트가 낡았다"
+        for node in ast.walk(tree)
+    ), "프로브 링크를 adopt 하는 곳이 없다 — 테스트가 낡았다"
 
-    guards = []
-    for node in ast.walk(tree):
-        if isinstance(node, ast.If):
-            end = getattr(node, "end_lineno", node.lineno)
-            if any(node.lineno < call.lineno <= end for call in adopts):
-                guards.append(ast.unparse(node.test))
-    assert any("pair_on_connect" in g for g in guards) or "pair_on_connect" in source, (
-        "프로파일이 connect 시점에 본딩하는지 보지 않고 프로브 링크를 이어받는다"
+    discards = [
+        ast.unparse(node.test)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.If)
+        and any(
+            isinstance(call, ast.Call)
+            and getattr(call.func, "id", None) == "close_probe_session"
+            for call in ast.walk(node)
+        )
+    ]
+    assert discards, (
+        "프로브 링크를 버리는 분기가 없다 — 이어받으면 connect-time 본딩이 "
+        "조용히 건너뛰어진다"
     )
-    assert "close_probe_session" in source, (
-        "이어받지 않기로 한 프로브 링크를 닫지 않으면 링크가 떠 있는 채로 남는다"
+    guard = discards[0]
+    assert "pair_on_connect" in guard, (
+        "프로파일이 connect 시점에 본딩하는지 보지 않고 프로브 링크를 버린다"
     )
+    # 프록시에서는 pair=True 가 나가지 않는다. 그런데도 프로브를 버리면 본드가
+    # 만들어지던 링크만 끊고 똑같은 연결로 갈아타는 셈이라, 순수한 손해다.
+    assert "is_local_adapter" in guard, (
+        "로컬 어댑터인지 보지 않는다 — 프록시에서 프로브 링크만 잃는다"
+    )
+
+
+def test_both_gates_use_the_same_local_adapter_predicate():
+    """설정 플로우와 연결 경로가 갈라지면 프록시에서 링크만 잃는다."""
+    import inspect
+
+    from custom_components.omron.omron_ble.omron_driver import (
+        establish_connection_with_bond_settle,
+    )
+
+    assert "is_local_adapter" in inspect.getsource(
+        establish_connection_with_bond_settle
+    ), "연결 경로가 공용 술어를 쓰지 않는다"

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -90,16 +90,19 @@ def test_driver_module_has_no_undefined_names():
     assert result.returncode == 0, result.stdout + result.stderr
 
 
-def test_nothing_asks_to_bond_at_connect_time():
-    """연결 시점 pair 요청은 사라졌다 — 커프가 Security Request 로 몰고 간다.
+def test_connect_time_bonding_is_fenced_to_a_local_adapter_and_the_pairing_session():
+    """연결 시점 본딩은 돌아왔지만, #142 가 막으려던 것은 그대로 막아야 한다.
 
-    보내서 얻는 게 없고 잃을 게 있었다. ESP-IDF 의 ``btc_dm_ble_auth_cmpl_evt``
-    는 SMP_CONN_TOUT(102) 을 default 분기로 흘려 ``btc_dm_remove_ble_bonding_keys()``
-    를 부른다. 이슈 #91 의 프록시 로그에서 페어링 직후 ``bonded=YES`` 였던 본드가
-    몇 분 뒤 사라진 게 그것이고, ``pair_only_when_pairing`` 은 그 손실을 줄이려고
-    있던 플래그였다. 요청 자체를 없애면 둘 다 필요 없다.
+    ESP-IDF 의 ``btc_dm_ble_auth_cmpl_evt`` 는 SMP_CONN_TOUT(102) 을 default
+    분기로 흘려 ``btc_dm_remove_ble_bonding_keys()`` 를 부른다. 프록시에서
+    완료되지 않은 pair 요청 하나가 저장된 본드를 영구히 날린다. 그리고 2.8.3 이
+    이 플래그를 달고도 ESP 에서 실패했으니, 거기서는 얻는 것도 없었다.
 
-    본드를 만들어야 하는 프로필은 디스커버리 뒤 ``pair()`` 에서 만든다.
+    반대로 재접속 본드가 유지된 유일한 실행(2.7.8-beta.15, 로컬 BlueZ)은 연결
+    시점에, 디스커버리보다 먼저 본딩했다.
+
+    그래서 세 가지 울타리를 친다: 로컬 어댑터일 때만, 본드를 만드는 세션에서만,
+    그리고 실패하면 평범한 연결로 물러난다.
     """
     import inspect
 
@@ -108,13 +111,32 @@ def test_nothing_asks_to_bond_at_connect_time():
     )
 
     source = inspect.getsource(establish_connection_with_bond_settle)
-    assert "pair=" not in source, "연결 경로가 다시 본딩을 요청하면 안 된다"
+    assert "_bluez_device_path" in source, (
+        "로컬 어댑터 여부를 확인하지 않는다 — 프록시에서 pair 요청이 나가면 "
+        "본드를 잃는다"
+    )
+    assert "pair=True" in source, "연결 시점 본딩 경로가 없다"
+    assert source.count("establish_connection(BleakClient") >= 2, (
+        "연결 시점 본딩이 실패했을 때 물러날 경로가 없다"
+    )
 
-    config = get_device_config("HEM-7386T1")
-    assert not hasattr(config, "pair_on_connect")
-    assert not hasattr(config, "pair_on_connect_for")
-    assert not hasattr(config, "pair_only_when_pairing")
-    assert not hasattr(config, "os_bond_once")
+
+def test_only_the_pairing_session_bonds_at_connect():
+    """재접속이 pair 요청을 보내면 안 된다 — 그게 프록시에서 본드를 날린 경로다."""
+    import inspect
+
+    from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+
+    source = inspect.getsource(OmronDeviceSession.connect)
+    assert "self._pairing_session and self._config.pair_on_connect" in source, (
+        "페어링 세션 여부로 걸러내지 않는다"
+    )
+
+
+def test_only_os_bonding_profiles_bond_at_connect():
+    """커스텀 키 프로파일은 OS 본드를 만들지 않는다."""
+    assert get_device_config("HEM-7386T1").pair_on_connect is True
+    assert get_device_config("HEM-7155T").pair_on_connect is False
 
 
 def test_one_poll_is_one_connection_attempt_on_the_profile_under_test():

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -119,6 +119,33 @@ def test_connect_time_bonding_is_fenced_to_a_local_adapter_and_the_pairing_sessi
     assert source.count("establish_connection(BleakClient") >= 2, (
         "연결 시점 본딩이 실패했을 때 물러날 경로가 없다"
     )
+    assert "_bluez_pairing_agent" in source, (
+        "agent 없이 Device1.Pair() 를 부르면 BlueZ 5.72+ 는 Just Works 확인을 "
+        "응답하지 않고 AuthenticationFailed 로 떨어진다 — 그러면 폴백이 타서 "
+        "디스커버리 뒤 pair() 와 구분되지 않는다"
+    )
+    assert "TimeoutError" in source, (
+        "bleak_retry_connector 가 소진 후 던지는 TimeoutError 에 폴백이 없다"
+    )
+    assert "pair_this_attempt = False" in source, (
+        "거절이 매 시도마다 반복된다 — 한 번 거절되면 남은 시도는 평범한 연결이어야 한다"
+    )
+
+
+def test_a_second_bonding_is_skipped_only_when_the_connect_actually_bonded():
+    """플래그가 아니라 결과로 판단해야 한다 — 폴백이 탄 뒤에도 본드는 만들어져야."""
+    import inspect
+
+    from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+
+    source = inspect.getsource(OmronDeviceSession.pair)
+    assert "_omron_bonded_at_connect" in source, (
+        "connect 가 실제로 본딩했는지 보지 않는다 — 같은 링크에서 두 번 본딩하면 "
+        "방금 만든 키를 돌린다"
+    )
+    assert "pair_on_connect" not in source, (
+        "프로파일 플래그로 건너뛰면 폴백이 탄 뒤에도 건너뛰어 본드가 없이 끝난다"
+    )
 
 
 def test_only_the_pairing_session_bonds_at_connect():

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -252,3 +252,44 @@ def test_the_two_profiles_under_test_stay_comparable():
     b = get_device_config("HEM-7380T1")
     for field in ("connect_settle_attempts", "keep_notify_subscriptions"):
         assert getattr(a, field) == getattr(b, field), field
+
+
+def test_the_bonding_result_is_scoped_to_the_connection_it_describes():
+    """settle 중 끊기고 재시도하면, 앞 시도의 결과가 남아 있으면 안 된다.
+
+    1차에서 pair=True 가 성공하고 settle 중 링크가 끊긴 뒤 2차가 폴백하면,
+    이번 연결은 본딩하지 않았는데 pair() 가 건너뛴다 — 본드 없이 끝난다.
+    connect_settle_attempts 가 1 인 프로파일은 해당 없지만, 3 인 OS 본딩
+    프로파일에서는 실재한다.
+    """
+    import ast
+    import inspect
+
+    from custom_components.omron.omron_ble.omron_driver import (
+        establish_connection_with_bond_settle,
+    )
+
+    tree = ast.parse(inspect.getsource(establish_connection_with_bond_settle).lstrip())
+    fn = tree.body[0]
+    loop = next(node for node in ast.walk(fn) if isinstance(node, ast.For))
+
+    def _assigned(scope) -> set[str]:
+        names = set()
+        for node in ast.walk(scope):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    if isinstance(target, ast.Name):
+                        names.add(target.id)
+        return names
+
+    stashed = "bonded_this_client"
+    assert stashed in _assigned(loop), (
+        f"{stashed} 가 루프 안에서 초기화되지 않는다 — 앞 시도의 결과가 "
+        "다음 연결에 딸려간다"
+    )
+    before_loop = ast.Module(
+        body=[node for node in fn.body if node is not loop], type_ignores=[]
+    )
+    assert stashed not in _assigned(before_loop), (
+        f"{stashed} 를 루프 밖에서도 대입한다 — 시도별 결과가 아니게 된다"
+    )

--- a/tests/test_wld3_keep_bond.py
+++ b/tests/test_wld3_keep_bond.py
@@ -293,3 +293,47 @@ def test_the_bonding_result_is_scoped_to_the_connection_it_describes():
     assert stashed not in _assigned(before_loop), (
         f"{stashed} 를 루프 밖에서도 대입한다 — 시도별 결과가 아니게 된다"
     )
+
+
+def test_the_probe_link_is_not_adopted_when_the_profile_bonds_at_connect():
+    """프로브 링크를 이어받으면 connect-time 본딩이 조용히 건너뛰어진다 (#24, #92).
+
+    프로브는 모델을 모르는 상태에서 링크를 열었으니 본딩할 수 없었고, 이미
+    디스커버리를 끝낸 링크는 "디스커버리보다 먼저" 본딩할 수 없다. 그대로
+    adopt 하면 connect() 가 즉시 반환해 pair=True 가 나가지 않는다 — 이 경로를
+    검증하려는 제보자들에게 아무 동작도 하지 않게 된다.
+
+    재접속 본드가 유지된 유일한 실행(2.7.8-beta.15)도 프로브 링크가 아니라 새
+    연결이었다.
+    """
+    import ast
+    from pathlib import Path
+
+    # conftest 가 voluptuous 를 채우지 않으므로 import 하지 않고 파일로 읽는다.
+    source = (
+        Path(__file__).resolve().parent.parent
+        / "custom_components" / "omron" / "config_flow.py"
+    ).read_text(encoding="utf-8")
+    tree = ast.parse(source)
+
+    adopts = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "adopt"
+    ]
+    assert adopts, "프로브 링크를 adopt 하는 곳이 없다 — 테스트가 낡았다"
+
+    guards = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.If):
+            end = getattr(node, "end_lineno", node.lineno)
+            if any(node.lineno < call.lineno <= end for call in adopts):
+                guards.append(ast.unparse(node.test))
+    assert any("pair_on_connect" in g for g in guards) or "pair_on_connect" in source, (
+        "프로파일이 connect 시점에 본딩하는지 보지 않고 프로브 링크를 이어받는다"
+    )
+    assert "close_probe_session" in source, (
+        "이어받지 않기로 한 프로브 링크를 닫지 않으면 링크가 떠 있는 채로 남는다"
+    )


### PR DESCRIPTION
The only run whose retained-bond reconnect has ever worked — the **2.7.8-beta.15** A/B on a local BlueZ adapter — bonded at connect time, before service discovery:

```
15:19:06  Connecting via local hci0, pair_on_connect=True
15:19:08  Fresh OS bond completed before service discovery
15:19:10  Service Changed subscribed
          ... four later connections resumed the retained bond, no 0x06
```

#142 removed that, and no build since has reproduced the result on any transport. #24 now has `btmon` for the other family showing what the reconnect looks like without it — `Encryption Change: PIN or Key Missing (0x06)` with the LTK sitting in BlueZ's device file.

## Restored, with three fences

#142's reason for removing it was real, so none of it is given back unconditionally.

- **Local adapter only.** On an ESP32 proxy a pair request that does not complete is read as an authentication failure and ESP-IDF drops the stored bond from flash. A `BLEDevice` routed through BlueZ carries a `/org/bluez/...` path and one routed through a proxy does not, so the existing `_bluez_device_path()` tells them apart.
- **The pairing session only.** An ordinary reconnect must never send a pair request — the cuff raises its own Security Request and both stacks answer it. That is the case #142 was actually protecting.
- **Falls back to a plain connect** if the connect-time pair is refused, leaving `pair()` after discovery to make the bond exactly as it does today.

## Why BlueZ only, beyond the hazard

**2.8.3 carried this flag, with the same guards, and still failed on a proxy.** So it is not the answer there — the difference between that run and beta.15 is the transport, not the configuration. ESP needs its own diagnosis and this does not pretend to be it.

That also means the reasoning in #142 about the 20-second stall deserves a second look: with `pair_only_when_pairing` set, that reconnect should not have sent a pair request at all, and `bleak_retry_connector`'s `BLEAK_TIMEOUT` is 20 s for the connect itself.

## Tests

`test_nothing_asks_to_bond_at_connect_time` is rewritten rather than deleted — against the fences, since the proxy hazard it was protecting is unchanged. Three tests now: the local-adapter check and the fallback path, the pairing-session gate, and that only OS-bonding profiles are eligible.

Reviewable by #24 and #92, who are both on local BlueZ.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
