### PR TITLE
feat: put the whole HEM-7188T1 family on the secure session

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ A custom integration for Home Assistant to connect and poll data directly from O
 | **HEM-7146T2** | X2 Smart+ | Upper Arm | ✅ |
 | **HEM-7151T** | BP5250/M3 Comfort | Upper Arm | ✅ |
 | **HEM-7155T** | BP7350/M4 Intelli IT | Upper Arm | ✅ |
-| **HEM-7188T1** | X2+ Connect | Upper Arm | ✅ |
+| **HEM-7188T1** | M2+ / X2+ Connect | Upper Arm | ✅ |
 | **HEM-716BT2** | BP5255/M4 Smart | Upper Arm | ✅ |
 | **HEM-7320T** | BP7450/M7 Intelli IT | Upper Arm | ✅ |
 | **HEM-7322T** | BP786/M6 Intelli IT | Upper Arm | ✅ |

--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1210,20 +1210,27 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7388T1-AJF3",
         ),
     ),
-    # HEM-7188T1 / HEM-7183T1 family ("X2+ Connect" / "M2+" etc.) — dedicated single-user profile
-    # with WLD4.0 transport (ConnectType.WLD4_0) and 30-slot 16-byte record
-    # layout at 0x01C4 with index pointer layout at 0x0010.
-    # Operationally uses token-key transport (UnlockMode.TOKEN_KEY): an
-    # application-layer ECDH secure session (0x70 0x01) was tried, but real
-    # devices reject the pairing request with error frame 0xff26, while the
-    # plaintext token-key path reads real measurement values. Revisit
-    # unlock_mode=SECURE_SESSION once the ECDH rejection is understood.
+    # HEM-7188T1 / HEM-7183T1 family ("M2+" / "X2+") — single-user WLD4.0,
+    # 30 slots of 16 bytes at 0x01C4, index block at 0x0010.
+    #
+    # One profile on the secure session. Token-key reads inside the -P- window
+    # and every reconnect after it is refused (#24, discussions#119). The ECDH
+    # path is verified end-to-end on the LEO: pairing, records over a resumed
+    # credential, 9/9 unattended polls across two proxies (#92). The LE and the
+    # HEM-7183T1 variants are untested on it.
+    #
+    # No explicit Pair(): the cuff raises its own Security Request and a
+    # registered agent answers it.
     "HEM-7188T1": DeviceConfig(
-        **_MODERN_OS_BONDING_BASE,
+        parent_service_uuid=MODERN_STACK_PARENT_SERVICE_UUID,
+        rx_channel_uuids=["49123040-aee8-11e1-a74d-0002a5d5c51b"],
+        tx_channel_uuids=["db5b55e0-aee7-11e1-965e-0002a5d5c51b"],
+        host_pairing_mode=HostPairingMode.NONE,
+        register_pairing_agent=True,
         model="HEM-7188T1",
         connect_type=ConnectType.WLD4_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
-        unlock_mode=UnlockMode.TOKEN_KEY,
+        unlock_mode=UnlockMode.SECURE_SESSION,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4],
         per_user_records_count=[30],
@@ -1248,55 +1255,8 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
             "HEM-7183T1_FLIN",
             "HEM-7183T1_LAP",
             "HEM-7188T1-LE",
+            "HEM-7188T1-LEO",
         ),
