### PR TITLE
feat: give the secure session a credential it can resume

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          pip install pytest dbus-fast
+          pip install pytest dbus-fast cryptography
 
       - name: Run tests
         run: python -m pytest tests/ -v

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -385,6 +385,12 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
         if entry.data.get(CONF_TRANSPORT_CREDENTIAL) == encoded:
             return
         _LOGGER.debug("Storing a new transport credential for %s", entry.entry_id)
+        # An entry update fires update_listener, which reloads the integration.
+        # This one runs inside the coordinator's own update method, so a reload
+        # here would tear down the coordinator mid-refresh. Nothing the reload
+        # exists for has changed -- the credential is internal, and the parser
+        # already holds it -- so mark it and let the listener skip.
+        hass.data[DOMAIN][entry.entry_id]["credential_write"] = True
         hass.config_entries.async_update_entry(
             entry, data={**entry.data, CONF_TRANSPORT_CREDENTIAL: encoded}
         )
@@ -507,6 +513,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
 
 async def update_listener(hass: HomeAssistant, entry: OmronConfigEntry) -> None:
     """Handle options update."""
+    entry_data = hass.data.get(DOMAIN, {}).get(entry.entry_id)
+    if entry_data is not None and entry_data.pop("credential_write", False):
+        # A credential a poll just stored. Reloading for it would drop the
+        # coordinator that is still running the poll that produced it.
+        _LOGGER.debug(
+            "Skipping reload for %s: only the transport credential changed",
+            entry.entry_id,
+        )
+        return
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/omron/__init__.py
+++ b/custom_components/omron/__init__.py
@@ -33,6 +33,7 @@ from datetime import datetime, timedelta
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from .const import (
     CONF_DEVICE_MODEL,
+    CONF_TRANSPORT_CREDENTIAL,
     DOMAIN,
 )
 from .util import aliases_dict_from_entry
@@ -293,6 +294,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
         device_model=device_model,
         user_aliases=slot_aliases,
     )
+    # Transport credential for profiles whose unlock keeps its own key. Stored
+    # hex; a malformed value is dropped rather than failing setup, which would
+    # leave the user with no way back other than deleting the entry.
+    stored_credential = entry.data.get(CONF_TRANSPORT_CREDENTIAL)
+    if stored_credential:
+        try:
+            data.transport_credential = bytes.fromhex(stored_credential)
+        except ValueError:
+            _LOGGER.warning(
+                "Ignoring an unreadable stored transport credential for %s; "
+                "re-add the device while it is in pairing mode",
+                address,
+            )
     hass.data[DOMAIN][entry.entry_id] = {}
     hass.data[DOMAIN][entry.entry_id]['address'] = address
     hass.data[DOMAIN][entry.entry_id]['data'] = data
@@ -354,6 +368,27 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
     hass.data[DOMAIN][entry.entry_id]["duration_coordinator"] = duration_coordinator
     hass.data[DOMAIN][entry.entry_id]["readout_coordinator"] = readout_coordinator
 
+    def _persist_transport_credential(
+        hass: HomeAssistant, entry: OmronConfigEntry, device_data
+    ) -> None:
+        """Store a credential a session just established, once.
+
+        The parser keeps it in memory as well, so a poll that runs before the
+        entry update lands still authenticates. Written only when it changed:
+        an entry update reloads the integration.
+        """
+        credential = device_data.pending_credential
+        if credential is None:
+            return
+        device_data.pending_credential = None
+        encoded = credential.hex()
+        if entry.data.get(CONF_TRANSPORT_CREDENTIAL) == encoded:
+            return
+        _LOGGER.debug("Storing a new transport credential for %s", entry.entry_id)
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, CONF_TRANSPORT_CREDENTIAL: encoded}
+        )
+
     async def _async_poll_data(hass: HomeAssistant, entry: OmronConfigEntry) -> SensorUpdate:
         entry_data = hass.data[DOMAIN][entry.entry_id]
         address = entry_data["address"]
@@ -398,6 +433,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: OmronConfigEntry) -> boo
                         result = await coordinator.device_data.async_poll(
                             device, preconnected_session=preconnected_session
                         )
+                _persist_transport_credential(hass, entry, coordinator.device_data)
                 readout_coordinator.async_set_updated_data(
                     coordinator.device_data.last_readout_at
                 )

--- a/custom_components/omron/config_flow.py
+++ b/custom_components/omron/config_flow.py
@@ -44,7 +44,13 @@ from .ble_session import (
     stash_probe_session,
     take_probe_session,
 )
-from .const import CONF_BINDKEY, CONF_DEVICE_MODEL, CONF_USER_ALIASES, DOMAIN
+from .const import (
+    CONF_BINDKEY,
+    CONF_DEVICE_MODEL,
+    CONF_TRANSPORT_CREDENTIAL,
+    CONF_USER_ALIASES,
+    DOMAIN,
+)
 from .omron_ble.const import DEFAULT_DEVICE_MODEL
 from .omron_ble.omron_driver import OmronDeviceSession, is_local_adapter
 from .omron_ble.setup import (
@@ -549,6 +555,11 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             # with the memory readout session left open so setup does not
             # close-then-immediately-reopen on the same link (which breaks
             # GATT on some stacks). The poll path closes it when finished.
+            # Profiles whose transport keeps its own credential hand one back
+            # here. Losing it costs the user another pass through the cuff's
+            # pairing mode, so it goes into the entry with everything else.
+            if session.new_credential is not None:
+                self._transport_credential = session.new_credential.hex()
             await stash_handoff_session(self.hass, address, session)
 
     async def async_step_bluetooth_confirm(
@@ -638,6 +649,15 @@ class OmronConfigFlow(ConfigFlow, domain=DOMAIN):
             getattr(self, "_scan_interval", 300)
         )
         data[CONF_USER_ALIASES] = dict(getattr(self, "_user_aliases", {}))
+        credential = getattr(self, "_transport_credential", None)
+        if credential:
+            data[CONF_TRANSPORT_CREDENTIAL] = credential
+        elif self.source == SOURCE_REAUTH:
+            # Re-auth rebuilds data from scratch; a pairing that established no
+            # new credential must not drop the stored one.
+            existing = self._get_reauth_entry().data.get(CONF_TRANSPORT_CREDENTIAL)
+            if existing:
+                data[CONF_TRANSPORT_CREDENTIAL] = existing
 
         if self.source == SOURCE_REAUTH:
             return self.async_update_reload_and_abort(

--- a/custom_components/omron/const.py
+++ b/custom_components/omron/const.py
@@ -8,3 +8,7 @@ DOMAIN = "omron"
 CONF_BINDKEY: Final = "bindkey"
 CONF_DEVICE_MODEL: Final = "device_model"
 CONF_USER_ALIASES: Final = "user_aliases"
+# Application-layer credential for profiles whose transport keeps its own
+# key (UnlockMode.SECURE_SESSION). Stored hex-encoded; only the entry that
+# established it can use it, so it never leaves this device's entry data.
+CONF_TRANSPORT_CREDENTIAL: Final = "transport_credential"

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.9.0-beta.1"
+  "version": "2.9.0-beta.2"
 }

--- a/custom_components/omron/manifest.json
+++ b/custom_components/omron/manifest.json
@@ -29,5 +29,5 @@
   "documentation": "https://github.com/eigger/hass-omron",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/eigger/hass-omron/issues",
-  "version": "2.8.9"
+  "version": "2.9.0-beta.1"
 }

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1248,8 +1248,55 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_FLIN",
             "HEM-7183T1_LAP",
             "HEM-7188T1-LE",
-            "HEM-7188T1-LEO",
         ),
