### PR TITLE
fix: clear a leftover host bond before pairing

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -56,6 +56,9 @@ _PAIRING_PROG_WAIT_TIMEOUT_SEC: float = 2.0
 _PAIRING_KEY_ACK_WAIT_TIMEOUT_SEC: float = 5.0
 _SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC: float = 5.0
 # Polling step while waiting for the device to end a session itself.
+# Waiting out RemoveDevice before an explicit pairing attempt.
+_PRE_PAIR_BOND_CLEAR_TIMEOUT_SEC: float = 2.0
+_PRE_PAIR_BOND_CLEAR_POLL_SEC: float = 0.25
 _OS_BOND_REFRESH_DELAY_SEC: float = 0.3
 _OS_BOND_RETRY_DELAY_SEC: float = 0.5
 _PAIR_UNLOCK_ATTEMPTS_AGGRESSIVE: int = 10
@@ -148,6 +151,11 @@ async def establish_connection_with_bond_settle(
             "%s: not a local adapter, leaving the bond to pair() after discovery",
             name,
         )
+    if pair_this_attempt:
+        # The user opened this window on purpose (-P- is lit), so there is no
+        # working bond to protect here -- and a stale one would keep the stack
+        # off the SMP path entirely.
+        await _clear_bond_before_pairing(ble_device, name)
     last_source = "unknown"
     for attempt in range(1, max_attempts + 1):
         source = _connection_source(ble_device)
@@ -577,6 +585,51 @@ async def _bluez_is_paired(client: BleakClient | BLEDevice) -> bool | None:
         return None
     finally:
         bus.disconnect()
+
+
+async def _clear_bond_before_pairing(ble_device: BLEDevice, name: str) -> None:
+    """Drop any host-side bond before an explicit pairing attempt.
+
+    While the host holds a bond the stack restarts encryption with the stored
+    LTK instead of running SMP -- and on BlueZ ``Pair()`` returns at once
+    rather than exchanging anything. If the cuff no longer holds the matching
+    key (re-registered elsewhere, reset, or evicted from its bond slot) it
+    answers "PIN or Key Missing" and drops the link, so pressing -P- cannot
+    help: no pairing request is ever sent (#24, #67, #91, #92). Clearing the
+    bond first is what puts the SMP path back on the table.
+
+    Pairing flow only. On an ordinary reconnect a bond that still matches is
+    exactly what we want to keep.
+    """
+    if await _bluez_is_paired(ble_device) is not True:
+        return
+    _LOGGER.info(
+        "%s: clearing the existing host bond before pairing so the stack runs "
+        "SMP instead of restarting encryption with a key the cuff may no "
+        "longer hold",
+        name,
+    )
+    if not await _bluez_remove_device(ble_device):
+        _LOGGER.warning(
+            "%s: could not clear the existing host bond; pairing may still be "
+            "refused if the cuff no longer holds the matching key",
+            name,
+        )
+        return
+    # RemoveDevice is not synchronous with the daemon's view of the bond, so
+    # connecting straight away can still take the encryption-restart path.
+    waited = 0.0
+    while waited < _PRE_PAIR_BOND_CLEAR_TIMEOUT_SEC:
+        if await _bluez_is_paired(ble_device) is not True:
+            return
+        await asyncio.sleep(_PRE_PAIR_BOND_CLEAR_POLL_SEC)
+        waited += _PRE_PAIR_BOND_CLEAR_POLL_SEC
+    _LOGGER.warning(
+        "%s: the host bond is still present %.1fs after RemoveDevice; "
+        "pairing anyway",
+        name,
+        _PRE_PAIR_BOND_CLEAR_TIMEOUT_SEC,
+    )
 
 
 def _is_non_fatal_os_pairing_error(exc: BaseException) -> bool:

