### PR TITLE
fix: read user 2's cursor from 0x02 on HEM-7155T-MW3

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -866,13 +866,13 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         index_pointer_layout={
             "index_region_byte_size": 0x10,
             "endianness": "little",
-            # Index entries are 8 bytes per user (uint32 write cursor + uint32
-            # unread counter), confirmed via HCI btsnoop of HEM-7155T-ESL:
-            # user1 cursor at 0x00, user2 cursor at 0x08 (NOT 0x02 — that offset
-            # lands in the high half of user1's word and reads the 0x80 flag).
+            # Fields are 2 bytes, so user2 sits at 0x02 like every other profile.
+            # 0x08 counts user1's own measurements in the #67 capture (30 -> 31 ->
+            # 32 across two user1 readings), and 0x02 reads 0x8000 there because
+            # that cuff's user2 had never recorded.
             "users": [
                 {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
-                {"write_cursor_offset": 0x08, "unread_counter_offset": 0x0C, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
+                {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1},
             ],
         },
         record_parser=RecordParser.CLASSIC_VITAL_14,

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -352,6 +352,27 @@ def test_the_cccd_switch_carries_the_two_settings_that_shipped_with_it():
     assert off.peer_closes_session_sec == 0.0
 
 
+def test_every_two_user_profile_reads_user2_from_the_same_offset():
+    """2인 프로파일의 user2 커서는 예외 없이 0x02다.
+
+    인덱스 필드는 2바이트이므로 user1이 0x00이면 user2는 0x02다. HEM-7155T-MW3만
+    0x08을 쓰고 있었는데, 그 자리는 #67 캡처에서 user1이 측정할 때마다 올라간다.
+    """
+    from custom_components.omron.omron_ble.device_catalog import (
+        CANONICAL_DEVICE_PROFILES,
+    )
+
+    for name, config in CANONICAL_DEVICE_PROFILES.items():
+        layout = config.index_pointer_layout or {}
+        users = layout.get("users") or []
+        if len(users) < 2:
+            continue
+        assert users[0]["write_cursor_offset"] == 0x00, name
+        assert users[1]["write_cursor_offset"] == 0x02, name
+        assert users[0]["unread_counter_offset"] == 0x04, name
+        assert users[1]["unread_counter_offset"] == 0x06, name
+
+
 def test_the_peer_close_window_covers_the_captured_delay():
     """폰 캡처에서 커프는 마지막 읽기 약 3초 뒤에 끊는다 — 여유가 있어야 한다."""
     assert get_device_config("HEM-7386T1").peer_closes_session_sec >= 3.0

--- a/tests/test_empty_user_clear_value.py
+++ b/tests/test_empty_user_clear_value.py
@@ -21,7 +21,7 @@ class TestEmptyUserClearValue:
                 "endianness": "little",
                 "users": [
                     {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1, "clear_value": 0x8000},
-                    {"write_cursor_offset": 0x08, "unread_counter_offset": 0x0C, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1, "clear_value": 0x8000},
+                    {"write_cursor_offset": 0x02, "unread_counter_offset": 0x06, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 59, "slot_index_bias": -1, "clear_value": 0x8000},
                 ],
             },
         )
@@ -32,10 +32,10 @@ class TestEmptyUserClearValue:
         # User 1: cursor = 0x0004 (slot 3), User 2: cursor = 0x8000 (clear_value, no records)
         # In little-endian:
         # offset 0x00: 04 00 ... (cursor 4)
-        # offset 0x08: 00 80 ... (cursor 0x8000)
+        # offset 0x02: 00 80 ... (cursor 0x8000)
         index_bytes = bytearray(16)
         index_bytes[0:2] = b"\x04\x00"
-        index_bytes[8:10] = b"\x00\x80"
+        index_bytes[2:4] = b"\x00\x80"
 
         read_calls = []
 


### PR DESCRIPTION
`HEM-7155T-MW3` was the only two-user profile in the catalog reading user 2 from
`0x08`/`0x0C`. The other eighteen all use `0x02`/`0x06`.

```
HEM-7155T-MW3    WLD3/4   u1(cur=0x00,unr=0x04)  u2(cur=0x08,unr=0x0C)
the other 18              u1(cur=0x00,unr=0x04)  u2(cur=0x02,unr=0x06)
```

## Why 0x08 is wrong

The comment defending it read:

> user2 cursor at 0x08 (NOT 0x02 — that offset lands in the high half of user1's
> word and reads the 0x80 flag)

That treats the entries as 4-byte fields. `_get_latest_via_index` reads two
(`index_bytes[off:off + 2]`), so `0x02` is user 2's own field, not the high half of
user 1's.

Decoding the index block across the four app sessions in the #67 HCI capture
(HEM-7155T-MW3, user 1 only):

| session | 0x00 | 0x02 | 0x04 | 0x08 | user 1 measured |
| --- | --- | --- | --- | --- | --- |
| 1 | 13 | `0x8000` | 13 | 30 | |
| 2 | 14 | `0x8000` | 1 | 31 | yes |
| 3 | 14 | `0x8000` | 0 | 31 | |
| 4 | 15 | `0x8000` | 1 | 32 | yes |

`0x08` goes up whenever **user 1** measures, so it cannot be user 2's cursor. The
`0x8000` at `0x02` that the old comment read as a stray flag is exactly the
`clear_value` this code already understands as "user 2 has never recorded" — correct
for that cuff.

Confirmed the other way on a BP5465 (`HEM-7386T1`, which already uses `0x02`), from
the debug logs attached to #91: `0x02` = 2 resolves to slot 1, and slot 1 parses as a
genuine user 2 reading.

## Effect

Only HEM-7155T-MW3 / HEM-7155T_ESL1 (#67). With a second user in use it read a slot
that follows user 1's measurement count instead of user 2's own cursor. Single-user
cuffs were unaffected: `0x08` pointed at an unwritten slot, which the all-`0xFF`
heuristic already reported as empty.

## Tests

Added `test_every_two_user_profile_reads_user2_from_the_same_offset` so the layout
cannot drift again, and moved the inline fixture in `test_empty_user_clear_value.py`
onto the real offsets — it names HEM-7155T-MW3 and carried the old ones.

`pytest tests/` — 234 passed. The two `test_bluez_agent.py` failures reproduce on a
clean `master`; they are a dbus_fast/Python 3.14 problem in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)