+    ),
+    # HEM-7188T1-LEO ("X2+ Connect") — the same hardware as the HEM-7188T1
+    # profile above, on the experimental secure-session transport.
+    #
+    # The token-key profile reads real values inside the -P- window but every
+    # ordinary reconnect afterwards is refused (#24). What works on this model
+    # is the application-layer ECDH session: authenticate, initialize with a
+    # close the device accepts, keep the credential it leaves behind, and
+    # resume with that credential on later connections. That path was blocked
+    # by error frame 0xff26 until the secure envelope was corrected (5-byte
+    # transport header, CCM nonce tail = peer contribution + host
+    # contribution); hardware-verified on Linux/BlueZ and macOS by the #24
+    # reporter, through pairing plus a saved-credential reconnect from a
+    # separate process after the display had turned off.
+    #
+    # Verified there for authentication and a metadata read, not yet for
+    # measurement records over a resumed session.
+    #
+    # No explicit Pair(): the cuff raises its own Security Request and a
+    # registered agent answers it. Only this model id -- the HEM-7183T1
+    # variants stay on the token-key profile until someone tests them.
+    "HEM-7188T1-LEO": DeviceConfig(
+        parent_service_uuid=MODERN_STACK_PARENT_SERVICE_UUID,
+        rx_channel_uuids=["49123040-aee8-11e1-a74d-0002a5d5c51b"],
+        tx_channel_uuids=["db5b55e0-aee7-11e1-965e-0002a5d5c51b"],
+        host_pairing_mode=HostPairingMode.NONE,
+        register_pairing_agent=True,
+        model="HEM-7188T1-LEO",
+        connect_type=ConnectType.WLD4_0,
+        keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
+        unlock_mode=UnlockMode.SECURE_SESSION,
+        endianness=Endianness.LITTLE,
+        user_start_addresses=[0x01C4],
+        per_user_records_count=[30],
+        record_byte_size=0x10,
+        transmission_block_size=0x38,
+        settings_read_address=0x0010,
+        settings_write_address=0x0054,
+        settings_time_sync_bytes=[0x2C, 0x3C],
+        time_sync_layout=TimeSyncLayout.AT_8,
+        index_pointer_layout={
+            "index_region_byte_size": 0x18,
+            "endianness": "little",
+            "users": [
+                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
+            ],
+        },
+        record_parser=RecordParser.CLASSIC_VITAL_14,
     ),
     # HEM-716BT2 family (30-slot variant of HEM-7142T2 / WLD1.0 stack)
     "HEM-716BT2": DeviceConfig(

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -149,6 +149,11 @@ class DeviceConfig:
     # avoided the churn, its comment recording that this family rejects a
     # pairing request (0xff 0x26) when the unlock CCCD is dropped and re-added.
     keep_notify_subscriptions: bool = False
+    # Hold an auto-confirming BlueZ agent registered across the connect
+    # without calling Pair() ourselves. For profiles where the cuff drives
+    # security with its own Security Request: BlueZ 5.72+ leaves the Just
+    # Works confirmation unanswered when no agent is registered.
+    register_pairing_agent: bool = False
 
     @property
     def pair_on_connect(self) -> bool:
@@ -201,17 +206,25 @@ class DeviceConfig:
 
     def __post_init__(self) -> None:
         """Validate unlock/pairing strategy combinations."""
-        if (
-            self.unlock_mode == UnlockMode.SECURE_SESSION
-            and self.host_pairing_mode != HostPairingMode.OS_BONDING
+        if self.unlock_mode == UnlockMode.SECURE_SESSION and not (
+            self.host_pairing_mode == HostPairingMode.OS_BONDING
+            or (
+                self.host_pairing_mode == HostPairingMode.NONE
+                and self.register_pairing_agent
+            )
         ):
+            # A secure session still runs over an encrypted link, so the bond
+            # has to come from somewhere: either we ask for it (OS_BONDING) or
+            # the cuff asks and a registered agent answers.
             raise ValueError(
                 "Invalid profile config for %s: secure-session unlock requires "
-                "host_pairing_mode=OS_BONDING (unlock_mode=%s host_pairing_mode=%s)"
+                "host_pairing_mode=OS_BONDING, or NONE with register_pairing_agent "
+                "(unlock_mode=%s host_pairing_mode=%s register_pairing_agent=%s)"
                 % (
                     self.model,
                     self.unlock_mode,
                     self.host_pairing_mode,
+                    self.register_pairing_agent,
                 )
             )
         if (
@@ -230,6 +243,12 @@ class DeviceConfig:
         if (
             self.host_pairing_mode == HostPairingMode.NONE
             and self.unlock_mode != UnlockMode.NONE
+            # A secure session carries its own credential and lets the cuff
+            # drive link security, so it has an unlock step without us pairing.
+            and not (
+                self.unlock_mode == UnlockMode.SECURE_SESSION
+                and self.register_pairing_agent
+            )
         ):
             raise ValueError(
                 "Invalid profile config for %s: host_pairing_mode=NONE requires unlock_mode=NONE "

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -127,6 +127,7 @@ async def establish_connection_with_bond_settle(
     model: str = "",
     max_attempts: int = _CONNECT_SETTLE_ATTEMPTS,
     pair_on_connect: bool = False,
+    hold_pairing_agent: bool = False,
 ) -> BleakClient:
     """Connect, let bonding/encryption settle, then refresh the GATT cache.
 
@@ -143,6 +144,12 @@ async def establish_connection_with_bond_settle(
     # A bare BLEDevice is enough: BlueZ routes carry a /org/bluez/... path,
     # proxy routes do not.
     pair_this_attempt = pair_on_connect and is_local_adapter(ble_device)
+    # Profiles that never call Pair() still need someone to answer the Just
+    # Works confirmation the cuff's own Security Request triggers, which lands
+    # inside establish_connection -- a few tens of milliseconds after connect,
+    # before service discovery. Local adapters only: a proxy has no BlueZ agent
+    # to register.
+    agent_this_attempt = hold_pairing_agent and is_local_adapter(ble_device)
     if pair_on_connect and not pair_this_attempt:
         _LOGGER.debug(
             "%s: not a local adapter, leaving the bond to pair() after discovery",
@@ -187,6 +194,9 @@ async def establish_connection_with_bond_settle(
                         type(pair_exc).__name__,
                         pair_exc,
                     )
+                    client = await establish_connection(BleakClient, ble_device, name)
+            elif agent_this_attempt:
+                async with _bluez_pairing_agent():
                     client = await establish_connection(BleakClient, ble_device, name)
             else:
                 client = await establish_connection(BleakClient, ble_device, name)
@@ -668,9 +678,13 @@ class OmronDeviceSession:
         device_config: DeviceConfig,
         *,
         pairing_session: bool = False,
+        credential: bytes | None = None,
     ) -> None:
         self._ble_device = ble_device
         self._config = device_config
+        # Application-layer credential for SECURE_SESSION profiles: None on the
+        # session that establishes one, the stored value on every later poll.
+        self._credential = credential
         # Only a session that exists to create a bond sends the connect-time
         # pair request on profiles that opt out of it for polls.
         self._pairing_session = pairing_session
@@ -680,6 +694,8 @@ class OmronDeviceSession:
         self, *, client: BleakClient | None, owns_connection: bool
     ) -> None:
         self._client = client
+        # Set only when this session established a credential worth storing.
+        self._new_credential: bytes | None = None
         self._owns_connection = owns_connection
         self._notify_subscribed = False
         self._last_reply_packet_type: bytes | None = None
@@ -709,6 +725,7 @@ class OmronDeviceSession:
         device_config: DeviceConfig,
         *,
         pairing_session: bool = False,
+        credential: bytes | None = None,
     ) -> "OmronDeviceSession":
         """Wrap an already-open client to run ops over a connection owned elsewhere.
 
@@ -719,6 +736,7 @@ class OmronDeviceSession:
         session._config = device_config
         # __init__ is bypassed, so this has to be set by hand.
         session._pairing_session = pairing_session
+        session._credential = credential
         session._init_session_state(client=client, owns_connection=False)
         return session
 
@@ -728,6 +746,16 @@ class OmronDeviceSession:
         if self._client is None:
             raise ConnectionError("OmronDeviceSession is not connected")
         return self._client
+
+    @property
+    def new_credential(self) -> bytes | None:
+        """A credential this session established that the caller should store.
+
+        ``None`` unless a SECURE_SESSION profile completed an initialization the
+        device accepted. Callers persist it against this entry; losing it costs
+        the user another pass through the cuff's pairing mode.
+        """
+        return self._new_credential
 
     @property
     def config(self) -> DeviceConfig:
@@ -765,6 +793,7 @@ class OmronDeviceSession:
             # Only the connection that creates the bond; a reconnect that sends
             # a pair request is what cost the bond on a proxy (#142).
             pair_on_connect=self._pairing_session and self._config.pair_on_connect,
+            hold_pairing_agent=self._config.register_pairing_agent,
         )
         return self
 
@@ -1121,7 +1150,12 @@ class OmronDeviceSession:
         if self._config.is_single_channel:
             frame_bytes = bytearray(self._channel_fragments[0])
             self._channel_fragments = [None] * 4
-            declared = frame_bytes[0] if frame_bytes else 0
+            # C0 is an encrypted envelope marker, not a 192-byte length.
+            secure_envelope = (
+                self._config.unlock_mode == UnlockMode.SECURE_SESSION
+                and self._secure_session is not None
+            )
+            declared = frame_bytes[0] if frame_bytes and not secure_envelope else 0
             if declared and len(frame_bytes) < declared:
                 _LOGGER.warning(
                     "Truncated BLE frame: declared %d bytes, received %d: %s",
@@ -1164,16 +1198,19 @@ class OmronDeviceSession:
             except Exception as exc:
                 _LOGGER.error("Secure session decryption failed: %s", exc)
                 return
-        else:
-            # Verify XOR CRC
-            xor_crc = 0
-            for byte in frame_bytes:
-                xor_crc ^= byte
-            if xor_crc:
-                _LOGGER.error(
-                    "CRC error in rx data: crc=%d, buffer=%s", xor_crc, _hex(frame_bytes)
-                )
+            if not frame_bytes or frame_bytes[0] != len(frame_bytes):
+                _LOGGER.error("Invalid decrypted memory-frame length")
                 return
+
+        # The inner memory protocol retains its XOR checksum under CCM.
+        xor_crc = 0
+        for byte in frame_bytes:
+            xor_crc ^= byte
+        if xor_crc:
+            _LOGGER.error(
+                "CRC error in rx data: crc=%d, buffer=%s", xor_crc, _hex(frame_bytes)
+            )
+            return
 
         # Check minimum valid frame length (len(1) + type(2) + addr(2) + datalen(1) + rescode(1) + crc(1) = 8)
         if len(frame_bytes) < 8:
@@ -1539,6 +1576,33 @@ class OmronDeviceSession:
         else:
             await asyncio.sleep(_PAIRING_SETTLE_DEFAULT_SEC)
 
+    async def _secure_unlock(self) -> None:
+        """Authenticate the application session, establishing or resuming it.
+
+        A pairing session runs the full initialization and keeps the credential
+        the device leaves behind only once it accepts the close; every later
+        session replays that credential and writes nothing. Losing the
+        credential costs the user another pass through the cuff's -P- window,
+        so it is only ever replaced by a completed initialization.
+        """
+        from .secure_flow import establish_secure_session
+
+        if not self._pairing_session and self._credential is None:
+            raise ConnectionError(
+                f"No stored transport credential for {self._config.model}; "
+                "re-add the device while it is in pairing mode"
+            )
+        credential = await establish_secure_session(
+            self,
+            # Re-pairing establishes a fresh credential rather than resuming
+            # one, which is also what the device expects in its -P- window.
+            stored_ltk=None if self._pairing_session else self._credential,
+            now=dt.datetime.now(),
+        )
+        if credential != self._credential:
+            self._credential = credential
+            self._new_credential = credential
+
     async def unlock(self, key: bytearray | None = None) -> None:
         """Unlock device with pairing key."""
         if self._config.unlock_mode == UnlockMode.NONE:
@@ -1747,137 +1811,6 @@ class OmronDeviceSession:
                     except Exception as exc:
                         _LOGGER.debug("token unlock RX pre-notify stop skipped: %s", exc)
                 self._debug_ble_link("token_unlock_after_stop_notify")
-
-    async def _secure_unlock(self) -> None:
-        """Perform encrypted secure handshake to unlock the device."""
-        _LOGGER.debug("Starting secure handshake unlock for model=%s", self._config.model)
-
-        # The 0x11/0x91 token handshake has to run immediately before the ECDH
-        # pairing request, on the same CCCD subscriptions -- re-adding the
-        # unlock CCCD in between makes the device reject it with 0xff 0x26.
-        from .secure_session import SecureSession
-
-        self._secure_session = SecureSession()
-        unlock_event = asyncio.Event()
-        response_holder: list[bytes | None] = [None]
-
-        def _secure_callback(_: Any, rx_bytes: bytearray) -> None:
-            response_holder[0] = bytes(rx_bytes)
-            unlock_event.set()
-
-        try:
-            # Token handshake first, keeping its CCCD subscriptions in place.
-            # This is inside the try so the finally below still releases those
-            # subscriptions if the token step itself fails.
-            await self._token_unlock(keep_notify=True)
-            self._unlocked = False
-
-            # Re-point the (already active) unlock CCCD at the secure-stage
-            # callback by swapping the dispatcher's handler — do NOT call
-            # start_notify again, the backend rejects a second subscribe on an
-            # already-enabled CCCD.
-            self._unlock_notify_handler = _secure_callback
-
-            # Step 1: Send Pairing Request
-            pair_req = self._secure_session.build_pair_req()
-            _LOGGER.debug("Sending Pairing Request (len=%d): %s", len(pair_req), pair_req.hex())
-            unlock_event.clear()
-            response_holder[0] = None
-            await self._client.write_gatt_char(UNLOCK_CHARACTERISTIC_UUID, pair_req, response=True)
-            
-            # Wait for Pairing Response
-            await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
-            pair_resp = response_holder[0]
-            _LOGGER.debug("Received Pairing Response (len=%d): %s", len(pair_resp) if pair_resp else 0, pair_resp.hex() if pair_resp else "None")
-            if not pair_resp:
-                raise ConnectionError("Empty pairing response")
-            err = _secure_error_frame_code(pair_resp)
-            if err is not None:
-                # Device rejected the ECDH pairing request with an error frame
-                # (e.g. 0xff26). The request itself is well-formed (structure and
-                # SECP256R1 little-endian pubkey are valid), so this is a
-                # device-state rejection: the cuff is likely already bonded to
-                # another host or is not currently accepting a fresh pairing.
-                raise ConnectionError(
-                    f"Device rejected secure pairing (error frame 0x{pair_resp[0]:02x}, "
-                    f"code 0x{err:02x}); the cuff may already be bonded to another "
-                    f"host or is not in pairing mode. Fully unpair/factory-reset "
-                    f"the cuff and try again."
-                )
-            if len(pair_resp) < 2:
-                raise ConnectionError("Invalid or empty pairing response")
-
-            # Process Pairing Response and derive LTK
-            self._secure_session.process_pair_resp(pair_resp)
-            _LOGGER.debug("Key exchange complete")
-
-            # Step 2: Send Encryption Start Request
-            start_enc_req = self._secure_session.build_start_enc_req()
-            _LOGGER.debug("Sending Encryption Start Request (len=%d): %s", len(start_enc_req), start_enc_req.hex())
-            unlock_event.clear()
-            response_holder[0] = None
-            await self._client.write_gatt_char(UNLOCK_CHARACTERISTIC_UUID, start_enc_req, response=True)
-
-            # Wait for Encryption Response
-            await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
-            enc_resp = response_holder[0]
-            _LOGGER.debug("Received Encryption Response (len=%d): %s", len(enc_resp) if enc_resp else 0, enc_resp.hex() if enc_resp else "None")
-            if not enc_resp:
-                raise ConnectionError("Empty encryption response")
-            err = _secure_error_frame_code(enc_resp)
-            if err is not None:
-                raise ConnectionError(
-                    f"Device rejected encryption start (error frame 0x{enc_resp[0]:02x}, "
-                    f"code 0x{err:02x})"
-                )
-            if len(enc_resp) < 2:
-                raise ConnectionError("Invalid or empty encryption response")
-
-            # Step 3: Challenge-Response mutual authentication
-            challenge_req = self._secure_session.build_challenge_req(enc_resp)
-            _LOGGER.debug("Sending Challenge Request (len=%d): %s", len(challenge_req), challenge_req.hex())
-            unlock_event.clear()
-            response_holder[0] = None
-            await self._client.write_gatt_char(UNLOCK_CHARACTERISTIC_UUID, challenge_req, response=True)
-
-            # Wait for Challenge Response
-            await asyncio.wait_for(unlock_event.wait(), timeout=_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC)
-            challenge_resp = response_holder[0]
-            _LOGGER.debug("Received Challenge Response (len=%d): %s", len(challenge_resp) if challenge_resp else 0, challenge_resp.hex() if challenge_resp else "None")
-            if not challenge_resp:
-                raise ConnectionError("Empty challenge response")
-            err = _secure_error_frame_code(challenge_resp)
-            if err is not None:
-                raise ConnectionError(
-                    f"Device rejected challenge (error frame 0x{challenge_resp[0]:02x}, "
-                    f"code 0x{err:02x})"
-                )
-            if len(challenge_resp) < 2:
-                raise ConnectionError("Invalid or empty challenge response")
-
-            # Finalize: verify peer's challenge response
-            self._secure_session.process_challenge_resp(challenge_resp)
-            _LOGGER.info("Secure handshake succeeded. Session unlocked.")
-            self._unlocked = True
-
-        except asyncio.TimeoutError as exc:
-            _LOGGER.error("Secure handshake timed out during negotiation")
-            raise ConnectionError("Secure unlock timeout") from exc
-        except Exception as exc:
-            _LOGGER.error("Secure handshake failed: %s", exc)
-            raise ConnectionError(f"Secure unlock failed: {exc}") from exc
-        finally:
-            self._unlock_notify_handler = None
-            try:
-                await self._client.stop_notify(UNLOCK_CHARACTERISTIC_UUID)
-            except Exception as exc:
-                _LOGGER.debug("secure unlock stop_notify skipped: %s", exc)
-            # _token_unlock(keep_notify=True) left the RX-channel CCCD enabled
-            # for us; release it here so it doesn't outlive the handshake.
-            try:
-                await self._client.stop_notify(self._config.rx_channel_uuids[0])
-            except Exception as exc:
-                _LOGGER.debug("secure unlock RX notify stop skipped: %s", exc)
 
     async def _pair_os_bonding(self) -> None:
         """Best-effort OS-level BLE bond establishment for modern profiles."""
@@ -2201,7 +2134,16 @@ class OmronDeviceSession:
             await self._pair_os_bonding()
             return
         if self._config.host_pairing_mode == HostPairingMode.NONE:
-            raise ConnectionError("Pairing is disabled for this device profile")
+            # Nothing for us to program. The cuff raises its own Security
+            # Request and the agent held across the connect answers it; any
+            # application-layer credential is established by unlock() instead.
+            # A no-op rather than an error so the ordinary setup and retry
+            # paths need no special case for these profiles.
+            _LOGGER.debug(
+                "Skipping host pairing for %s: the device drives security itself",
+                self._config.model,
+            )
+            return
         if self._config.host_pairing_mode != HostPairingMode.CUSTOM_KEY:
             raise ConnectionError("Pairing is not supported for this device")
         if _bluez_device_path(self._bluez_target()) is None:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -5,7 +5,7 @@ import datetime as dt
 import logging
 import secrets
 import traceback
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from typing import Any, AsyncIterator
 
 from bleak import BleakClient
@@ -145,10 +145,9 @@ async def establish_connection_with_bond_settle(
     # proxy routes do not.
     pair_this_attempt = pair_on_connect and is_local_adapter(ble_device)
     # Profiles that never call Pair() still need someone to answer the Just
-    # Works confirmation the cuff's own Security Request triggers, which lands
-    # inside establish_connection -- a few tens of milliseconds after connect,
-    # before service discovery. Local adapters only: a proxy has no BlueZ agent
-    # to register.
+    # Works confirmation the cuff's own Security Request triggers. The caller
+    # holds an agent for the whole session (see OmronDeviceSession.connect);
+    # this one only covers the connect itself for callers that do not.
     agent_this_attempt = hold_pairing_agent and is_local_adapter(ble_device)
     if pair_on_connect and not pair_this_attempt:
         _LOGGER.debug(
@@ -696,6 +695,9 @@ class OmronDeviceSession:
         self._client = client
         # Set only when this session established a credential worth storing.
         self._new_credential: bytes | None = None
+        # Pairing agent held for the lifetime of the session, for profiles
+        # where the device drives security itself.
+        self._pairing_agent: AsyncExitStack | None = None
         self._owns_connection = owns_connection
         self._notify_subscribed = False
         self._last_reply_packet_type: bytes | None = None
@@ -785,6 +787,27 @@ class OmronDeviceSession:
             raise ConnectionError(
                 "OmronDeviceSession.adopt() sessions cannot connect; open the client first"
             )
+        if (
+            self._config.register_pairing_agent
+            and self._pairing_agent is None
+            and is_local_adapter(self._ble_device)
+        ):
+            # For the whole session, not just the connect: on these profiles the
+            # device raises its Security Request on its own schedule, and the
+            # hardware-verified sequence had an agent registered throughout.
+            # Released in aclose().
+            stack = AsyncExitStack()
+            try:
+                await stack.enter_async_context(_bluez_pairing_agent())
+            except Exception as exc:
+                await stack.aclose()
+                _LOGGER.debug(
+                    "Could not hold a pairing agent for %s: %s",
+                    self._config.model,
+                    exc,
+                )
+            else:
+                self._pairing_agent = stack
         self._client = await establish_connection_with_bond_settle(
             self._ble_device,
             self.address,
@@ -909,6 +932,12 @@ class OmronDeviceSession:
             pass
         finally:
             self._client = None
+            if self._pairing_agent is not None:
+                agent, self._pairing_agent = self._pairing_agent, None
+                try:
+                    await agent.aclose()
+                except Exception as exc:
+                    _LOGGER.debug("Releasing the pairing agent failed: %s", exc)
             if disconnected:
                 _LOGGER.debug("BLE link closed for %s", addr)
 
@@ -1110,6 +1139,15 @@ class OmronDeviceSession:
             await self._client.stop_notify(UNLOCK_CHARACTERISTIC_UUID)
         except Exception as exc:
             _LOGGER.debug("unlock stop_notify during reset ignored: %s", exc)
+        # Same for the secure session's async-notice channel: a retry
+        # re-subscribes it, and BlueZ refuses a second subscribe on a CCCD it
+        # still holds.
+        try:
+            from .secure_flow import ASYNC_NOTICE_UUID
+
+            await self._client.stop_notify(ASYNC_NOTICE_UUID)
+        except Exception as exc:
+            _LOGGER.debug("async-notice stop_notify during reset ignored: %s", exc)
         self._unlocked = False
         self._secure_session = None
         self._memory_session_active = False
@@ -1291,17 +1329,32 @@ class OmronDeviceSession:
         else:
             self._expected_reply_memory_address = None
 
-        if self._config.unlock_mode == UnlockMode.SECURE_SESSION and self._secure_session is not None:
-            try:
-                command = bytearray(self._secure_session.encrypt(bytes(command)))
-            except Exception as exc:
-                _LOGGER.error("Secure session encryption failed for command: %s", exc)
-                raise
-
+        plaintext = bytearray(command)
         max_retries = _MEMORY_PROTOCOL_TX_MAX_RETRIES
         try:
             for retry in range(max_retries):
                 self._reply_ready.clear()
+
+                if (
+                    self._config.unlock_mode == UnlockMode.SECURE_SESSION
+                    and self._secure_session is not None
+                ):
+                    # Encrypt per transmission: every CCM frame carries a
+                    # counter the device will not accept twice, so a retry that
+                    # replayed the first attempt's ciphertext would be refused
+                    # and burn the whole retry budget without ever reaching the
+                    # device's command handler.
+                    try:
+                        command = bytearray(
+                            self._secure_session.encrypt(bytes(plaintext))
+                        )
+                    except Exception as exc:
+                        _LOGGER.error(
+                            "Secure session encryption failed for command: %s", exc
+                        )
+                        raise
+                else:
+                    command = plaintext
 
                 # Split command across TX channels
                 remaining_cmd = command

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -75,6 +75,11 @@ class OmronBluetoothDeviceData(BluetoothData):
         self._user_aliases: dict[int, str] = _normalize_user_aliases(user_aliases)
         self._last_record_signature: tuple[Any, ...] | None = None
         self._last_readout_at: dt.datetime | None = None
+        # Application-layer credential for SECURE_SESSION profiles: loaded from
+        # the config entry at setup, and replaced here when a session
+        # establishes a new one so the entry can be updated after the poll.
+        self.transport_credential: bytes | None = None
+        self.pending_credential: bytes | None = None
         self._last_record_signatures_by_user: dict[int, tuple[Any, ...]] = {}
         self._bp_char_unavailable = False
         self._bls_racp_unavailable_logged = False
@@ -96,6 +101,28 @@ class OmronBluetoothDeviceData(BluetoothData):
         self.result_identifier_num: int = 0
 
         self._seed_measurement_entities()
+
+    def _open_session(
+        self, ble_device: BLEDevice, *, pairing_session: bool = False
+    ) -> OmronDeviceSession:
+        """Build a session carrying the stored transport credential."""
+        return OmronDeviceSession(
+            ble_device,
+            self._device_config,
+            pairing_session=pairing_session,
+            credential=self.transport_credential,
+        )
+
+    def _collect_credential(self, session: OmronDeviceSession) -> None:
+        """Take a credential the session established, for the entry to store.
+
+        Kept in memory as well: a poll that follows before the entry is written
+        back still has to authenticate with it.
+        """
+        new = session.new_credential
+        if new is not None and new != self.transport_credential:
+            self.transport_credential = new
+            self.pending_credential = new
 
     @property
     def device_model(self) -> str:
@@ -1070,7 +1097,7 @@ class OmronBluetoothDeviceData(BluetoothData):
                         )
                         preconnected_session.reclaim_ownership()
                         await preconnected_session.aclose()
-                    session = OmronDeviceSession(ble_device, self._device_config)
+                    session = self._open_session(ble_device)
                 async with session:
                     client = session.client
 
@@ -1223,6 +1250,8 @@ class OmronBluetoothDeviceData(BluetoothData):
                             ble_device,
                             memory_session_active=False,
                         )
+                    # An adopted setup session may have established one.
+                    self._collect_credential(session)
 
             except ConnectionError as exc:
                 # Expected when the cuff is off, out of range, or the link drops mid-poll.
@@ -1258,9 +1287,7 @@ class OmronBluetoothDeviceData(BluetoothData):
         ``async_poll`` adopts this link instead of opening a new one; a caller
         that does not park it still owns the link and must close it.
         """
-        session = OmronDeviceSession(
-            ble_device, self._device_config, pairing_session=True
-        )
+        session = self._open_session(ble_device, pairing_session=True)
         try:
             await session.connect()
             if not await session.verify_parent_service():
@@ -1284,11 +1311,14 @@ class OmronBluetoothDeviceData(BluetoothData):
             # aclose() swallows its own errors, so it cannot mask this one.
             await session.aclose()
             raise
+        # Only after the whole pairing path succeeded: a credential kept from a
+        # half-finished initialization would not authenticate later.
+        self._collect_credential(session)
         return session
 
     async def async_sync_time(self, ble_device: BLEDevice) -> None:
         """Connect to the device and synchronize time only."""
-        async with OmronDeviceSession(ble_device, self._device_config) as session:
+        async with self._open_session(ble_device) as session:
             await self._async_sync_current_time_with_client(
                 session.client, ble_device.address, session
             )

--- a/custom_components/omron/omron_ble/secure_flow.py
+++ b/custom_components/omron/omron_ble/secure_flow.py
@@ -1,0 +1,237 @@
+"""Application-layer secure session: establish a credential, then resume it.
+
+This is the whole ``UnlockMode.SECURE_SESSION`` path. A device on it keeps its
+own credential independent of the BLE bond: the first session authenticates,
+initializes the device and keeps the credential the device leaves behind, and
+every later session replays that credential and writes nothing.
+
+Contributed for HEM-7188T1-LEO by the #24 reporter and hardware-verified there
+on Linux/BlueZ and macOS. Nothing here is written for that model specifically:
+every address comes out of the catalog fields the profile already carries.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+import logging
+import secrets
+
+from .devices import DeviceConfig, UnlockMode
+from .omron_driver import UNLOCK_CHARACTERISTIC_UUID
+from .secure_session import SecureSession
+
+_LOGGER = logging.getLogger(__name__)
+
+# Vendor characteristic that carries unsolicited device notices. Subscribed
+# alongside the control and data channels because the working reference does.
+ASYNC_NOTICE_UUID = "8858eb40-aee8-11e1-bb67-0002a5d5c51b"
+# Device Information reads the reference performs before the ECDH exchange.
+_PRE_HANDSHAKE_DIS_UUIDS = (
+    "00002a26-0000-1000-8000-00805f9b34fb",  # Firmware Revision String
+    "00002a28-0000-1000-8000-00805f9b34fb",  # Software Revision String
+)
+# System authentication, sent encrypted once the session key exists.
+_SYSTEM_AUTH_REQUEST = b"\x20\x01\x00" + bytes(17)
+
+
+class SecureInitLayout:
+    """Addresses the initialization step copies, all derived from the profile.
+
+    The device-owned settings region is mirrored into the write region, and the
+    clock record inside it is stamped with the current time. ``settings_read_address``,
+    ``settings_write_address``, ``settings_time_sync_bytes`` and the index region
+    size already describe both regions, so no profile needs new fields for this.
+    """
+
+    def __init__(self, config: DeviceConfig) -> None:
+        read_addr = config.settings_read_address
+        write_addr = config.settings_write_address
+        time_range = config.settings_time_sync_bytes
+        index_size = int(
+            (config.index_pointer_layout or {}).get("index_region_byte_size", 0)
+        )
+        if (
+            read_addr is None
+            or write_addr is None
+            or not time_range
+            or len(time_range) != 2
+            or index_size <= 0
+        ):
+            raise ValueError(
+                f"Profile {config.model} cannot describe a secure initialization: "
+                "settings addresses, time-sync range and index region size are all required"
+            )
+        clock_size = time_range[1] - time_range[0]
+        if clock_size <= 0:
+            raise ValueError(
+                f"Profile {config.model} has an empty time-sync range {time_range}"
+            )
+        self.head_read_address = read_addr
+        # Everything ahead of the clock record.
+        self.head_read_size = time_range[0]
+        # Only the index region is mirrored; the rest is device-owned.
+        self.head_write_address = write_addr
+        self.head_write_size = index_size
+        self.clock_read_address = read_addr + time_range[0]
+        # Read past the clock record so the trailing bytes are preserved.
+        self.clock_read_size = index_size
+        self.clock_write_address = write_addr + time_range[0]
+        self.clock_write_size = clock_size
+
+
+async def prepare_secure_token(session, timeout: float) -> None:
+    """Run the pre-handshake reads, subscriptions and 0x11/0x91 token exchange.
+
+    The token step has to reach the device on the same subscriptions the ECDH
+    exchange then uses: re-adding the unlock CCCD in between makes the device
+    reject the pairing request.
+    """
+    for uuid in _PRE_HANDSHAKE_DIS_UUIDS:
+        await session._client.read_gatt_char(uuid)
+        _LOGGER.debug("Secure session: device information read %s", uuid[:8])
+    token = secrets.token_bytes(4)
+    accepted = asyncio.Event()
+
+    def token_reply(_char, data):
+        if len(data) >= 6 and data[:2] == b"\x91\x00" and data[2:6] == token:
+            accepted.set()
+
+    def control_dispatch(char, data):
+        handler = session._unlock_notify_handler
+        if handler is not None:
+            handler(char, data)
+
+    def async_notice(_char, data):
+        _LOGGER.debug("Secure session: async notification bytes=%d", len(data))
+
+    session._unlock_notify_handler = token_reply
+    await session._client.start_notify(UNLOCK_CHARACTERISTIC_UUID, control_dispatch)
+    session._rebuild_notify_handle_index_map()
+    await session._client.start_notify(
+        session._config.rx_channel_uuids[0], session._on_notify_channel_data
+    )
+    session._notify_subscribed = True
+    await session._client.start_notify(ASYNC_NOTICE_UUID, async_notice)
+    _LOGGER.debug("Secure session: subscribed control, rx and async channels")
+    await asyncio.sleep(0.75)
+    await session._client.write_gatt_char(
+        UNLOCK_CHARACTERISTIC_UUID, b"\x11" + token + bytes(15), response=True
+    )
+    await asyncio.wait_for(accepted.wait(), timeout)
+    _LOGGER.debug("Secure session: token accepted")
+
+
+def clock_block(tail: bytes, now: datetime, size: int) -> bytes:
+    """Stamp the clock record: set its flag, write the time, fix the checksum.
+
+    ``tail`` is read longer than the record so the trailing device-owned bytes
+    are not disturbed; only the first ``size`` bytes are written back.
+    """
+    if len(tail) < size or size < 15 or not 2000 <= now.year <= 2255:
+        raise ValueError("Invalid secure initialization clock record or year")
+    block = bytearray(tail[:size])
+    block[4] |= 1
+    block[8:14] = bytes(
+        (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
+    )
+    block[14] = sum(block[:14]) & 0xFF
+    return bytes(block)
+
+
+async def establish_secure_session(
+    session, *, stored_ltk: bytes | None, now: datetime, timeout: float = 7.0
+) -> bytes:
+    """Authenticate and, for a pairing session, initialize the device.
+
+    Returns the credential to store, bound to this device and adapter. Any
+    exception means the caller must close the connection and keep whatever
+    credential it already had: a credential from a half-finished initialization
+    does not authenticate later.
+    """
+    if session._config.unlock_mode != UnlockMode.SECURE_SESSION:
+        raise ValueError("The secure session path requires unlock_mode=SECURE_SESSION")
+    pairing = session._pairing_session
+    if pairing != (stored_ltk is None):
+        raise ValueError(
+            "Explicit pairing requires a new key; resume requires a stored key"
+        )
+    if stored_ltk is not None and len(stored_ltk) != 16:
+        raise ValueError("A stored secure-session credential must be 16 bytes")
+    layout = SecureInitLayout(session._config) if pairing else None
+
+    crypto = SecureSession(stored_ltk=stored_ltk)
+    # Key generation and lazy crypto imports must not delay token -> request.
+    first_request = crypto.build_pair_req() if pairing else crypto.build_start_enc_req()
+    replies: asyncio.Queue = asyncio.Queue()
+
+    def receive(_char, data):
+        replies.put_nowait(bytes(data))
+
+    async def exchange(packet: bytes, prefix: bytes) -> bytes:
+        _LOGGER.debug(
+            "Secure session TX stage=%s bytes=%d", prefix.hex(), len(packet)
+        )
+        await session._client.write_gatt_char(
+            UNLOCK_CHARACTERISTIC_UUID, packet, response=True
+        )
+        response = await asyncio.wait_for(replies.get(), timeout)
+        if not response.startswith(prefix):
+            # Only a protocol discriminator, never the challenge or key payload.
+            raise ConnectionError(
+                f"Unexpected secure-session response: expected={prefix.hex()} "
+                f"received_prefix={response[:2].hex()} bytes={len(response)}"
+            )
+        return response
+
+    try:
+        await prepare_secure_token(session, timeout)
+        session._unlocked = False
+        session._secure_session = crypto
+        session._unlock_notify_handler = receive
+        if pairing:
+            response = await exchange(first_request, b"\xf0\x81")
+            crypto.process_pair_resp(response)
+        start_request = crypto.build_start_enc_req() if pairing else first_request
+        response = await exchange(start_request, b"\xf0\x85")
+        response = await exchange(crypto.build_challenge_req(response), b"\xf0\x86")
+        crypto.process_challenge_resp(response)
+        request = crypto.encrypt(_SYSTEM_AUTH_REQUEST)
+        response = crypto.decrypt(await exchange(request, b"\xc0"))
+        if len(response) != 4 or response[0] != 0xA0 or response[2] != 0:
+            raise ConnectionError("Secure session system authentication rejected")
+        session._unlocked = True
+
+        if layout is not None:
+            await session.open_memory_session()
+            head = await session.read_memory_block(
+                layout.head_read_address, layout.head_read_size
+            )
+            tail = await session.read_memory_block(
+                layout.clock_read_address, layout.clock_read_size
+            )
+            if len(head) != layout.head_read_size or len(tail) != layout.clock_read_size:
+                raise ConnectionError("Incomplete secure initialization settings")
+            block = clock_block(tail, now, layout.clock_write_size)
+            await session.write_memory_block(
+                layout.head_write_address,
+                bytearray(head[: layout.head_write_size]),
+            )
+            await session.write_memory_block(
+                layout.clock_write_address, bytearray(block)
+            )
+            await session.close_memory_session()
+            # close_memory_session only warns on a rejection. Never commit a
+            # credential on one: the device did not accept the initialization.
+            if (
+                session._last_reply_packet_type != b"\x8f\x00"
+                or session._last_reply_payload != b"\x00"
+            ):
+                raise ConnectionError("Secure initialization close was not accepted")
+        if crypto.ltk is None or len(crypto.ltk) != 16:
+            raise ConnectionError("Missing authenticated secure-session credential")
+        return crypto.ltk
+    except BaseException:
+        session._unlocked = False
+        raise
+    finally:
+        session._unlock_notify_handler = None

--- a/custom_components/omron/omron_ble/secure_flow.py
+++ b/custom_components/omron/omron_ble/secure_flow.py
@@ -17,7 +17,11 @@ import logging
 import secrets
 
 from .devices import DeviceConfig, UnlockMode
-from .omron_driver import UNLOCK_CHARACTERISTIC_UUID
+from .omron_driver import (
+    _SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC,
+    UNLOCK_CHARACTERISTIC_UUID,
+    _secure_error_frame_code,
+)
 from .secure_session import SecureSession
 
 _LOGGER = logging.getLogger(__name__)
@@ -73,8 +77,11 @@ class SecureInitLayout:
         self.head_write_address = write_addr
         self.head_write_size = index_size
         self.clock_read_address = read_addr + time_range[0]
-        # Read past the clock record so the trailing bytes are preserved.
-        self.clock_read_size = index_size
+        # Never shorter than what gets written back, or the record cannot be
+        # built at all -- and the head write has already landed by then. The
+        # reference reads past the record on the one profile where the index
+        # region is the larger of the two, so keep that read length.
+        self.clock_read_size = max(clock_size, index_size)
         self.clock_write_address = write_addr + time_range[0]
         self.clock_write_size = clock_size
 
@@ -105,13 +112,19 @@ async def prepare_secure_token(session, timeout: float) -> None:
         _LOGGER.debug("Secure session: async notification bytes=%d", len(data))
 
     session._unlock_notify_handler = token_reply
-    await session._client.start_notify(UNLOCK_CHARACTERISTIC_UUID, control_dispatch)
+    # Through the recovery path, not raw start_notify: on a profile that keeps
+    # its subscriptions, BlueZ can still hold the CCCD from the previous
+    # connection, and a retry re-enters here with them enabled (#92).
+    await session._ensure_services_cache()
+    await session._start_notify_with_recovery(
+        UNLOCK_CHARACTERISTIC_UUID, control_dispatch
+    )
     session._rebuild_notify_handle_index_map()
-    await session._client.start_notify(
+    await session._start_notify_with_recovery(
         session._config.rx_channel_uuids[0], session._on_notify_channel_data
     )
     session._notify_subscribed = True
-    await session._client.start_notify(ASYNC_NOTICE_UUID, async_notice)
+    await session._start_notify_with_recovery(ASYNC_NOTICE_UUID, async_notice)
     _LOGGER.debug("Secure session: subscribed control, rx and async channels")
     await asyncio.sleep(0.75)
     await session._client.write_gatt_char(
@@ -124,22 +137,33 @@ async def prepare_secure_token(session, timeout: float) -> None:
 def clock_block(tail: bytes, now: datetime, size: int) -> bytes:
     """Stamp the clock record: set its flag, write the time, fix the checksum.
 
-    ``tail`` is read longer than the record so the trailing device-owned bytes
-    are not disturbed; only the first ``size`` bytes are written back.
+    ``tail`` may be read longer than the record; only the first ``size`` bytes
+    are written back. The checksum is the additive sum of everything ahead of
+    it and sits in the second-to-last byte, so it moves with ``size`` rather
+    than living at a fixed offset -- verified on every 16-byte sample in the
+    #67 and #91 captures, where byte 14 holds the sum of bytes 0..13.
     """
-    if len(tail) < size or size < 15 or not 2000 <= now.year <= 2255:
-        raise ValueError("Invalid secure initialization clock record or year")
+    if len(tail) < size or size < 16 or not 2000 <= now.year <= 2255:
+        raise ValueError(
+            f"Invalid secure initialization clock record (size={size}, "
+            f"available={len(tail)}) or year {now.year}"
+        )
     block = bytearray(tail[:size])
+    checksum_at = size - 2
     block[4] |= 1
     block[8:14] = bytes(
         (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
     )
-    block[14] = sum(block[:14]) & 0xFF
+    block[checksum_at] = sum(block[:checksum_at]) & 0xFF
     return bytes(block)
 
 
 async def establish_secure_session(
-    session, *, stored_ltk: bytes | None, now: datetime, timeout: float = 7.0
+    session,
+    *,
+    stored_ltk: bytes | None,
+    now: datetime,
+    timeout: float = _SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC,
 ) -> bytes:
     """Authenticate and, for a pairing session, initialize the device.
 
@@ -176,6 +200,18 @@ async def establish_secure_session(
         )
         response = await asyncio.wait_for(replies.get(), timeout)
         if not response.startswith(prefix):
+            error = _secure_error_frame_code(response)
+            if error is not None:
+                # A refusal, not a malformed reply: the request itself is
+                # well-formed, so this is device state. Say what to do about it.
+                raise ConnectionError(
+                    f"Device rejected the secure session (error frame "
+                    f"0x{response[0]:02x}, code 0x{error:02x}) at stage "
+                    f"{prefix.hex()}; the cuff may already be registered to "
+                    f"another host, or is not in pairing mode. Put it in "
+                    f"pairing mode, or fully unpair/factory-reset it, and "
+                    f"try again."
+                )
             # Only a protocol discriminator, never the challenge or key payload.
             raise ConnectionError(
                 f"Unexpected secure-session response: expected={prefix.hex()} "

--- a/custom_components/omron/omron_ble/secure_session.py
+++ b/custom_components/omron/omron_ble/secure_session.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     pass
 
 # Protocol constants
-PACKET_HEADER_SIZE = 13
+PACKET_HEADER_SIZE = 5
 MAX_DATA_SIZE = 231
 PROTOCOL_SALT = bytes.fromhex("6c888391aaf5a53860370bdb5a6083be")
 
@@ -75,7 +75,7 @@ class SecureSession:
         # Encryption-stage buffers
         self.enc_own_challenge = None  # 16 bytes
         self.enc_own_salt = None  # 28 bytes
-        self.enc_peer_salt_nonce = None  # 4 bytes from peer Encryption Response
+        self.enc_peer_salt_nonce = None  # peer and host 4-byte nonce contributions
 
         # Temp cache for bonding flow step splitting
         self._cached_start_enc_req = None
@@ -234,8 +234,9 @@ class SecureSession:
         # Extract peer's encryption challenge and salt
         peer_enc_challenge = start_enc_resp[2:18]
         peer_enc_salt = start_enc_resp[18:46]
-        # 8-byte device value embedded in every CCM nonce (bytes 5..13).
-        self.enc_peer_salt_nonce = peer_enc_salt[8:16]
+        # X2+ nonce tail: peer contribution followed by host contribution.
+        # Salt bytes 12 onward are padding, not the host contribution.
+        self.enc_peer_salt_nonce = peer_enc_salt[8:12] + self.enc_own_salt[8:12]
 
         # Session key = AES-CMAC(LTK, peer_salt[:8] || own_salt[:8])
         session_kdf_msg = peer_enc_salt[0:8] + self.enc_own_salt[0:8]
@@ -296,7 +297,7 @@ class SecureSession:
         """Encrypt a data-plane command packet.
 
         Returns:
-            ``0xC0 || counter(4 LE) || zero(8) || ciphertext || tag(8)`` (13-byte header)
+            ``0xC0 || counter(4 LE) || ciphertext || tag(8)`` (5-byte header)
         """
         _require_cryptography()
         from cryptography.hazmat.primitives.ciphers.aead import AESCCM
@@ -316,8 +317,8 @@ class SecureSession:
         aesccm = AESCCM(self.session_key, tag_length=8)
         ciphertext = aesccm.encrypt(nonce, plaintext, aad)
 
-        # 13-byte transport header: 0xC0 || counter(4 LE) || zero(8)
-        header = b"\xc0" + counter_bytes + b"\x00" * (PACKET_HEADER_SIZE - 5)
+        # The negotiated nonce tail is not repeated in the transport header.
+        header = b"\xc0" + counter_bytes
         return header + ciphertext
 
     def decrypt(self, packet: bytes) -> bytes:

--- a/examples/README-x2.md
+++ b/examples/README-x2.md
@@ -1,0 +1,73 @@
+# Experimental X2+ session probe
+
+Hardware-tested on HEM-7188T1-LEO with macOS/CoreBluetooth and Linux/BlueZ.
+This is not enabled by the Home Assistant device catalog and does not claim
+support for other OMRON models or Bluetooth proxies.
+
+Use an isolated Python environment with the integration's Python dependencies,
+including cryptography, bleak, bleak-retry-connector, sensor-state-data and
+aiooui. On Linux the passive pairing agent additionally requires dbus-fast and
+access to the system BlueZ service. Run `python examples/x2_session_probe.py
+--help` for required arguments. Use the repository root as `--checkout`.
+
+## Explicit first pairing
+
+The owner must activate physical pairing mode. The successful Linux test began
+with no existing X2 association on that test host, using both
+`--no-connect-pair --passive-bonding-agent`. The latter retains the upstream
+BlueZ agent without explicitly calling Pair. The probe never removes an OS
+association automatically. Removing one is a separate owner-controlled action;
+do not remove unrelated Bluetooth devices.
+
+```sh
+python examples/x2_session_probe.py pair \
+  --checkout /path/to/hass-omron \
+  --credentials /private/path/x2-key.json \
+  --address YOUR_DEVICE_ADDRESS \
+  --no-connect-pair --passive-bonding-agent
+```
+
+For macOS omit `--passive-bonding-agent` and use the CoreBluetooth device UUID.
+First pairing writes preserved initialization settings and the host's local
+clock. Check the host clock/timezone first. It may replace the meter's existing
+application association. It does not read measurement records.
+
+The credential is created privately, without overwriting an existing file,
+only after the initialization close is accepted. It is bound to the device
+address and host name. Do not commit it, attach it to an issue, or copy a phone's
+credentials into this test. Keep it for reconnects; a transient failure is not
+permission to erase it or fall back to fresh pairing.
+
+## Reconnect after display-off
+
+Let the display turn off and do not reactivate P. Start a separate process:
+
+```sh
+python examples/x2_session_probe.py reconnect \
+  --checkout /path/to/hass-omron \
+  --credentials /private/path/x2-key.json \
+  --address YOUR_DEVICE_ADDRESS --no-connect-pair
+```
+
+The hardware-validated result is `ADVERTISEMENT_MODE normal`,
+`X2_RESUME_AUTH_OK`, `METADATA_READ_OK bytes=24; NO_RECORDS_READ`,
+`READ_CLOSE_OK`, `CONNECTION_CLOSED`, exit 0. Reconnect does not initialize the
+clock or write settings. A display-off reconnect is not a battery-removal test.
+
+## Remaining Home Assistant integration work
+
+- In config_flow, choose the exact X2 profile without forcing connect-time
+  Pair; persist the returned application credential only after accepted close.
+- Use a dedicated credential field and bind it to the device and adapter route.
+  The existing bindkey field is not yet consumed by the poll path for this flow.
+- Pass that credential through setup/parser into the session authentication
+  path; currently `_secure_unlock` constructs a fresh SecureSession each time.
+- Keep explicit pairing initialization separate from ordinary polling; do not
+  run generic pairing/time initialization again during saved-key resume.
+- Integrate and test failure recovery, handoff-session ownership, credential
+  redaction in diagnostics, HA restart and adapter-route changes before enabling
+  automatic catalog selection. No proxy acceptance is implied by local BlueZ.
+
+The successful Linux run did not have an SMP capture. Deferred pairing plus a
+fresh host association and retained agent is a tested combination, not proof
+that explicit Pair timing alone caused earlier FF26 failures.

--- a/examples/x2_session_probe.py
+++ b/examples/x2_session_probe.py
@@ -1,0 +1,115 @@
+"""Explicit X2+ candidate test, private device-bound key, metadata-only read."""
+import argparse
+import asyncio
+from contextlib import AsyncExitStack
+from dataclasses import replace
+from datetime import datetime
+import json
+import logging
+import os
+from pathlib import Path
+import socket
+import sys
+import tempfile
+import types
+
+parser = argparse.ArgumentParser()
+parser.add_argument("mode", choices=["pair", "reconnect"])
+parser.add_argument("--checkout", type=Path, required=True)
+parser.add_argument("--credentials", type=Path, required=True)
+parser.add_argument("--address", required=True)
+parser.add_argument("--no-connect-pair", action="store_true",
+                    help="Diagnostic: use existing OS bond, skip connect-time Pair")
+parser.add_argument("--passive-bonding-agent", action="store_true",
+                    help="Linux diagnostic: retain BlueZ agent without calling Pair")
+args = parser.parse_args()
+if args.passive_bonding_agent and (sys.platform != "linux" or not args.no_connect_pair):
+    parser.error("--passive-bonding-agent requires Linux and --no-connect-pair")
+package = types.ModuleType("omron_ble")
+package.__path__ = [str(args.checkout / "custom_components/omron/omron_ble")]
+sys.modules["omron_ble"] = package
+
+from bleak import BleakScanner  # noqa: E402
+from omron_ble.devices import UnlockMode, get_device_config  # noqa: E402
+from omron_ble.omron_driver import OmronDeviceSession, _bluez_pairing_agent  # noqa: E402
+from omron_ble.secure_flow import establish_secure_session  # noqa: E402
+
+
+async def main():
+    binding = {"address": args.address.upper(), "host": socket.gethostname()}
+    key = None
+    if args.mode == "reconnect":
+        saved = json.loads(args.credentials.read_text())
+        if any(saved.get(k) != v for k, v in binding.items()):
+            raise ValueError("Credential device/host mismatch")
+        if args.credentials.stat().st_mode & 0o077:
+            raise ValueError("Credential permissions must be private")
+        key = bytes.fromhex(saved["ltk"])
+    elif args.credentials.exists():
+        raise ValueError("Pair test will not overwrite an existing credential file")
+    config = replace(get_device_config("HEM-7188T1-LEO"),
+                     model="HEM-7188T1-LEO", unlock_mode=UnlockMode.SECURE_SESSION)
+    if args.no_connect_pair:
+        print("DIAGNOSTIC_SKIP_CONNECT_PAIR", flush=True)
+    wanted_service = "0000fcb4-0000-1000-8000-00805f9b34fb" if key is None else "0000fe4a-0000-1000-8000-00805f9b34fb"
+    async with AsyncExitStack() as resources:
+        if args.passive_bonding_agent:
+            agent = await resources.enter_async_context(_bluez_pairing_agent())
+            if agent is None:
+                raise RuntimeError("BlueZ agent unavailable; diagnostic not started")
+            print("PASSIVE_BONDING_AGENT_READY; NO_EXPLICIT_PAIR_CALL", flush=True)
+        scanner = await resources.enter_async_context(BleakScanner())
+        print("SCAN_READY", args.mode, flush=True)
+        async with asyncio.timeout(60):
+            async for device, advertisement in scanner.advertisement_data():
+                if device.address.upper() == binding["address"] and wanted_service in advertisement.service_uuids:
+                    break
+        print("FOUND_TARGET", flush=True)
+        print("ADVERTISEMENT_MODE", "pairing" if
+              "0000fcb4-0000-1000-8000-00805f9b34fb" in advertisement.service_uuids
+              else "normal", flush=True)
+        session = OmronDeviceSession(device, config,
+                                     pairing_session=key is None and not args.no_connect_pair)
+        try:
+            await asyncio.wait_for(session.connect(), timeout=25)
+            # Diagnostic changes only connect-time bonding, not the explicit
+            # application-level initialization mode selected by the user.
+            session._pairing_session = key is None
+            print("CONNECTED", flush=True)
+            authenticated_key = await establish_secure_session(
+                session, stored_ltk=key, now=datetime.now()
+            )
+            print("X2_AUTH_AND_INITIALIZATION_OK" if key is None else "X2_RESUME_AUTH_OK", flush=True)
+            if key is None:
+                args.credentials.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+                fd, temporary = tempfile.mkstemp(dir=args.credentials.parent, prefix=".x2-key-")
+                try:
+                    with os.fdopen(fd, "w") as out:
+                        json.dump({**binding, "ltk": authenticated_key.hex()}, out)
+                        out.flush()
+                        os.fsync(out.fileno())
+                    # No-overwrite publication; temporary file is already mode 0600.
+                    os.link(temporary, args.credentials)
+                finally:
+                    os.unlink(temporary)
+                print("CREDENTIAL_COMMITTED_AFTER_CLOSE", flush=True)
+            else:
+                await session.open_memory_session()
+                metadata = await session.read_memory_block(0x0010, 24)
+                if len(metadata) != 24:
+                    raise ValueError("Incomplete metadata response")
+                print("METADATA_READ_OK bytes=24; NO_RECORDS_READ", flush=True)
+                await session.close_memory_session()
+                if session._last_reply_packet_type != b"\x8f\x00" or session._last_reply_payload != b"\x00":
+                    raise ConnectionError("Read close not accepted")
+                print("READ_CLOSE_OK", flush=True)
+            await asyncio.sleep(1.2)
+        finally:
+            await session.aclose()
+            print("CONNECTION_CLOSED", flush=True)
+
+
+if __name__ == "__main__":
+    logging.basicConfig(level=logging.WARNING)
+    logging.getLogger("omron_ble.secure_flow").setLevel(logging.INFO)
+    asyncio.run(asyncio.wait_for(main(), timeout=150))

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -15,15 +15,22 @@ class TestCatalogResolution:
     """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
 
     def test_hem7188t1_leo_resolves_to_own_profile(self):
-        # HEM-7188T1-LEO ("X2+ Connect") keeps its own dedicated profile
-        # (distinct connect_type WLD4.0 vs HEM-7142T2's WLD1.0) with corrected
-        # memory map layout.
-        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1"
+        # HEM-7188T1-LEO ("X2+ Connect") has its own profile on the secure
+        # session transport (#24): the token-key path reads values inside the
+        # -P- window but every reconnect after it is refused. The HEM-7183T1
+        # variants share the hardware but not the testing, so they stay on the
+        # token-key profile.
+        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1-LEO"
         assert resolve_profile_model_id("HEM-7183T1-AP") == "HEM-7188T1"
         assert resolve_profile_model_id("HEM-7183T1_FLIN") == "HEM-7188T1"
+        assert get_device_config("HEM-7183T1-AP").unlock_mode.value == "token_key"
         cfg = get_device_config("HEM-7188T1-LEO")
         assert cfg.model == "HEM-7188T1-LEO"
-        assert cfg.unlock_mode.value == "token_key"
+        assert cfg.unlock_mode.value == "secure_session"
+        # No explicit Pair(); the cuff drives security and an agent answers it.
+        assert cfg.host_pairing_mode.value == "none"
+        assert cfg.register_pairing_agent is True
+        assert cfg.pair_on_connect is False
         assert cfg.connect_type == ConnectType.WLD4_0
         assert cfg.user_start_addresses == [0x01C4]
         assert cfg.per_user_records_count == [30]

--- a/tests/test_secure_flow.py
+++ b/tests/test_secure_flow.py
@@ -1,0 +1,188 @@
+"""Session ordering/persistence gates; crypto wire vectors are tested separately."""
+import asyncio
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from custom_components.omron.omron_ble.devices import UnlockMode
+from custom_components.omron.omron_ble.secure_flow import (
+    clock_block,
+    establish_secure_session,
+    prepare_secure_token,
+)
+
+
+class Crypto:
+    def __init__(self, stored_ltk=None):
+        self.ltk = stored_ltk or bytes(range(16))
+
+    def build_pair_req(self):
+        return b"\x70\x01"
+
+    def process_pair_resp(self, response):
+        assert response == b"\xf0\x81"
+
+    def build_start_enc_req(self):
+        return b"\x70\x05"
+
+    def build_challenge_req(self, response):
+        assert response == b"\xf0\x85"
+        return b"\x70\x06"
+
+    def process_challenge_resp(self, response):
+        assert response == b"\xf0\x86"
+
+    def encrypt(self, payload):
+        assert payload == b"\x20\x01\x00" + bytes(17)
+        return b"\xc0"
+
+    def decrypt(self, payload):
+        assert payload == b"\xc0"
+        return b"\xa0\x01\x00\x01"
+
+
+def make_session(pairing, close_code=b"\x00"):
+    events = []
+    session = SimpleNamespace(
+        _config=SimpleNamespace(
+            model="HEM-7188T1-LEO",
+            unlock_mode=UnlockMode.SECURE_SESSION,
+            settings_read_address=0x0010,
+            settings_write_address=0x0054,
+            settings_time_sync_bytes=[0x2C, 0x3C],
+            index_pointer_layout={"index_region_byte_size": 0x18},
+        ),
+        _pairing_session=pairing,
+        _token_unlock=AsyncMock(), open_memory_session=AsyncMock(),
+        read_memory_block=AsyncMock(side_effect=[bytes(range(44)), bytes(range(24))]),
+        write_memory_block=AsyncMock(),
+        _last_reply_packet_type=None, _last_reply_payload=None,
+    )
+
+    async def write(uuid, packet, response):
+        assert response is True
+        events.append(packet)
+        answer = {b"\x70\x01": b"\xf0\x81", b"\x70\x05": b"\xf0\x85",
+                  b"\x70\x06": b"\xf0\x86", b"\xc0": b"\xc0"}[packet]
+        session._unlock_notify_handler(None, answer)
+
+    async def close():
+        session._last_reply_packet_type = b"\x8f\x00"
+        session._last_reply_payload = close_code
+
+    session._client = SimpleNamespace(write_gatt_char=write)
+    session.close_memory_session = AsyncMock(side_effect=close)
+    return session, events
+
+
+def run(session, key=None):
+    with patch("custom_components.omron.omron_ble.secure_flow.SecureSession", Crypto), patch(
+        "custom_components.omron.omron_ble.secure_flow.prepare_secure_token", new_callable=AsyncMock
+    ):
+        return asyncio.run(establish_secure_session(session, stored_ltk=key, now=datetime(2026, 9, 6, 12, 30, 45)))
+
+
+def test_resume_never_pairs_or_writes_settings():
+    session, events = make_session(False)
+    assert run(session, bytes(range(16))) == bytes(range(16))
+    assert events == [b"\x70\x05", b"\x70\x06", b"\xc0"]
+    session.open_memory_session.assert_not_awaited()
+    session.write_memory_block.assert_not_awaited()
+
+
+def test_pairing_returns_key_only_after_close():
+    session, events = make_session(True)
+    assert run(session) == bytes(range(16))
+    assert events[0] == b"\x70\x01"
+    session.close_memory_session.assert_awaited_once()
+    calls = session.write_memory_block.await_args_list
+    assert calls[0].args == (0x0054, bytearray(range(24)))
+    assert calls[1].args[0] == 0x0080
+
+
+def test_rejected_close_does_not_return_key():
+    session, _ = make_session(True, close_code=b"\x01")
+    with pytest.raises(ConnectionError, match="close"):
+        run(session)
+    assert session._unlocked is False
+
+
+def test_timeout_does_not_return_key():
+    session, _ = make_session(True)
+    session.close_memory_session = AsyncMock(side_effect=TimeoutError())
+    with pytest.raises(TimeoutError):
+        run(session)
+    assert session._unlocked is False
+
+
+def test_resume_without_key_is_rejected_before_io():
+    session, events = make_session(False)
+    with pytest.raises(ValueError, match="resume requires"):
+        run(session)
+    assert events == []
+    session._token_unlock.assert_not_awaited()
+
+
+def test_request_is_precomputed_before_token_preparation():
+    for pairing in (True, False):
+        events = []
+        class TracedCrypto(Crypto):
+            def build_pair_req(self):
+                events.append("pair_request")
+                return super().build_pair_req()
+
+            def build_start_enc_req(self):
+                events.append("start_request")
+                return super().build_start_enc_req()
+
+        async def prepared(_session, _timeout):
+            events.append("token")
+
+        session, _ = make_session(pairing)
+        with patch("custom_components.omron.omron_ble.secure_flow.SecureSession", TracedCrypto), patch(
+            "custom_components.omron.omron_ble.secure_flow.prepare_secure_token", prepared
+        ):
+            asyncio.run(establish_secure_session(session, stored_ltk=None if pairing else bytes(16),
+                                     now=datetime(2026, 9, 6)))
+        assert events[:2] == ["pair_request" if pairing else "start_request", "token"]
+
+
+def test_clock_preserves_unrelated_settings():
+    source = bytes(range(24))
+    block = clock_block(source, datetime(2026, 9, 6, 12, 30, 45), 16)
+    assert block[:4] == source[:4]
+    assert block[4] == source[4] | 1
+    assert block[5:8] == source[5:8]
+    assert block[8:14] == bytes([26, 9, 6, 12, 30, 45])
+    assert block[14] == sum(block[:14]) % 256
+    assert block[15] == source[15]
+
+
+def test_prepare_reads_then_subscribes_control_rx_async_before_token():
+    events, handlers = [], {}
+    control = "b305b680-aee7-11e1-a730-0002a5d5c51b"
+    async def read(uuid):
+        events.append(("read", uuid[:8]))
+        return b"synthetic"
+    async def subscribe(uuid, handler):
+        handlers[uuid.lower()] = handler
+        events.append(("notify", uuid.lower()))
+    async def write(uuid, value, response):
+        assert response is True
+        assert len(value) == 20 and value[0] == 0x11
+        events.append(("token", uuid.lower()))
+        handlers[control](None, b"\x91\x00" + value[1:5])
+    session = SimpleNamespace(
+        _client=SimpleNamespace(read_gatt_char=read, start_notify=subscribe, write_gatt_char=write),
+        _config=SimpleNamespace(rx_channel_uuids=["rx"]),
+        _rebuild_notify_handle_index_map=lambda: None,
+        _on_notify_channel_data=lambda *_: None,
+    )
+    asyncio.run(prepare_secure_token(session, 1))
+    assert events == [("read", "00002a26"), ("read", "00002a28"),
+                      ("notify", control), ("notify", "rx"),
+                      ("notify", "8858eb40-aee8-11e1-bb67-0002a5d5c51b"),
+                      ("token", control)]
+    assert session._notify_subscribed

--- a/tests/test_secure_flow.py
+++ b/tests/test_secure_flow.py
@@ -174,14 +174,28 @@ def test_prepare_reads_then_subscribes_control_rx_async_before_token():
         assert len(value) == 20 and value[0] == 0x11
         events.append(("token", uuid.lower()))
         handlers[control](None, b"\x91\x00" + value[1:5])
+    async def raw_start_notify(uuid, handler):
+        raise AssertionError(
+            "raw start_notify bypasses the recovery path: a kept CCCD from the "
+            "previous connection makes the retry fail outright (#92)"
+        )
+
+    async def ensure_cache():
+        events.append(("cache", ""))
+
     session = SimpleNamespace(
-        _client=SimpleNamespace(read_gatt_char=read, start_notify=subscribe, write_gatt_char=write),
+        _client=SimpleNamespace(
+            read_gatt_char=read, start_notify=raw_start_notify, write_gatt_char=write
+        ),
         _config=SimpleNamespace(rx_channel_uuids=["rx"]),
         _rebuild_notify_handle_index_map=lambda: None,
         _on_notify_channel_data=lambda *_: None,
+        _ensure_services_cache=ensure_cache,
+        _start_notify_with_recovery=subscribe,
     )
     asyncio.run(prepare_secure_token(session, 1))
     assert events == [("read", "00002a26"), ("read", "00002a28"),
+                      ("cache", ""),
                       ("notify", control), ("notify", "rx"),
                       ("notify", "8858eb40-aee8-11e1-bb67-0002a5d5c51b"),
                       ("token", control)]

--- a/tests/test_secure_rx_frames.py
+++ b/tests/test_secure_rx_frames.py
@@ -1,0 +1,53 @@
+"""Exercise the actual driver callback with synthetic encrypted secure-session replies."""
+from unittest.mock import MagicMock
+
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+
+from custom_components.omron.omron_ble.devices import DeviceConfig, HostPairingMode, UnlockMode
+from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+from custom_components.omron.omron_ble.secure_session import SecureSession
+
+
+def make_session():
+    config = DeviceConfig(
+        model="HEM-7188T1-LEO",
+        unlock_mode=UnlockMode.SECURE_SESSION,
+        host_pairing_mode=HostPairingMode.OS_BONDING,
+        rx_channel_uuids=["49123040-aee8-11e1-a74d-0002a5d5c51b"],
+        tx_channel_uuids=["db5b55e0-aee7-11e1-965e-0002a5d5c51b"],
+    )
+    session = OmronDeviceSession(MagicMock(), config)
+    crypto = SecureSession(stored_ltk=bytes(16))
+    crypto.state = crypto.STATE_PAIRED
+    crypto.session_key = bytes(range(16))
+    crypto.enc_peer_salt_nonce = bytes(range(8))
+    session._secure_session = crypto
+    session._expected_reply_packet_type = b"\x80\x00"
+    return session
+
+
+def deliver(session, plaintext):
+    counter = b"\x01\x00\x00\x00"
+    encrypted = AESCCM(bytes(range(16)), tag_length=8).encrypt(
+        counter + b"\x00" + bytes(range(8)), plaintext, counter,
+    )
+    session._on_notify_channel_data(0, bytearray(b"\xc0" + counter + encrypted))
+
+
+def test_encrypted_open_reply_is_not_treated_as_192_byte_frame():
+    session = make_session()
+    deliver(session, bytes.fromhex("0880000000100098"))
+    assert session._reply_ready.is_set()
+    assert session._last_reply_payload == b"\x00"
+
+
+def test_authenticated_but_invalid_inner_checksum_is_rejected():
+    session = make_session()
+    deliver(session, bytes.fromhex("0880000000100099"))
+    assert not session._reply_ready.is_set()
+
+
+def test_authenticated_but_truncated_inner_frame_is_rejected():
+    session = make_session()
+    deliver(session, bytes.fromhex("08800000"))
+    assert not session._reply_ready.is_set()

--- a/tests/test_secure_session_vectors.py
+++ b/tests/test_secure_session_vectors.py
@@ -1,0 +1,80 @@
+"""Synthetic secure-session wire-format regression tests.
+
+No real credentials, device access, or medical records are used.
+These vectors do not establish end-to-end HA or other-model compatibility.
+"""
+import unittest
+
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+
+from custom_components.omron.omron_ble.secure_session import SecureSession
+
+
+class X2SecureVectors(unittest.TestCase):
+    def data_session(self):
+        session = SecureSession(stored_ltk=bytes(range(16)))
+        session.state = session.STATE_PAIRED
+        session.session_key = bytes(range(16))
+        session.enc_peer_salt_nonce = bytes(range(8))
+        return session
+
+    def peer_packet(self, counter=1, payload=b"synthetic-response"):
+        count = counter.to_bytes(4, "little")
+        sealed = AESCCM(bytes(range(16)), tag_length=8).encrypt(
+            count + b"\x00" + bytes(range(8)), payload, count,
+        )
+        return b"\xc0" + count + sealed
+
+    def test_receive_five_byte_header(self):
+        session = self.data_session()
+        self.assertEqual(session.decrypt(self.peer_packet()), b"synthetic-response")
+        self.assertEqual(session.last_peer_packet_counter, 1)
+
+    def test_invalid_tag_does_not_consume_counter(self):
+        session = self.data_session()
+        packet = self.peer_packet()
+        with self.assertRaises(ValueError):
+            session.decrypt(packet[:-1] + bytes([packet[-1] ^ 1]))
+        self.assertEqual(session.last_peer_packet_counter, 0)
+        self.assertEqual(session.decrypt(packet), b"synthetic-response")
+
+    def test_repeated_response_rejected(self):
+        session = self.data_session()
+        packet = self.peer_packet()
+        session.decrypt(packet)
+        with self.assertRaises(ValueError):
+            session.decrypt(packet)
+
+    def test_valid_tag_but_wrong_challenge_rejected(self):
+        session = self.data_session()
+        session.state = session.STATE_CHALLENGE_REQ_SENT
+        session.enc_own_challenge = bytes(range(16, 32))
+        sealed = AESCCM(session.session_key, tag_length=8).encrypt(
+            bytes(5) + bytes(range(8)), bytes(36), bytes(4),
+        )
+        with self.assertRaisesRegex(ValueError, "challenge mismatch"):
+            session.process_challenge_resp(b"\xf0\x86" + sealed)
+        self.assertNotEqual(session.state, session.STATE_PAIRED)
+
+    def test_challenge_uses_both_nonce_contributions(self):
+        session = SecureSession(stored_ltk=bytes(range(16)))
+        session.build_start_enc_req()
+        session.enc_own_salt = bytes(range(28))
+        peer_salt = bytes(range(32, 60))
+        peer_challenge = bytes(range(64, 80))
+        frame = session.build_challenge_req(b"\xf0\x85" + peer_challenge + peer_salt)
+        nonce = bytes(4) + b"\x80" + peer_salt[8:12] + session.enc_own_salt[8:12]
+        plaintext = AESCCM(session.session_key, tag_length=8).decrypt(nonce, frame[2:], bytes(4))
+        self.assertEqual(plaintext[:32], peer_challenge + bytes(16))
+
+    def test_transport_has_five_byte_header(self):
+        session = SecureSession(stored_ltk=bytes(range(16)))
+        session.state = session.STATE_PAIRED
+        session.session_key = bytes(range(16))
+        session.enc_peer_salt_nonce = bytes(range(8))
+        plaintext = b"synthetic-vector"
+        counter = b"\x01\x00\x00\x00"
+        ciphertext = AESCCM(session.session_key, tag_length=8).encrypt(
+            counter + b"\x80" + bytes(range(8)), plaintext, counter,
+        )
+        self.assertEqual(session.encrypt(plaintext), b"\xc0" + counter + ciphertext)

--- a/tests/test_session_cccd_persistence.py
+++ b/tests/test_session_cccd_persistence.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 from custom_components.omron.omron_ble.devices import get_device_config
 from custom_components.omron.omron_ble.const import UNLOCK_CHARACTERISTIC_UUID
 from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+from custom_components.omron.omron_ble.secure_flow import ASYNC_NOTICE_UUID
 
 
 class _FakeSession:
@@ -148,9 +149,12 @@ def test_reset_releases_the_subscription_on_the_profile_under_test():
     # The unlock characteristic is released too. It is not an RX channel, so the
     # loop over rx_channel_uuids never covered it -- and on BlueZ it is the one
     # left holding a notify session from the previous connection (#92).
+    # The async-notice channel goes with them: the secure session subscribes
+    # it and a retry re-subscribes, which BlueZ refuses while it still holds
+    # the CCCD.
     assert target._client.stopped == list(
         get_device_config("HEM-7386T1").rx_channel_uuids
-    ) + [UNLOCK_CHARACTERISTIC_UUID]
+    ) + [UNLOCK_CHARACTERISTIC_UUID, ASYNC_NOTICE_UUID]
     assert target._unlocked is False
 
 

--- a/tests/test_transport_credential.py
+++ b/tests/test_transport_credential.py
@@ -1,0 +1,176 @@
+"""SECURE_SESSION 프로파일의 자격증명 왕복 (#24).
+
+이 전송 방식의 기기는 BLE 본드와 별개로 **애플리케이션 계층 자격증명**을 갖는다.
+첫 세션이 초기화를 마치고 기기가 close 를 수락했을 때만 자격증명을 남기고, 이후
+세션은 그걸 그대로 재생하며 아무것도 쓰지 않는다. 자격증명을 잃으면 사용자가
+커프의 -P- 창을 다시 거쳐야 하므로, 저장 경로가 끊기지 않는 것이 중요하다.
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 통합 계층은 실행할 수
+없어 (test_stale_bond_guard.py 와 같은 이유) 그쪽은 AST 로 검사한다.
+"""
+import ast
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omron.omron_ble.devices import (
+    HostPairingMode,
+    UnlockMode,
+    get_device_config,
+)
+from custom_components.omron.omron_ble.secure_flow import SecureInitLayout
+
+_ROOT = Path(__file__).resolve().parent.parent
+_COMPONENT = _ROOT / "custom_components" / "omron"
+
+
+def _tree(relative: str) -> ast.AST:
+    return ast.parse((_COMPONENT / relative).read_text(encoding="utf-8"))
+
+
+class TestSecureInitLayout:
+    """초기화 주소는 프로파일에서 유도된다 — 한 기종에 박아넣지 않는다."""
+
+    def test_addresses_come_from_the_profile(self):
+        cfg = get_device_config("HEM-7188T1-LEO")
+        layout = SecureInitLayout(cfg)
+        # 읽기/쓰기 영역은 카탈로그의 settings 주소 그대로,
+        # 시계 레코드는 그 안의 time-sync 오프셋에 얹힌다.
+        assert layout.head_read_address == cfg.settings_read_address
+        assert layout.head_write_address == cfg.settings_write_address
+        assert layout.clock_read_address == cfg.settings_read_address + 0x2C
+        assert layout.clock_write_address == cfg.settings_write_address + 0x2C
+        assert layout.clock_write_size == 0x3C - 0x2C
+
+    def test_a_different_profile_shape_moves_every_address(self):
+        """주소가 상수로 굳어 있으면 이 테스트가 잡는다."""
+        other = SimpleNamespace(
+            model="synthetic",
+            settings_read_address=0x0100,
+            settings_write_address=0x0200,
+            settings_time_sync_bytes=[0x10, 0x20],
+            index_pointer_layout={"index_region_byte_size": 0x08},
+        )
+        layout = SecureInitLayout(other)
+        assert layout.head_read_address == 0x0100
+        assert layout.head_read_size == 0x10
+        assert layout.head_write_address == 0x0200
+        assert layout.head_write_size == 0x08
+        assert layout.clock_read_address == 0x0110
+        assert layout.clock_write_address == 0x0210
+        assert layout.clock_write_size == 0x10
+
+    def test_an_incomplete_profile_is_rejected(self):
+        bare = SimpleNamespace(
+            model="bare",
+            settings_read_address=None,
+            settings_write_address=None,
+            settings_time_sync_bytes=None,
+            index_pointer_layout=None,
+        )
+        with pytest.raises(ValueError, match="secure initialization"):
+            SecureInitLayout(bare)
+
+
+class TestOneSecurePath:
+    """SECURE_SESSION 은 하나의 경로여야 한다 — 기종별 분기를 두지 않는다."""
+
+    def test_the_driver_has_no_model_whitelist(self):
+        source = (_COMPONENT / "omron_ble" / "omron_driver.py").read_text(encoding="utf-8")
+        assert "HEM-7188T1-LEO" not in source, (
+            "드라이버가 특정 기종 이름으로 분기한다 — 프로파일 필드로 표현할 것"
+        )
+
+    def test_the_secure_flow_dispatches_on_the_unlock_mode_alone(self):
+        fn = None
+        for node in ast.walk(_tree("omron_ble/omron_driver.py")):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "unlock":
+                fn = node
+        assert fn is not None, "unlock() 을 찾지 못했다"
+        calls = {
+            node.func.attr
+            for node in ast.walk(fn)
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute)
+        }
+        assert "_secure_unlock" in calls
+        assert "_x2_unlock" not in calls, "기종 전용 unlock 이 남아 있다"
+
+
+class TestPairingIsOptional:
+    """커프가 스스로 보안을 주도하는 프로파일에서는 Pair() 를 부르지 않는다."""
+
+    def test_the_profile_holds_an_agent_instead_of_pairing(self):
+        cfg = get_device_config("HEM-7188T1-LEO")
+        assert cfg.host_pairing_mode is HostPairingMode.NONE
+        assert cfg.unlock_mode is UnlockMode.SECURE_SESSION
+        # 에이전트가 없으면 BlueZ 5.72+ 는 Just Works 확인을 방치한다.
+        assert cfg.register_pairing_agent is True
+
+    def test_pair_is_a_no_op_rather_than_an_error(self):
+        """예외를 던지면 평범한 setup/재시도 경로가 전부 특수 분기를 져야 한다."""
+        fn = None
+        for node in ast.walk(_tree("omron_ble/omron_driver.py")):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "pair":
+                fn = node
+        assert fn is not None, "pair() 를 찾지 못했다"
+        for node in ast.walk(fn):
+            if not isinstance(node, ast.If):
+                continue
+            test = ast.unparse(node.test)
+            if "HostPairingMode.NONE" not in test:
+                continue
+            body = ast.unparse(node.body)
+            assert "raise" not in body, f"NONE 분기가 여전히 예외를 던진다: {body}"
+            assert "return" in body
+            break
+        else:
+            raise AssertionError("pair() 에 HostPairingMode.NONE 분기가 없다")
+
+
+class TestCredentialRoundTrip:
+    """저장 -> 세션 -> 갱신 -> 저장 고리가 어느 지점에서도 끊기면 안 된다."""
+
+    def test_sessions_are_opened_with_the_stored_credential(self):
+        fn = None
+        for node in ast.walk(_tree("omron_ble/parser.py")):
+            if isinstance(node, ast.FunctionDef) and node.name == "_open_session":
+                fn = node
+        assert fn is not None, "_open_session 을 찾지 못했다"
+        assert "self.transport_credential" in ast.unparse(fn), (
+            "세션이 저장된 자격증명 없이 열린다 — 재연결이 인증에 실패한다"
+        )
+
+    def test_every_session_construction_goes_through_the_helper(self):
+        """직접 생성하는 자리가 남으면 그 세션만 자격증명 없이 열린다."""
+        built = []
+        for node in ast.walk(_tree("omron_ble/parser.py")):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and any(
+                isinstance(sub, ast.Call)
+                and getattr(sub.func, "id", None) == "OmronDeviceSession"
+                for sub in ast.walk(node)
+            ):
+                built.append(node.name)
+        assert built == ["_open_session"], f"세션을 직접 여는 자리: {built}"
+
+    def test_the_entry_stores_what_a_pairing_established(self):
+        source = (_COMPONENT / "config_flow.py").read_text(encoding="utf-8")
+        assert "session.new_credential" in source
+        assert "CONF_TRANSPORT_CREDENTIAL" in source
+
+    def test_setup_loads_it_and_a_poll_writes_it_back(self):
+        source = (_COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        assert "data.transport_credential = bytes.fromhex" in source, (
+            "저장된 자격증명을 파서에 싣지 않는다"
+        )
+        assert "_persist_transport_credential" in source
+        tree = ast.parse(source)
+        fn = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_persist_transport_credential":
+                fn = node
+        assert fn is not None, "_persist_transport_credential 을 찾지 못했다"
+        body = ast.unparse(fn)
+        assert "async_update_entry" in body
+        # 값이 그대로면 쓰지 않는다: 엔트리 갱신은 통합을 리로드한다.
+        assert "return" in body

--- a/tests/test_transport_credential.py
+++ b/tests/test_transport_credential.py
@@ -10,6 +10,7 @@ conftest 가 homeassistant/bleak 를 MagicMock 으로 치환해 통합 계층은
 """
 import ast
 from pathlib import Path
+from datetime import datetime
 from types import SimpleNamespace
 
 import pytest
@@ -19,7 +20,10 @@ from custom_components.omron.omron_ble.devices import (
     UnlockMode,
     get_device_config,
 )
-from custom_components.omron.omron_ble.secure_flow import SecureInitLayout
+from custom_components.omron.omron_ble.secure_flow import (
+    SecureInitLayout,
+    clock_block,
+)
 
 _ROOT = Path(__file__).resolve().parent.parent
 _COMPONENT = _ROOT / "custom_components" / "omron"
@@ -60,6 +64,43 @@ class TestSecureInitLayout:
         assert layout.clock_read_address == 0x0110
         assert layout.clock_write_address == 0x0210
         assert layout.clock_write_size == 0x10
+
+    def test_the_clock_read_always_covers_what_is_written_back(self):
+        """짧게 읽으면 head 쓰기가 끝난 뒤에 ValueError 로 죽는다.
+
+        시계 레코드 크기는 time-sync 범위에서 오고 읽기 길이는 인덱스 영역
+        크기에서 왔는데, 후자가 더 작은 배치에서는 되쓸 레코드를 만들 수조차
+        없다 — 그것도 기기 메모리를 이미 한 번 쓴 뒤에.
+        """
+        for index_size, time_sync in (
+            (0x08, [0x10, 0x20]),   # 인덱스 영역이 레코드보다 작은 배치
+            (0x18, [0x2C, 0x3C]),   # HEM-7188T1-LEO
+            (0x40, [0x2C, 0x3C]),   # 인덱스 영역이 훨씬 큰 배치
+        ):
+            cfg = SimpleNamespace(
+                model="synthetic",
+                settings_read_address=0x0100,
+                settings_write_address=0x0200,
+                settings_time_sync_bytes=time_sync,
+                index_pointer_layout={"index_region_byte_size": index_size},
+            )
+            layout = SecureInitLayout(cfg)
+            assert layout.clock_read_size >= layout.clock_write_size
+            # 실제로 만들어봐야 의미가 있다: 주소만 검사하면 이 버그를 놓친다.
+            block = clock_block(
+                bytes(layout.clock_read_size), datetime(2026, 9, 6, 12, 30, 45),
+                layout.clock_write_size,
+            )
+            assert len(block) == layout.clock_write_size
+
+    def test_the_checksum_sits_at_the_end_of_the_record(self):
+        """체크섬 위치를 14 로 박아두면 16바이트 레코드에서만 우연히 맞는다."""
+        for size in (16, 20, 24):
+            block = clock_block(bytes(range(size)), datetime(2026, 9, 6, 12, 30, 45), size)
+            assert block[size - 2] == sum(block[: size - 2]) & 0xFF
+        # #67 캡처의 실제 레코드로 규칙 자체를 고정한다.
+        captured = bytes.fromhex("c8a80000010000001a06110f1806cf00")
+        assert captured[14] == sum(captured[:14]) & 0xFF
 
     def test_an_incomplete_profile_is_rejected(self):
         bare = SimpleNamespace(
@@ -106,6 +147,28 @@ class TestPairingIsOptional:
         assert cfg.unlock_mode is UnlockMode.SECURE_SESSION
         # 에이전트가 없으면 BlueZ 5.72+ 는 Just Works 확인을 방치한다.
         assert cfg.register_pairing_agent is True
+
+    def test_the_agent_is_held_for_the_session_not_just_the_connect(self):
+        """핸드셰이크 시점에 커프가 Security Request 를 올리면 답할 주체가 있어야
+        한다. 하드웨어로 검증된 순서도 세션 내내 에이전트를 붙잡고 있었다."""
+        fn = None
+        for node in ast.walk(_tree("omron_ble/omron_driver.py")):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "connect":
+                fn = node
+        assert fn is not None, "connect() 를 찾지 못했다"
+        body = ast.unparse(fn)
+        assert "_bluez_pairing_agent()" in body, (
+            "connect() 가 에이전트를 잡지 않는다 — establish_connection 안에서만 "
+            "유지되면 이후 핸드셰이크의 보안 요청에 답할 주체가 없다"
+        )
+        assert "register_pairing_agent" in body
+
+        released = None
+        for node in ast.walk(_tree("omron_ble/omron_driver.py")):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "aclose":
+                released = ast.unparse(node)
+        assert released is not None, "aclose() 를 찾지 못했다"
+        assert "_pairing_agent" in released, "세션이 끝나도 에이전트를 놓지 않는다"
 
     def test_pair_is_a_no_op_rather_than_an_error(self):
         """예외를 던지면 평범한 setup/재시도 경로가 전부 특수 분기를 져야 한다."""

--- a/tests/test_transport_credential.py
+++ b/tests/test_transport_credential.py
@@ -221,6 +221,34 @@ class TestCredentialRoundTrip:
         assert "session.new_credential" in source
         assert "CONF_TRANSPORT_CREDENTIAL" in source
 
+    def test_storing_it_does_not_reload_the_integration(self):
+        """엔트리 갱신은 update_listener 를 통해 통합을 리로드한다. 자격증명 쓰기는
+        코디네이터의 업데이트 메서드 안에서 일어나므로, 리로드하면 그 폴을 돌리고
+        있는 코디네이터를 스스로 무너뜨린다."""
+        source = (_COMPONENT / "__init__.py").read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        listener = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.AsyncFunctionDef) and node.name == "update_listener":
+                listener = node
+        assert listener is not None, "update_listener 를 찾지 못했다"
+        body = ast.unparse(listener)
+        assert "credential_write" in body, (
+            "리스너가 자격증명 전용 변경을 구분하지 않는다 — 폴 도중 리로드가 걸린다"
+        )
+        # 건너뛰는 경로는 리로드에 도달하기 전에 반환해야 한다.
+        assert body.index("credential_write") < body.index("async_reload")
+
+        persist = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_persist_transport_credential":
+                persist = node
+        assert persist is not None
+        marked = ast.unparse(persist)
+        assert marked.index("credential_write") < marked.index("async_update_entry"), (
+            "표시를 엔트리 갱신 뒤에 하면 리스너가 이미 지나간 뒤다"
+        )
+
     def test_setup_loads_it_and_a_poll_writes_it_back(self):
         source = (_COMPONENT / "__init__.py").read_text(encoding="utf-8")
         assert "data.transport_credential = bytes.fromhex" in source, (


### PR DESCRIPTION
Devices on `UnlockMode.SECURE_SESSION` keep an **application-layer credential** independent of the BLE bond. Until now our secure path only ever ran a fresh ECDH pairing, had no way to resume, and never got that far anyway: the device answered the pairing request with error frame `0xff26`. That is why the mode was enabled on **no profile at all**.

## Two bugs in the envelope

Both were in the shared `SecureSession`, so every profile on this mode gets the fix:

- The transport header is **5 bytes** (`0xC0 || counter`), not 13. The negotiated nonce tail is not repeated in it.
- The CCM nonce tail is the **peer's 4-byte contribution followed by the host's**, not 8 bytes taken from the peer's salt.

Authentication was breaking on the very first encrypted packet, so the device was right to refuse.

## One secure path

With those corrected the full flow works: token handshake → ECDH → system authentication → (pairing sessions only) initialization. The credential is kept **only once the device accepts the close**; later sessions replay it and write nothing.

Every address the initialization touches is derived from catalog fields the profile already carries — `settings_read_address`, `settings_write_address`, `settings_time_sync_bytes`, `index_region_byte_size`. This is the path for the unlock mode, not a per-model branch, and a new profile only fills in fields. The older secure unlock is deleted rather than kept alongside it.

## Credential persistence

Stored in the config entry and loaded back into the parser at setup, because a reconnect has to authenticate with it. Losing it costs the user another pass through the cuff's pairing mode. The entry is only written when the value actually changes, since updating it reloads the integration.

## First profile

`HEM-7188T1-LEO` ("X2+ Connect") gets its own entry on this path. The `HEM-7183T1` variants share the hardware but not the testing, so they stay on token-key.

It pairs without an explicit `Pair()`: the cuff raises its own Security Request and a registered agent answers it. For that, `pair()` is now a no-op for `HostPairingMode.NONE` rather than an error — otherwise every setup and retry path needs a special case — and profiles carry a `register_pairing_agent` field.

## Review fixes

Seven findings from review, all confirmed and addressed in c8f1b7b:

1. **CCM counter replay.** Encryption sat outside the TX retry loop, so a retransmit replayed a counter the device has already seen and the retry budget could be spent without a frame reaching the command handler. Encrypt per transmission from the retained plaintext. (Latent before this PR — no profile had the mode enabled.)
2. **Async-notice CCCD never released.** `reset_session_state` freed the RX and unlock CCCDs but not the secure session's third channel, so attempts 2 and 3 of the memory-session retry loop re-subscribed a CCCD BlueZ still held.
3. **Clock read length.** It came from the index region size, which has nothing to do with the record being written back: on a profile whose index region is smaller than its clock record, `clock_block` raised *after* the head write had already landed. Now the larger of the two, which keeps the verified read length where one exists.
4. **Raw `start_notify`.** The subscriptions bypassed `_start_notify_with_recovery` / `_ensure_services_cache` — the path #92 added for exactly this situation on profiles that keep their subscriptions.
5. **Agent lifetime.** It was held only for the duration of `establish_connection`. The hardware-verified sequence keeps one registered for the whole session, and the device raises its Security Request on its own schedule, so the session holds it and releases it in `aclose()`.
6. **Checksum position.** Hardcoded at byte 14, correct only for a 16-byte record. It is the second-to-last byte, so it follows the size. Verified against every 16-byte sample in the #67 and #91 captures.
7. **Dead code, and a lost message.** Deleting the old secure unlock left `_secure_error_frame_code` and `_SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC` referenced only by their own tests, and took the actionable `0xff26` guidance with it. Both are back in use: a rejection is reported as a rejection, with what to do about it.

## What is verified, and what is not

The #24 reporter verified this on hardware on Linux/BlueZ 5.82 and macOS: pairing, then a **saved-credential reconnect from a separate process** after the display had turned off, without re-entering pairing mode.

That covers **authentication and a metadata read**. It does **not** cover reading measurement records over a resumed session. No SMP capture exists for the successful attempt, so the reporter's caution against attributing `0xff26` to `Pair()` timing still stands — and the envelope bugs above are a sufficient explanation on their own.

Findings 1 and 2 would not have shown up in the reporter's probe (single session, no retries), so repeated polling on this branch is what would confirm them.

230 tests pass. CI gained a `cryptography` dependency.

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)
