### PR TITLE
fix: retry an ordinary reconnect that fails outright, not just one that settle-drops

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -159,36 +159,57 @@ async def establish_connection_with_bond_settle(
         # Per attempt: a connect that bonded and then dropped during the
         # settle says nothing about the one that replaces it.
         bonded_this_client = False
-        if pair_this_attempt:
-            try:
-                # BlueZ 5.72+ leaves the Just Works confirmation unanswered
-                # without a registered agent and fails the pair with
-                # AuthenticationFailed, so the agent is what makes this path
-                # actually bond rather than quietly fall back.
-                async with _bluez_pairing_agent():
-                    client = await establish_connection(
-                        BleakClient, ble_device, name, pair=True
+        try:
+            if pair_this_attempt:
+                try:
+                    # BlueZ 5.72+ leaves the Just Works confirmation unanswered
+                    # without a registered agent and fails the pair with
+                    # AuthenticationFailed, so the agent is what makes this path
+                    # actually bond rather than quietly fall back.
+                    async with _bluez_pairing_agent():
+                        client = await establish_connection(
+                            BleakClient, ble_device, name, pair=True
+                        )
+                    bonded_this_client = True
+                    _LOGGER.info(
+                        "%s bonded before service discovery via %s", name, source
                     )
-                bonded_this_client = True
-                _LOGGER.info(
-                    "%s bonded before service discovery via %s", name, source
-                )
-            except (BleakError, TimeoutError, asyncio.TimeoutError) as pair_exc:
-                # Fall back rather than fail: pair() after discovery still makes
-                # the bond, as it does on every build since #142. One shot only
-                # -- retrying the request on each attempt turns one refusal into
-                # several.
-                pair_this_attempt = False
-                _LOGGER.warning(
-                    "Connect-time bonding for %s failed (%s: %s); connecting "
-                    "without it and leaving the bond to pair()",
-                    name,
-                    type(pair_exc).__name__,
-                    pair_exc,
-                )
+                except (BleakError, TimeoutError, asyncio.TimeoutError) as pair_exc:
+                    # Fall back rather than fail: pair() after discovery still
+                    # makes the bond, as it does on every build since #142. One
+                    # shot only -- retrying the request on each attempt turns
+                    # one refusal into several.
+                    pair_this_attempt = False
+                    _LOGGER.warning(
+                        "Connect-time bonding for %s failed (%s: %s); connecting "
+                        "without it and leaving the bond to pair()",
+                        name,
+                        type(pair_exc).__name__,
+                        pair_exc,
+                    )
+                    client = await establish_connection(BleakClient, ble_device, name)
+            else:
                 client = await establish_connection(BleakClient, ble_device, name)
-        else:
-            client = await establish_connection(BleakClient, ble_device, name)
+        except (BleakError, TimeoutError, asyncio.TimeoutError) as connect_exc:
+            # An ordinary reconnect (pair_this_attempt False, so nothing above
+            # catches this) used to let a transient failure here -- e.g.
+            # "failed to discover services, device disconnected" -- escape the
+            # loop on the first iteration, spending none of max_attempts's
+            # retry budget; that budget only ever covered a settle-drop below.
+            # Retry like one instead.
+            if attempt == max_attempts:
+                raise
+            _LOGGER.warning(
+                "Connecting to %s via source=%s failed (attempt %d/%d): %s: %s "
+                "— retrying",
+                name,
+                source,
+                attempt,
+                max_attempts,
+                type(connect_exc).__name__,
+                connect_exc,
+            )
+            continue
         # Only the radio that paired holds the bond, so report both paths.
         connected_via = _connected_path(client, ble_device)
         # Read back by pair(), which skips its own bonding only when this

--- a/tests/test_ordinary_reconnect_retries.py
+++ b/tests/test_ordinary_reconnect_retries.py
@@ -1,0 +1,100 @@
+"""Regression test: an ordinary reconnect must spend its retry budget.
+
+``establish_connection_with_bond_settle`` takes ``max_attempts`` and its
+docstring frames the loop as retrying connection trouble. But on an ordinary
+reconnect to an already-bonded device (``pair_on_connect`` False, which is
+every scheduled poll and every "Refresh Data" press once pairing is done),
+the plain ``client = await establish_connection(...)`` call sat outside any
+try/except. A transient failure there -- ``bleak_retry_connector`` giving up
+with "failed to discover services, device disconnected" after its own
+internal attempts -- propagated straight out of the loop on its first
+iteration. ``max_attempts`` only ever covered the other case below it (a
+connect that briefly succeeds and then drops during the post-connect
+settle), never a connect that fails outright.
+
+conftest replaces bleak/bleak_retry_connector with MagicMock, so the two
+names this test needs to control -- ``BleakError`` and ``establish_connection``
+-- are monkeypatched on the module the same way test_session_cccd_persistence
+already does for ``BleakError``, and async functions run via ``asyncio.run``
+rather than a pytest-asyncio plugin, matching the rest of this test suite.
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omron.omron_ble import omron_driver
+
+
+class _FakeClient:
+    """Enough of a BleakClient for the settle/refresh steps to no-op cleanly."""
+
+    def __init__(self):
+        self.is_connected = True
+
+    async def disconnect(self):
+        pass
+
+
+def test_a_connect_failure_on_an_ordinary_reconnect_is_retried(monkeypatch):
+    class _BlueZError(Exception):
+        pass
+
+    monkeypatch.setattr(omron_driver, "BleakError", _BlueZError)
+    monkeypatch.setattr(omron_driver, "_POST_CONNECT_BOND_SETTLE_SEC", 0)
+    monkeypatch.setattr(omron_driver, "_SETTLE_POLL_STEP_SEC", 0)
+
+    calls = 0
+
+    async def fake_establish_connection(client_class, ble_device, name, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise _BlueZError(
+                "X - X: Failed to connect after 4 attempt(s): failed to "
+                "discover services, device disconnected"
+            )
+        return _FakeClient()
+
+    monkeypatch.setattr(omron_driver, "establish_connection", fake_establish_connection)
+
+    async def _run():
+        ble_device = SimpleNamespace(details={})
+        return await omron_driver.establish_connection_with_bond_settle(
+            ble_device, "test-device", model="HEM-TEST", max_attempts=3
+        )
+
+    client = asyncio.run(_run())
+
+    assert calls == 2
+    assert isinstance(client, _FakeClient)
+
+
+def test_the_retry_budget_is_not_unlimited(monkeypatch):
+    class _BlueZError(Exception):
+        pass
+
+    monkeypatch.setattr(omron_driver, "BleakError", _BlueZError)
+    monkeypatch.setattr(omron_driver, "_POST_CONNECT_BOND_SETTLE_SEC", 0)
+    monkeypatch.setattr(omron_driver, "_SETTLE_POLL_STEP_SEC", 0)
+
+    calls = 0
+
+    async def always_fails(client_class, ble_device, name, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise _BlueZError("failed to discover services, device disconnected")
+
+    monkeypatch.setattr(omron_driver, "establish_connection", always_fails)
+
+    async def _run():
+        ble_device = SimpleNamespace(details={})
+        await omron_driver.establish_connection_with_bond_settle(
+            ble_device, "test-device", model="HEM-TEST", max_attempts=3
+        )
+
+    with pytest.raises(Exception):
+        asyncio.run(_run())
+
+    assert calls == 3


### PR DESCRIPTION
## Problem

\`establish_connection_with_bond_settle\` takes \`max_attempts\` and its docstring frames the loop as retrying connection trouble. But for an ordinary reconnect to an already-bonded device (\`pair_on_connect=False\` — every scheduled poll and every Refresh Data press once pairing is done), the plain

```python
client = await establish_connection(BleakClient, ble_device, name)
```

call sat outside any try/except. A failure there — e.g. \`bleak_retry_connector\` giving up with "failed to discover services, device disconnected" after its own internal attempts — propagated straight out of the loop on its first iteration. \`max_attempts\` never actually got spent on this kind of failure; the loop only ever retried the other case below it (a connect that briefly succeeds and then drops during the post-connect settle).

## Fix

Catch \`(BleakError, TimeoutError, asyncio.TimeoutError)\` around the connect step (both the plain path and the pairing-fallback path) and \`continue\` to the next attempt instead of letting it propagate, re-raising only once \`max_attempts\` is spent so a genuinely broken link still fails the same way it always has, in the same format.

## Testing

- Added \`tests/test_ordinary_reconnect_retries.py\`: one test confirms a transient failure is retried and eventually succeeds, the other confirms the original exception still propagates once the budget is exhausted.
- Full suite green (198 passed, 1 pre-existing skip), \`ruff check\` clean.
- Verified live against a real HEM-7188T1-LEO on top of 2.8.9: deployed the patched file to a real Home Assistant instance and watched two full poll cycles over the live log. The retry fired correctly both times (\`WARNING ... failed (attempt 1/3): ... — retrying\`), including one cycle where attempt 2 hit a different \`BleakError\` subclass (\`BleakNotFoundError\`) than attempt 1, confirming the catch isn't narrowly tuned to one symptom. Attempt 3's failure correctly re-raised in the original format rather than looping forever.
- It did not recover a separate, persistent service-discovery failure on that particular cuff — that failure held identically across all 3 attempts in both cycles tested, so it needs its own fix — but the loop now spends the retry budget it always claimed to have, which is a real gap on its own regardless of that device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)