-    ),
-    # HEM-7188T1-LEO ("X2+ Connect") — the same hardware as the HEM-7188T1
-    # profile above, on the experimental secure-session transport.
-    #
-    # The token-key profile reads real values inside the -P- window but every
-    # ordinary reconnect afterwards is refused (#24). What works on this model
-    # is the application-layer ECDH session: authenticate, initialize with a
-    # close the device accepts, keep the credential it leaves behind, and
-    # resume with that credential on later connections. That path was blocked
-    # by error frame 0xff26 until the secure envelope was corrected (5-byte
-    # transport header, CCM nonce tail = peer contribution + host
-    # contribution); hardware-verified on Linux/BlueZ and macOS by the #24
-    # reporter, through pairing plus a saved-credential reconnect from a
-    # separate process after the display had turned off.
-    #
-    # Verified there for authentication and a metadata read, not yet for
-    # measurement records over a resumed session.
-    #
-    # No explicit Pair(): the cuff raises its own Security Request and a
-    # registered agent answers it. Only this model id -- the HEM-7183T1
-    # variants stay on the token-key profile until someone tests them.
-    "HEM-7188T1-LEO": DeviceConfig(
-        parent_service_uuid=MODERN_STACK_PARENT_SERVICE_UUID,
-        rx_channel_uuids=["49123040-aee8-11e1-a74d-0002a5d5c51b"],
-        tx_channel_uuids=["db5b55e0-aee7-11e1-965e-0002a5d5c51b"],
-        host_pairing_mode=HostPairingMode.NONE,
-        register_pairing_agent=True,
-        model="HEM-7188T1-LEO",
-        connect_type=ConnectType.WLD4_0,
-        keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
-        unlock_mode=UnlockMode.SECURE_SESSION,
-        endianness=Endianness.LITTLE,
-        user_start_addresses=[0x01C4],
-        per_user_records_count=[30],
-        record_byte_size=0x10,
-        transmission_block_size=0x38,
-        settings_read_address=0x0010,
-        settings_write_address=0x0054,
-        settings_time_sync_bytes=[0x2C, 0x3C],
-        time_sync_layout=TimeSyncLayout.AT_8,
-        index_pointer_layout={
-            "index_region_byte_size": 0x18,
-            "endianness": "little",
-            "users": [
-                {"write_cursor_offset": 0x00, "unread_counter_offset": 0x04, "write_cursor_mask": 0xFF, "slot_index_min": 0, "slot_index_max": 29, "slot_index_bias": -1},
-            ],
-        },
-        record_parser=RecordParser.CLASSIC_VITAL_14,
     ),
     # HEM-716BT2 family (30-slot variant of HEM-7142T2 / WLD1.0 stack)
     "HEM-716BT2": DeviceConfig(

--- a/tests/test_devices.py
+++ b/tests/test_devices.py
@@ -14,18 +14,24 @@ from custom_components.omron.omron_ble.devices import (
 class TestCatalogResolution:
     """카탈로그 변이(equivalent_model_ids) -> 캐노니컬 프로파일 매핑."""
 
-    def test_hem7188t1_leo_resolves_to_own_profile(self):
-        # HEM-7188T1-LEO ("X2+ Connect") has its own profile on the secure
-        # session transport (#24): the token-key path reads values inside the
-        # -P- window but every reconnect after it is refused. The HEM-7183T1
-        # variants share the hardware but not the testing, so they stay on the
-        # token-key profile.
-        assert resolve_profile_model_id("HEM-7188T1-LEO") == "HEM-7188T1-LEO"
-        assert resolve_profile_model_id("HEM-7183T1-AP") == "HEM-7188T1"
-        assert resolve_profile_model_id("HEM-7183T1_FLIN") == "HEM-7188T1"
-        assert get_device_config("HEM-7183T1-AP").unlock_mode.value == "token_key"
-        cfg = get_device_config("HEM-7188T1-LEO")
-        assert cfg.model == "HEM-7188T1-LEO"
+    def test_the_whole_7188t1_family_shares_the_secure_session_profile(self):
+        """7188T1 계열은 프로파일 하나로 묶여 secure session을 탄다.
+
+        토큰키는 -P- 창 안에서만 읽히고 이후 재접속이 거부된다 (#24,
+        discussions#119). 메모리 레이아웃은 원래부터 같았다.
+        """
+        for variant in (
+            "HEM-7188T1-LE",
+            "HEM-7188T1-LEO",
+            "HEM-7183T1-AP",
+            "HEM-7183T1_FLIN",
+        ):
+            assert resolve_profile_model_id(variant) == "HEM-7188T1", variant
+
+        # Config entries created before the merge still name the LEO.
+        assert "HEM-7188T1-LEO" in get_supported_models()
+
+        cfg = get_device_config("HEM-7188T1")
         assert cfg.unlock_mode.value == "secure_session"
         # No explicit Pair(); the cuff drives security and an agent answers it.
         assert cfg.host_pairing_mode.value == "none"


### PR DESCRIPTION
`HEM-7188T1` and `HEM-7188T1-LEO` were two profiles for one family. Every field
except the way in was already identical — `WLD4.0`, `0x01C4`, 30 slots of 16 bytes,
settings at `0x0010`/`0x0054`, time sync `[0x2C, 0x3C]` `AT_8`, index block `0x18`,
`CLASSIC_VITAL_14`. The catalog said as much: *"the same hardware as the HEM-7188T1
profile above"*.

This collapses them into `HEM-7188T1` on the secure session and folds
`HEM-7188T1-LEO` into `equivalent_model_ids`.

## The secure session is proven

The old comment said the ECDH path was verified "for authentication and a metadata
read, not yet for measurement records over a resumed session". That has been stale
since 2.9.0 — [#92](https://github.com/eigger/hass-omron/issues/92#issuecomment-5559525215)
covers exactly the part it called out:

- fresh pairing through the real integration, `User1 [HEM-7188T1-LEO] slot=11 parsed:
  sys=125 dia=82 bpm=65`
- 9 connections, 9 successes, every reconnect resuming the saved credential and
  skipping `f081`, across **two different proxies**
- two new measurements picked up by unattended scheduled polls, cuff untouched

The comment now says that instead.

## Why the rest of the family should come along

The token-key half does not work. In
[discussions#119](https://github.com/eigger/hass-omron/discussions/119) a
HEM-7188T1-LE (`M2+ Connect`) unlocks fine while pairing and is gone on every
reconnect after:

```
22:55:34  Token unlock OK (nonce=d7fedf54)          <- inside the -P- window
22:57:51  token unlock RX pre-notify prime skipped: [org.bluez.Error.NotConnected]
```

That is the sentence the LEO profile was created for (#24), reproduced on a second
model id. The reporter tested 2.7.1 through 2.8.0-beta2 with no change.

The old comment held the family back "until someone tests them". Nobody has, and
meanwhile they get nothing at all from the token-key path — there is no working
behaviour left to protect, and the path they are moving to is now the proven one.
If a variant turns out to need token-key after all, splitting it back out is one
entry in `equivalent_model_ids`.

## Migration

`HEM-7188T1-LEO` stays selectable — `get_supported_models()` is canonical keys ∪
variant keys, so existing config entries naming it keep resolving, now to the merged
profile with the same settings. A test pins that.

Also fixed README, which listed `HEM-7188T1` as "X2+ Connect" while `X2+` resolves to
the LEO and `M2+` to the LE; it now reads "M2+ / X2+ Connect".

## Tests

Replaced `test_hem7188t1_leo_resolves_to_own_profile` with
`test_the_whole_7188t1_family_shares_the_secure_session_profile`.

`pytest tests/` — 234 passed. The two `test_bluez_agent.py` failures reproduce on a
clean `master`; they are a dbus_fast/Python 3.14 problem in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)