--- a/tests/test_pre_pair_bond_clear.py
+++ b/tests/test_pre_pair_bond_clear.py
@@ -1,0 +1,100 @@
+"""페어링 창에서는 남아 있는 호스트 본드를 먼저 지운다 (#24, #67, #91, #92).
+
+호스트에 본드가 있으면 스택은 SMP 를 돌리지 않고 저장된 LTK 로 **암호화를
+재개**한다. BlueZ 는 한 술 더 떠 ``Device1.Paired`` 가 참이면 ``Pair()`` 가
+아무것도 주고받지 않고 즉시 돌아온다. 커프가 그 키를 이미 버렸다면 (다른 폰
+재등록, 리셋, 본드 슬롯 축출) 커프는 "PIN or Key Missing" 으로 끊는다. 이때는
+사용자가 -P- 를 눌러도 소용이 없다 — 페어링 요청 자체가 나가지 않기 때문이다.
+
+그래서 **페어링 플로우에서만** 본드를 먼저 지워 SMP 경로를 되살린다. 평범한
+재연결에서 지우면 멀쩡한 본드를 버리는 것이므로 반대로 해롭다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 실제로 돌릴 수 없어
+(test_stale_bond_guard.py 와 같은 이유) AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+
+_DRIVER = (
+    Path(__file__).resolve().parent.parent
+    / "custom_components" / "omron" / "omron_ble" / "omron_driver.py"
+)
+
+
+def _tree() -> ast.AST:
+    return ast.parse(_DRIVER.read_text(encoding="utf-8"))
+
+
+def _find_function(tree: ast.AST, name: str):
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} 을(를) 찾지 못했다 — 이름을 바꿨다면 이 테스트도 갱신할 것")
+
+
+def _calls(fn: ast.AST, name: str) -> list[ast.Call]:
+    return [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Call) and getattr(node.func, "id", None) == name
+    ]
+
+
+def _enclosing_ifs(fn: ast.AST, target_lineno: int) -> list[ast.If]:
+    """해당 줄을 몸통에 품고 있는 if 문들."""
+    found = []
+    for node in ast.walk(fn):
+        if isinstance(node, ast.If) and node.lineno < target_lineno:
+            if target_lineno <= getattr(node, "end_lineno", node.lineno):
+                found.append(node)
+    return found
+
+
+def test_the_bond_is_cleared_in_the_pairing_flow():
+    fn = _find_function(_tree(), "establish_connection_with_bond_settle")
+    assert _calls(fn, "_clear_bond_before_pairing"), (
+        "페어링 전에 본드를 지우지 않는다 — 오래된 본드가 남아 있으면 스택이 "
+        "SMP 를 아예 시작하지 않는다"
+    )
+
+
+def test_an_ordinary_reconnect_keeps_its_bond():
+    """가드가 없으면 매 재연결마다 본드를 버려 커프를 못 쓰게 만든다."""
+    fn = _find_function(_tree(), "establish_connection_with_bond_settle")
+    for call in _calls(fn, "_clear_bond_before_pairing"):
+        guards = " ".join(ast.unparse(node.test) for node in _enclosing_ifs(fn, call.lineno))
+        assert "pair_this_attempt" in guards, (
+            f"본드 제거가 pair_this_attempt 안에 있지 않다 (guards={guards!r}). "
+            "평범한 재연결에서 지우면 멀쩡한 본드를 버린다."
+        )
+
+
+def test_the_bond_is_cleared_before_the_link_is_opened():
+    """연결한 뒤에 지우면 이미 암호화 재개 경로를 탄 뒤라 늦는다."""
+    fn = _find_function(_tree(), "establish_connection_with_bond_settle")
+    clears = [call.lineno for call in _calls(fn, "_clear_bond_before_pairing")]
+    connects = [call.lineno for call in _calls(fn, "establish_connection")]
+    assert clears and connects, "호출이 사라졌다 — 테스트가 낡았다"
+    assert min(clears) < min(connects), (
+        "본드 제거가 첫 establish_connection 뒤에 있다"
+    )
+
+
+def test_nothing_is_removed_when_no_bond_exists():
+    """없는 본드를 지우겠다고 기기 객체를 날리면 페어링 창만 낭비한다 (#92)."""
+    fn = _find_function(_tree(), "_clear_bond_before_pairing")
+    probes = [call.lineno for call in _calls(fn, "_bluez_is_paired")]
+    removals = [call.lineno for call in _calls(fn, "_bluez_remove_device")]
+    assert probes and removals, "호출이 사라졌다 — 테스트가 낡았다"
+    assert min(probes) < min(removals), "본드 존재 여부를 묻기 전에 지운다"
+    assert any(
+        isinstance(node, ast.Return) and node.value is None for node in ast.walk(fn)
+    ), "본드가 없을 때 그냥 빠져나오는 경로가 없다"
+
+
+def test_the_daemon_is_given_time_to_forget():
+    """RemoveDevice 는 즉시 반영되지 않는다 — 바로 연결하면 그대로 재개 경로다."""
+    fn = _find_function(_tree(), "_clear_bond_before_pairing")
+    assert any(isinstance(node, ast.While) for node in ast.walk(fn)), (
+        "제거 완료를 기다리지 않는다"
+    )


### PR DESCRIPTION
## 문제

호스트가 본드를 들고 있으면 연결 시 스택은 **SMP 를 돌리지 않습니다**. 저장된 LTK/EDIV/Rand 로 암호화를 재개할 뿐이고, BlueZ 에서는 `Device1.Paired` 가 참이면 `Pair()` 가 아무것도 주고받지 않고 즉시 반환합니다.

커프가 그 사이 자기 쪽 키를 잃었다면 — 다른 폰에 재등록, 리셋, 본드 슬롯 축출 — 커프는 `Encryption Change: PIN or Key Missing (0x06)` 으로 거절하고 링크를 끊습니다. 사용자에게는 `failed to discover services, device disconnected` 로 보입니다.

이 상태에서는 **-P- 를 눌러도 복구되지 않습니다.** 호스트가 페어링 요청 자체를 보내지 않기 때문입니다.

기존 본드 제거는 반응형이라 `Pair()` 가 던지는 `AuthenticationFailed` 에 걸려 있는데, 위 경로는 그 예외를 내지 않습니다. 그래서 오래된 본드가 영영 남습니다.

## 수정

페어링 플로우에서 연결 전에 본드를 먼저 지우고, BlueZ 가 실제로 잊을 때까지 기다립니다 (`RemoveDevice` 는 데몬 상태 반영과 동기가 아닙니다).

`pair_this_attempt` 안에만 두었습니다:

- 평범한 재연결에서는 지우지 않습니다 — 멀쩡한 본드를 버리면 기기를 못 쓰게 만듭니다.
- 프록시 경로에서는 애초에 여기서 지울 본드가 없습니다 (`_bluez_remove_device` 가 False 를 돌려주고 no-op).
- 본드가 없으면 아무것도 하지 않습니다 (#92 의 "없는 본드를 지우다 페어링 창을 버리는" 문제 재발 방지).

## 테스트

`tests/test_pre_pair_bond_clear.py` 5 개 추가 (AST 검사 — conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 실행 검증이 불가한 기존 관례를 따름):

- 페어링 플로우에서 본드를 지운다
- 그 호출이 `pair_this_attempt` 가드 안에 있다 (재연결은 본드 유지)
- 첫 `establish_connection` **전에** 지운다
- `_bluez_is_paired` 를 먼저 묻고, 없으면 조기 반환한다
- 제거 완료를 기다린다

전체 204 passed.

Refs #24, #67, #91, #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)
