### PR TITLE
feat: log the index block's unread counter

### DIFF
--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -2716,6 +2716,25 @@ class OmronDeviceDriver:
                 ptr_endian,
                 bytes(index_bytes).hex(),
             )
+            # Diagnostic only. The app clears this counter at session end and we
+            # never write it, so a drop between polls means the phone app synced
+            # (#69, #132). The offsets themselves are unvalidated (#133).
+            unread = []
+            for idx, user_cfg in enumerate(user_layouts):
+                offset = int(user_cfg.get("unread_counter_offset", -1))
+                if offset < 0 or offset + 2 > len(index_bytes):
+                    continue
+                raw_unread = int.from_bytes(
+                    index_bytes[offset:offset + 2], ptr_endian, signed=False
+                )
+                unread.append(
+                    f"user{idx + 1}@0x{offset:02X}=0x{raw_unread:04X}"
+                    f"({raw_unread & 0xFF})"
+                )
+            if unread:
+                _LOGGER.debug(
+                    "Index unread [%s]: %s", self._config.model, " ".join(unread)
+                )
             for idx, user_cfg in enumerate(user_layouts):
                 if idx >= len(record_addresses) or idx >= len(self._config.per_user_records_count):
                     continue


### PR DESCRIPTION
`index_pointer_layout` carries `unread_counter_offset` for every profile in the
catalog, and nothing in the driver has ever read it. The index block is already
fetched whole and logged as raw hex, so decoding the field costs no BLE traffic,
no write, and no behaviour change — one more value pulled out of a buffer we hold.

```
Index unread [HEM-7155T-MW3]: user1@0x04=0x000D(13) user2@0x0C=0x0000(0)
```

## Why

Verified against the four app sessions in the #67 HCI capture
(HEM-7155T-MW3, `C4:24:E8:23:8F:68`):

| session | user1 cursor | user1 unread | user2 cursor | user2 unread |
| --- | --- | --- | --- | --- |
| 1 | 13 | 13 | 30 | 0 |
| 2 | 14 | 1 | 31 | 0 |
| 3 | 14 | `0x8000` → 0 | 31 | 0 |
| 4 | 15 | 1 | 32 | 0 |

Session 3 is the control: no measurement was taken between it and session 2, and
the counter reads 0 — the OMRON app writes `0x80008000` into this field at session
end and that is what resets it. The records themselves are untouched; the app only
writes `0x02A4` and `0x02D0`, and the record region starts at `0x02E8`.

Three things this makes visible:

- **#69, #132** — we never write this field, so a drop between two polls means the
  phone app synced. That turns "did the app take my data" from a guess into a log
  line.
- **#133** — the offsets have never been validated on hardware. On a two-user
  device, whichever offset moves when user 2 measures is that user's field.
  Settling the layout no longer needs a phone capture or an EEPROM dump, just
  debug logs across a few polls.
- **#91** — the device-side value behind `Data Pending`, next to what the
  advertisement claims.

## Tests

`pytest tests/` — 233 passed. The two `test_bluez_agent.py` failures reproduce on a
clean checkout of `master`; they are a dbus_fast/Python 3.14 problem in this
environment, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)