### PR TITLE
fix: offer the modern X4 Smart alongside the other two

### DIFF
--- a/custom_components/omron/omron_ble/model_aliases.py
+++ b/custom_components/omron/omron_ble/model_aliases.py
@@ -18,7 +18,14 @@ The app ships HEM-7155T_ESL and HEM-7155T_K4-ESL with all three names identical
 them apart by a group id the device never transmits. It knows which is which
 only because the user picked the model, and so must we.
 
-Resolvable in principle: the two stacks expose different parent service UUIDs,
+A third X4 Smart exists that the app's list does not separate either: the
+modern-fe4a firmware, WLD3.0 with a token handshake, which this catalog carries
+as HEM-7155T_ESL1 (#67, confirmed by HCI btsnoop). It has to be offered
+alongside the other two -- it is the one that reads records on that firmware,
+and a candidate list without it sends its owners to a profile that either
+cannot connect or connects and transfers nothing.
+
+Resolvable in principle: the stacks expose different parent service UUIDs,
 visible on connect. That needs the device in hand, so it is left for later.
 
 Resolution aliases only: get_supported_models does not offer them in the
@@ -188,6 +195,9 @@ AMBIGUOUS_MODEL_NAMES: dict[str, tuple[str, ...]] = {
         "HEM-7155T_K4-EBK",
     ),
     "HEM-7155T_ESL": (
+        # Modern-fe4a firmware first: it is the one with reports behind it, and
+        # the only one that reads records on that firmware (#67).
+        "HEM-7155T_ESL1",
         "HEM-7155T_ESL",
         "HEM-7155T_K4-ESL",
     ),
@@ -208,6 +218,7 @@ AMBIGUOUS_MODEL_NAMES: dict[str, tuple[str, ...]] = {
         "HEM-716BT2-ZAZ",
     ),
     "X4 Smart": (
+        "HEM-7155T_ESL1",
         "HEM-7155T_ESL",
         "HEM-7155T_K4-ESL",
     ),

--- a/tests/test_model_aliases.py
+++ b/tests/test_model_aliases.py
@@ -95,10 +95,36 @@ def test_names_covering_several_stacks_are_not_guessed() -> None:
         assert infer_model_id_from_local_name(name) is None, name
         assert len(ambiguous_model_candidates(name)) > 1, name
 
+    # Three stacks, not two: the modern-fe4a firmware is a third X4 Smart and
+    # the only one that reads records on that firmware. Leaving it out of the
+    # candidates sent its owners to a profile that either cannot connect or
+    # connects and transfers nothing (#67). It goes first because it is the one
+    # with reports behind it.
     assert ambiguous_model_candidates("X4 Smart") == (
+        "HEM-7155T_ESL1",
         "HEM-7155T_ESL",
         "HEM-7155T_K4-ESL",
     )
+    assert ambiguous_model_candidates("HEM-7155T_ESL")[0] == "HEM-7155T_ESL1"
+
+
+def test_the_x4_smart_candidates_are_three_different_profiles() -> None:
+    """세 후보가 같은 프로파일로 모이면 고를 이유가 없다."""
+    from custom_components.omron.omron_ble.devices import (
+        get_device_config,
+        resolve_profile_model_id,
+    )
+
+    profiles = {
+        candidate: resolve_profile_model_id(candidate)
+        for candidate in ambiguous_model_candidates("X4 Smart")
+    }
+    assert len(set(profiles.values())) == 3, profiles
+    modern = get_device_config("HEM-7155T_ESL1")
+    # 이 펌웨어는 -P- 창 밖에서 메모리를 읽으려면 토큰 핸드셰이크가 필요하다.
+    # 나머지 두 후보에는 그것이 없어서 연결은 되고 데이터는 오지 않는다.
+    assert modern.unlock_mode.value == "token_key"
+    assert modern.settings_read_address == 0x0260
 
 
 def test_a_resolvable_name_is_not_called_ambiguous() -> None:


### PR DESCRIPTION
An X4 Smart answers with a name nothing can resolve, so the config flow names candidates rather than guessing. It named two:

| candidate | profile | unlock | settings | stack |
|---|---|---|---|---|
| `HEM-7155T_ESL` | `HEM-7155T` | `classic_key` | 0x0010 | WLS3.0 |
| `HEM-7155T_K4-ESL` | `HEM-7155T-K4` | `none` | 0x0260 | WLD2.0 |

**There is a third.** The modern-fe4a firmware is WLD3.0 with a `0x11/0x91` token handshake, carried here as `HEM-7155T_ESL1` → profile `HEM-7155T-MW3`, `unlock_mode=token_key`, settings 0x0260. This catalog has that profile *because* an HCI btsnoop of exactly such a cuff confirmed it in [#67](https://github.com/eigger/hass-omron/issues/67).

It was missing from the candidates, so owners of that firmware were pointed at the only two profiles that cannot work for them — which is precisely the report that prompted this:

> If I select `HEM-7155T-ESL` as the device, I cannot establish a connection. If I select `HEM-7155T_K4-ESL`, I do establish a connection, but no data is transmitted. Both of these devices are suggested during setup.

Both halves follow from the table. The classic profile drives the wrong stack, so it does not connect. The WLD2.0 profile has `unlock_mode=NONE`, and the catalog note on the modern profile already predicts the rest:

> The token is required for memory access outside the device's `-P-` pairing grace window: a normal-mode poll without it returns no data.

`get_supported_models()` fills the dropdown with every supported model, so `HEM-7155T_ESL1` was always selectable. It was the *guidance* that was wrong — and the guidance is what users follow.

Listed first, because it is the variant with reports behind it.

Two tests: the candidate tuple, and that the three candidates resolve to three different profiles with the modern one on token-key at 0x0260 — so a future edit cannot quietly collapse them.

Refs #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)
