### PR TITLE
Fix HEM-7386T1/BP5465 pairing registration persistence

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1195,6 +1195,11 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
         unlock_mode=UnlockMode.TOKEN_KEY,
         connect_settle_attempts=_WLD3_SINGLE_CONNECT_ATTEMPT,
+        # The cuff accepts the bond a fresh pairing makes and then refuses to
+        # resume it (HCI 0x06) unless that session also wrote the settings
+        # mirror the app writes before closing. Verified on a BP5465 over local
+        # BlueZ, through a power cycle (#175).
+        pairing_registration_write=True,
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0E4C],
         per_user_records_count=[100, 100],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -154,6 +154,10 @@ class DeviceConfig:
     # security with its own Security Request: BlueZ 5.72+ leaves the Just
     # Works confirmation unanswered when no agent is registered.
     register_pairing_agent: bool = False
+    # Write the app's end-of-pairing settings mirror (index with the unread
+    # counter cleared, one transfer slot, stamped clock) on the pairing session.
+    # WLD3.0 token-key cuffs refuse to resume the bond without it (#175).
+    pairing_registration_write: bool = False
 
     @property
     def pair_on_connect(self) -> bool:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -18,7 +18,12 @@ from .const import (
     SERVICE_CHANGED_UUID,
     UNLOCK_CHARACTERISTIC_UUID,
 )
-from .devices import DeviceConfig, HostPairingMode, UnlockMode
+from .devices import (
+    DeviceConfig,
+    HostPairingMode,
+    UnlockMode,
+    resolve_profile_model_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -716,6 +721,10 @@ class OmronDeviceSession:
         self._channel_fragments: list[bytes | None] = [None] * 4
         self._notify_handle_to_channel: dict[int, int] = {}
         self._memory_session_active = False
+        # The HEM-7386T1 family needs one pairing-only registration commit
+        # before the first bonded session closes. Keep this per-session guard
+        # so the operation cannot run more than once on the pairing link.
+        self._hem_7386t1_pairing_registration_done = False
         self._unlocked = False
         self._secure_session = None
         # Swappable handler for the unlock characteristic notifications. The
@@ -1524,12 +1533,85 @@ class OmronDeviceSession:
             await self._unsubscribe_notify_channels(force=True)
             raise
 
+    async def _finalize_hem_7386t1_pairing_registration(self) -> None:
+        """Commit HEM-7386T1 pairing registration before the first close.
+
+        OMRON Connect performs two pairing-only EEPROM writes on the BP5465
+        (HEM-7382T1-AZAZ) before ending the initial bonded session: a 38-byte
+        registration block at 0x0058 followed by a 16-byte clock/state block
+        at 0x0088. Without this pairing finalization, the cuff can reject the
+        stored bond on the next connection with HCI status 0x06 (PIN or Key
+        Missing). Ordinary retained-bond sessions must not repeat these writes.
+        """
+        if self._hem_7386t1_pairing_registration_done or not self._pairing_session:
+            return
+        if resolve_profile_model_id(self._config.model) != "HEM-7386T1":
+            return
+
+        self._require_connected("finalize_hem_7386t1_pairing_registration")
+        if not self._memory_session_active:
+            raise ConnectionError(
+                "HEM-7386T1 pairing finalization requires an open memory session"
+            )
+
+        if (
+            self._config.settings_read_address != 0x0010
+            or self._config.settings_write_address != 0x0058
+        ):
+            raise ConnectionError(
+                "Unexpected HEM-7386T1 settings layout during pairing finalization: "
+                f"read={self._config.settings_read_address!r} "
+                f"write={self._config.settings_write_address!r}"
+            )
+
+        # Pairing registration block. OMRON Connect reads 48 bytes from 0x0010,
+        # transforms the first 38 bytes, then writes them as one block to 0x0058.
+        head_read = await self.read_memory_range(
+            0x0010, 0x30, self._config.transmission_block_size
+        )
+        if len(head_read) != 0x30:
+            raise ConnectionError(
+                "HEM-7386T1 pairing finalization expected 48 settings bytes, "
+                f"got {len(head_read)}"
+            )
+        head_write = bytearray(head_read[:0x26])
+        head_write[4] = 0x00
+        head_write[5] = 0x80
+        head_write[17] = 0x80
+        head_write[32] = (head_write[32] + 1) & 0xFF
+        head_write[36] = (head_write[36] + 1) & 0xFF
+        await self.write_memory_range(0x0058, head_write, block_size=len(head_write))
+
+        # Pairing clock/state block. OMRON Connect reads 24 bytes from 0x0040,
+        # updates the first 16 bytes, then writes them as one block to 0x0088.
+        clock_read = await self.read_memory_range(
+            0x0040, 0x18, self._config.transmission_block_size
+        )
+        if len(clock_read) != 0x18:
+            raise ConnectionError(
+                "HEM-7386T1 pairing finalization expected 24 clock/state bytes, "
+                f"got {len(clock_read)}"
+            )
+        clock_write = bytearray(clock_read[:0x10])
+        now = dt.datetime.now().astimezone()
+        clock_write[4] |= 0x01
+        clock_write[8:14] = bytes(
+            (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
+        )
+        clock_write[14] = sum(clock_write[:14]) & 0xFF
+        await self.write_memory_range(0x0088, clock_write, block_size=len(clock_write))
+
+        self._hem_7386t1_pairing_registration_done = True
+
     async def close_memory_session(self) -> None:
         """End a data readout session (no-op if not open)."""
         if not self._memory_session_active:
             return
 
         try:
+            # HEM-7386T1-family cuffs commit pairing registration before the
+            # first 0x080f close; retained-bond sessions skip this operation.
+            await self._finalize_hem_7386t1_pairing_registration()
             stop_cmd = bytearray.fromhex("080f000000000007")
             await self._write_command_and_wait_reply(stop_cmd)
             if self._last_reply_packet_type != bytearray.fromhex("8f00"):

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -18,16 +18,16 @@ from .const import (
     SERVICE_CHANGED_UUID,
     UNLOCK_CHARACTERISTIC_UUID,
 )
-from .devices import (
-    DeviceConfig,
-    HostPairingMode,
-    UnlockMode,
-    resolve_profile_model_id,
-)
+from .devices import DeviceConfig, HostPairingMode, UnlockMode
 
 _LOGGER = logging.getLogger(__name__)
 
 # BLE memory-protocol pacing (extra margin for weak RF / busy stacks).
+# The per-transfer slot that follows the index region in the settings mirror
+# (#175 BP5465 capture; same shape in the #67 HEM-7155T-MW3 capture).
+_REGISTRATION_SLOT_SIZE: int = 10
+_REGISTRATION_SLOT_COUNTER_OFFSETS: tuple[int, ...] = (4, 8)
+_REGISTRATION_INDEX_FLAG_OFFSET: int = 0x11
 _MEMORY_PROTOCOL_REPLY_TIMEOUT_SEC: float = 5.0
 _MEMORY_PROTOCOL_TX_MAX_RETRIES: int = 4
 _MEMORY_PROTOCOL_RETRY_BACKOFF_SEC: float = 0.25
@@ -721,10 +721,9 @@ class OmronDeviceSession:
         self._channel_fragments: list[bytes | None] = [None] * 4
         self._notify_handle_to_channel: dict[int, int] = {}
         self._memory_session_active = False
-        # The HEM-7386T1 family needs one pairing-only registration commit
-        # before the first bonded session closes. Keep this per-session guard
-        # so the operation cannot run more than once on the pairing link.
-        self._hem_7386t1_pairing_registration_done = False
+        # A pairing session commits its registration once; a retried readout on
+        # the same link must not bump the cuff's transfer counters twice.
+        self._pairing_registration_done = False
         self._unlocked = False
         self._secure_session = None
         # Swappable handler for the unlock characteristic notifications. The
@@ -1533,75 +1532,100 @@ class OmronDeviceSession:
             await self._unsubscribe_notify_channels(force=True)
             raise
 
-    async def _finalize_hem_7386t1_pairing_registration(self) -> None:
-        """Commit HEM-7386T1 pairing registration before the first close.
+    async def commit_pairing_registration(self) -> bool:
+        """Write the settings mirror the app writes at the end of a pairing.
 
-        OMRON Connect performs two pairing-only EEPROM writes on the BP5465
-        (HEM-7382T1-AZAZ) before ending the initial bonded session: a 38-byte
-        registration block at 0x0058 followed by a 16-byte clock/state block
-        at 0x0088. Without this pairing finalization, the cuff can reject the
-        stored bond on the next connection with HCI status 0x06 (PIN or Key
-        Missing). Ordinary retained-bond sessions must not repeat these writes.
+        A WLD3.0 cuff on the token-key transport accepts the bond it just made
+        and then refuses to resume it on the next connection -- HCI 0x06, PIN
+        or Key Missing -- unless the pairing session also wrote its mirror:
+        the index region with the unread counter cleared plus one 10-byte
+        transfer slot, and the clock record stamped with the current time.
+        The official app does both before its 080f close; hardware-verified
+        on a BP5465 / HEM-7382T1-AZAZ over local BlueZ, through a power cycle
+        (#175). The same slot structure -- two counters at +4 and +8 that step
+        once per transfer -- is what the #67 phone capture of an HEM-7155T-MW3
+        shows, so the layout is read off the profile rather than pinned to a
+        model.
+
+        Pairing sessions only, once per link, and after the records have been
+        read: the unread counter is cleared here. Returns whether it wrote.
+        Never raises -- the close that follows matters more than this write,
+        and a retained-bond session that ends without it is still a working
+        session. The caller logs.
         """
-        if self._hem_7386t1_pairing_registration_done or not self._pairing_session:
-            return
-        if resolve_profile_model_id(self._config.model) != "HEM-7386T1":
-            return
-
-        self._require_connected("finalize_hem_7386t1_pairing_registration")
+        cfg = self._config
+        if (
+            not cfg.pairing_registration_write
+            or not self._pairing_session
+            or self._pairing_registration_done
+        ):
+            return False
+        self._require_connected("commit_pairing_registration")
         if not self._memory_session_active:
             raise ConnectionError(
-                "HEM-7386T1 pairing finalization requires an open memory session"
+                "Pairing registration needs an open memory session"
             )
+        from .settings_mirror import SettingsMirrorLayout, clock_block
 
-        if (
-            self._config.settings_read_address != 0x0010
-            or self._config.settings_write_address != 0x0058
-        ):
+        layout = SettingsMirrorLayout(cfg)
+        index_size = layout.head_write_size
+        head_size = index_size + _REGISTRATION_SLOT_SIZE
+        if layout.head_read_size < head_size:
             raise ConnectionError(
-                "Unexpected HEM-7386T1 settings layout during pairing finalization: "
-                f"read={self._config.settings_read_address!r} "
-                f"write={self._config.settings_write_address!r}"
+                f"Settings region of {cfg.model} is {layout.head_read_size} bytes; "
+                f"the registration block needs {head_size}"
             )
+        users = (cfg.index_pointer_layout or {}).get("users") or ()
+        if not users:
+            raise ConnectionError(f"{cfg.model} has no index layout to clear")
 
-        # Pairing registration block. OMRON Connect reads 48 bytes from 0x0010,
-        # transforms the first 38 bytes, then writes them as one block to 0x0058.
-        head_read = await self.read_memory_range(
-            0x0010, 0x30, self._config.transmission_block_size
+        head = await self.read_memory_range(
+            layout.head_read_address, layout.head_read_size, cfg.transmission_block_size
         )
-        if len(head_read) != 0x30:
+        if len(head) != layout.head_read_size:
             raise ConnectionError(
-                "HEM-7386T1 pairing finalization expected 48 settings bytes, "
-                f"got {len(head_read)}"
+                f"Short settings read for registration: {len(head)} of "
+                f"{layout.head_read_size}"
             )
-        head_write = bytearray(head_read[:0x26])
-        head_write[4] = 0x00
-        head_write[5] = 0x80
-        head_write[17] = 0x80
-        head_write[32] = (head_write[32] + 1) & 0xFF
-        head_write[36] = (head_write[36] + 1) & 0xFF
-        await self.write_memory_range(0x0058, head_write, block_size=len(head_write))
-
-        # Pairing clock/state block. OMRON Connect reads 24 bytes from 0x0040,
-        # updates the first 16 bytes, then writes them as one block to 0x0088.
-        clock_read = await self.read_memory_range(
-            0x0040, 0x18, self._config.transmission_block_size
+        block = bytearray(head[:head_size])
+        # User 1's unread counter, cleared to the 0x8000 "nothing pending"
+        # marker the cuff itself uses (the phone does the same every transfer).
+        unread = int(users[0]["unread_counter_offset"])
+        block[unread : unread + 2] = (0x8000).to_bytes(2, "little")
+        # As captured, meaning unknown: byte 0x11 of the index region is set
+        # to 0x80 in the app's write. Reproduced rather than reasoned about.
+        block[_REGISTRATION_INDEX_FLAG_OFFSET] = 0x80
+        # The transfer slot's two counters step once per transfer.
+        for offset in _REGISTRATION_SLOT_COUNTER_OFFSETS:
+            at = index_size + offset
+            block[at] = (block[at] + 1) & 0xFF
+        await self.write_memory_range(
+            layout.head_write_address, block, block_size=len(block)
         )
-        if len(clock_read) != 0x18:
+
+        tail = await self.read_memory_range(
+            layout.clock_read_address, layout.clock_read_size, cfg.transmission_block_size
+        )
+        if len(tail) < layout.clock_write_size:
             raise ConnectionError(
-                "HEM-7386T1 pairing finalization expected 24 clock/state bytes, "
-                f"got {len(clock_read)}"
+                f"Short clock read for registration: {len(tail)} of "
+                f"{layout.clock_write_size}"
             )
-        clock_write = bytearray(clock_read[:0x10])
-        now = dt.datetime.now().astimezone()
-        clock_write[4] |= 0x01
-        clock_write[8:14] = bytes(
-            (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
+        stamped = clock_block(
+            tail, dt.datetime.now().astimezone(), layout.clock_write_size
         )
-        clock_write[14] = sum(clock_write[:14]) & 0xFF
-        await self.write_memory_range(0x0088, clock_write, block_size=len(clock_write))
-
-        self._hem_7386t1_pairing_registration_done = True
+        await self.write_memory_range(
+            layout.clock_write_address, bytearray(stamped), block_size=len(stamped)
+        )
+        self._pairing_registration_done = True
+        _LOGGER.info(
+            "%s: pairing registration written (settings mirror 0x%04X, clock "
+            "0x%04X)",
+            cfg.model,
+            layout.head_write_address,
+            layout.clock_write_address,
+        )
+        return True
 
     async def close_memory_session(self) -> None:
         """End a data readout session (no-op if not open)."""
@@ -1609,9 +1633,6 @@ class OmronDeviceSession:
             return
 
         try:
-            # HEM-7386T1-family cuffs commit pairing registration before the
-            # first 0x080f close; retained-bond sessions skip this operation.
-            await self._finalize_hem_7386t1_pairing_registration()
             stop_cmd = bytearray.fromhex("080f000000000007")
             await self._write_command_and_wait_reply(stop_cmd)
             if self._last_reply_packet_type != bytearray.fromhex("8f00"):

--- a/custom_components/omron/omron_ble/parser.py
+++ b/custom_components/omron/omron_ble/parser.py
@@ -1066,6 +1066,21 @@ class OmronBluetoothDeviceData(BluetoothData):
         except Exception as exc:
             _LOGGER.debug("Failed to read Model Number: %s", exc)
 
+        # After the records, before the close: the pairing session's one
+        # registration write, on the profiles that need it. A failure here is
+        # logged and the session still closes normally -- the close is what
+        # keeps the cuff usable, and the user can pair again.
+        if memory_session_active:
+            try:
+                await session.commit_pairing_registration()
+            except Exception as exc:
+                _LOGGER.warning(
+                    "Pairing registration for %s failed; the next reconnect may "
+                    "be refused and need another pairing: %s",
+                    ble_device.address,
+                    exc,
+                )
+
     async def async_poll(
         self, ble_device: BLEDevice, preconnected_session: OmronDeviceSession | None = None
     ) -> SensorUpdate:

--- a/custom_components/omron/omron_ble/secure_flow.py
+++ b/custom_components/omron/omron_ble/secure_flow.py
@@ -16,13 +16,18 @@ from datetime import datetime
 import logging
 import secrets
 
-from .devices import DeviceConfig, UnlockMode
+from .devices import UnlockMode
 from .omron_driver import (
     _SECURE_HANDSHAKE_WAIT_TIMEOUT_SEC,
     UNLOCK_CHARACTERISTIC_UUID,
     _secure_error_frame_code,
 )
 from .secure_session import SecureSession
+from .settings_mirror import SettingsMirrorLayout, clock_block
+
+# The secure flow's initialization is the same mirror write; kept under its
+# old name so callers and tests importing it from here keep working.
+SecureInitLayout = SettingsMirrorLayout
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,54 +41,6 @@ _PRE_HANDSHAKE_DIS_UUIDS = (
 )
 # System authentication, sent encrypted once the session key exists.
 _SYSTEM_AUTH_REQUEST = b"\x20\x01\x00" + bytes(17)
-
-
-class SecureInitLayout:
-    """Addresses the initialization step copies, all derived from the profile.
-
-    The device-owned settings region is mirrored into the write region, and the
-    clock record inside it is stamped with the current time. ``settings_read_address``,
-    ``settings_write_address``, ``settings_time_sync_bytes`` and the index region
-    size already describe both regions, so no profile needs new fields for this.
-    """
-
-    def __init__(self, config: DeviceConfig) -> None:
-        read_addr = config.settings_read_address
-        write_addr = config.settings_write_address
-        time_range = config.settings_time_sync_bytes
-        index_size = int(
-            (config.index_pointer_layout or {}).get("index_region_byte_size", 0)
-        )
-        if (
-            read_addr is None
-            or write_addr is None
-            or not time_range
-            or len(time_range) != 2
-            or index_size <= 0
-        ):
-            raise ValueError(
-                f"Profile {config.model} cannot describe a secure initialization: "
-                "settings addresses, time-sync range and index region size are all required"
-            )
-        clock_size = time_range[1] - time_range[0]
-        if clock_size <= 0:
-            raise ValueError(
-                f"Profile {config.model} has an empty time-sync range {time_range}"
-            )
-        self.head_read_address = read_addr
-        # Everything ahead of the clock record.
-        self.head_read_size = time_range[0]
-        # Only the index region is mirrored; the rest is device-owned.
-        self.head_write_address = write_addr
-        self.head_write_size = index_size
-        self.clock_read_address = read_addr + time_range[0]
-        # Never shorter than what gets written back, or the record cannot be
-        # built at all -- and the head write has already landed by then. The
-        # reference reads past the record on the one profile where the index
-        # region is the larger of the two, so keep that read length.
-        self.clock_read_size = max(clock_size, index_size)
-        self.clock_write_address = write_addr + time_range[0]
-        self.clock_write_size = clock_size
 
 
 async def prepare_secure_token(session, timeout: float) -> None:
@@ -132,30 +89,6 @@ async def prepare_secure_token(session, timeout: float) -> None:
     )
     await asyncio.wait_for(accepted.wait(), timeout)
     _LOGGER.debug("Secure session: token accepted")
-
-
-def clock_block(tail: bytes, now: datetime, size: int) -> bytes:
-    """Stamp the clock record: set its flag, write the time, fix the checksum.
-
-    ``tail`` may be read longer than the record; only the first ``size`` bytes
-    are written back. The checksum is the additive sum of everything ahead of
-    it and sits in the second-to-last byte, so it moves with ``size`` rather
-    than living at a fixed offset -- verified on every 16-byte sample in the
-    #67 and #91 captures, where byte 14 holds the sum of bytes 0..13.
-    """
-    if len(tail) < size or size < 16 or not 2000 <= now.year <= 2255:
-        raise ValueError(
-            f"Invalid secure initialization clock record (size={size}, "
-            f"available={len(tail)}) or year {now.year}"
-        )
-    block = bytearray(tail[:size])
-    checksum_at = size - 2
-    block[4] |= 1
-    block[8:14] = bytes(
-        (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
-    )
-    block[checksum_at] = sum(block[:checksum_at]) & 0xFF
-    return bytes(block)
 
 
 async def establish_secure_session(

--- a/custom_components/omron/omron_ble/settings_mirror.py
+++ b/custom_components/omron/omron_ble/settings_mirror.py
@@ -1,0 +1,93 @@
+"""The settings mirror a session writes back before it closes.
+
+Every OMRON memory-protocol cuff keeps a device-owned settings region and an
+app-maintained mirror of it at a fixed, model-specific offset. The official app
+refreshes the mirror at the end of a session: the index region (with the unread
+counters cleared), a per-transfer slot record, and the clock record stamped with
+the current time. Where and how much is entirely a property of the profile --
+``settings_read_address``, ``settings_write_address``,
+``settings_time_sync_bytes`` and the index region size already describe both
+regions -- so nothing here is written for one model.
+
+Two paths use this: the secure session (``secure_flow``), whose initialization
+is what earns its credential, and the token-key pairing commit
+(``OmronDeviceSession.commit_pairing_registration``), which a WLD3.0 cuff needs
+before it will resume the bond on the next connection (#175, #91).
+"""
+from __future__ import annotations
+
+from datetime import datetime
+
+from .devices import DeviceConfig
+
+
+class SettingsMirrorLayout:
+    """Addresses the mirror write copies, all derived from the profile.
+
+    The device-owned settings region is mirrored into the write region, and the
+    clock record inside it is stamped with the current time. ``settings_read_address``,
+    ``settings_write_address``, ``settings_time_sync_bytes`` and the index region
+    size already describe both regions, so no profile needs new fields for this.
+    """
+
+    def __init__(self, config: DeviceConfig) -> None:
+        read_addr = config.settings_read_address
+        write_addr = config.settings_write_address
+        time_range = config.settings_time_sync_bytes
+        index_size = int(
+            (config.index_pointer_layout or {}).get("index_region_byte_size", 0)
+        )
+        if (
+            read_addr is None
+            or write_addr is None
+            or not time_range
+            or len(time_range) != 2
+            or index_size <= 0
+        ):
+            raise ValueError(
+                f"Profile {config.model} cannot describe a secure initialization: "
+                "settings addresses, time-sync range and index region size are all required"
+            )
+        clock_size = time_range[1] - time_range[0]
+        if clock_size <= 0:
+            raise ValueError(
+                f"Profile {config.model} has an empty time-sync range {time_range}"
+            )
+        self.head_read_address = read_addr
+        # Everything ahead of the clock record.
+        self.head_read_size = time_range[0]
+        # Only the index region is mirrored; the rest is device-owned.
+        self.head_write_address = write_addr
+        self.head_write_size = index_size
+        self.clock_read_address = read_addr + time_range[0]
+        # Never shorter than what gets written back, or the record cannot be
+        # built at all -- and the head write has already landed by then. The
+        # reference reads past the record on the one profile where the index
+        # region is the larger of the two, so keep that read length.
+        self.clock_read_size = max(clock_size, index_size)
+        self.clock_write_address = write_addr + time_range[0]
+        self.clock_write_size = clock_size
+
+
+def clock_block(tail: bytes, now: datetime, size: int) -> bytes:
+    """Stamp the clock record: set its flag, write the time, fix the checksum.
+
+    ``tail`` may be read longer than the record; only the first ``size`` bytes
+    are written back. The checksum is the additive sum of everything ahead of
+    it and sits in the second-to-last byte, so it moves with ``size`` rather
+    than living at a fixed offset -- verified on every 16-byte sample in the
+    #67 and #91 captures, where byte 14 holds the sum of bytes 0..13.
+    """
+    if len(tail) < size or size < 16 or not 2000 <= now.year <= 2255:
+        raise ValueError(
+            f"Invalid secure initialization clock record (size={size}, "
+            f"available={len(tail)}) or year {now.year}"
+        )
+    block = bytearray(tail[:size])
+    checksum_at = size - 2
+    block[4] |= 1
+    block[8:14] = bytes(
+        (now.year - 2000, now.month, now.day, now.hour, now.minute, now.second)
+    )
+    block[checksum_at] = sum(block[:checksum_at]) & 0xFF
+    return bytes(block)

--- a/tests/test_pairing_registration.py
+++ b/tests/test_pairing_registration.py
@@ -1,0 +1,215 @@
+"""페어링 세션의 등록 쓰기 (#175, #91).
+
+WLD3.0 token-key 커프는 방금 만든 본드를 받아들이고도 다음 연결에서 재개를
+거부한다 (HCI 0x06). 페어링 세션이 앱과 같은 설정 미러를 써두면 재개된다:
+미읽음 카운터를 지운 인덱스 영역 + 10바이트 전송 슬롯 하나, 그리고 현재 시각을
+찍은 시계 레코드. BP5465 / 로컬 BlueZ 에서 전원 리셋을 거쳐 실기 검증됐다.
+
+여기서 고정하는 것:
+
+- 바이트 단위로 검증된 그 변환이 리팩터링으로 흘러가지 않게 (정확한 출력)
+- 주소가 모델이 아니라 프로파일에서 나오게
+- 페어링 세션에서만, 링크당 한 번만
+- ``close_memory_session`` 사이에 끼지 않게 — 080f 는 어떤 경우에도 나가야 한다
+- 호출 지점이 예외를 삼키게 — 등록 실패는 세션을 죽일 이유가 아니다
+
+conftest 가 homeassistant/bleak 를 MagicMock 으로 치환하므로 통합 계층은 AST 로,
+드라이버 메서드는 unbound 호출로 검사한다 (test_session_cccd_persistence.py 방식).
+"""
+import ast
+import asyncio
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.omron.omron_ble.devices import get_device_config
+from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
+from custom_components.omron.omron_ble.settings_mirror import (
+    SettingsMirrorLayout,
+    clock_block,
+)
+
+_COMPONENT = Path(__file__).resolve().parent.parent / "custom_components" / "omron"
+
+
+def _function(path: Path, name: str):
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"))):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and node.name == name:
+            return node
+    raise AssertionError(f"{name} 을(를) 찾지 못했다 — 이름을 바꿨다면 이 테스트도 갱신할 것")
+
+
+def _session(config, *, pairing=True, memory_active=True, memory=None):
+    """커프 EEPROM 을 흉내 내는 최소 세션: 읽으면 memory 를, 쓰면 기록을 남긴다."""
+    memory = memory if memory is not None else bytes(range(256)) * 16
+    writes: list[tuple[int, bytes]] = []
+
+    async def read_memory_range(address, size, block_size):
+        return memory[address : address + size]
+
+    async def write_memory_range(address, data, block_size):
+        writes.append((address, bytes(data)))
+
+    target = SimpleNamespace(
+        _config=config,
+        _pairing_session=pairing,
+        _pairing_registration_done=False,
+        _memory_session_active=memory_active,
+        _require_connected=lambda _what: None,
+        read_memory_range=read_memory_range,
+        write_memory_range=write_memory_range,
+        writes=writes,
+    )
+    return target
+
+
+def _commit(target):
+    return asyncio.run(OmronDeviceSession.commit_pairing_registration(target))
+
+
+class TestVerifiedBytes:
+    """#175 가 하드웨어에서 검증한 변환을 바이트 단위로 고정한다."""
+
+    def test_the_registration_block_matches_the_capture_transform(self):
+        cfg = get_device_config("HEM-7386T1")
+        memory = bytearray(0x400)
+        head = bytes(range(0x30))              # 0x0010 에서 읽히는 48바이트
+        memory[0x0010 : 0x0010 + 0x30] = head
+        target = _session(cfg, memory=bytes(memory))
+
+        assert _commit(target) is True
+        (head_addr, head_written), (clock_addr, clock_written) = target.writes
+
+        # #175 의 변환 그대로: [:0x26], [4]=0x00 [5]=0x80 [17]=0x80 [32]+=1 [36]+=1
+        expected = bytearray(head[:0x26])
+        expected[4] = 0x00
+        expected[5] = 0x80
+        expected[17] = 0x80
+        expected[32] = (expected[32] + 1) & 0xFF
+        expected[36] = (expected[36] + 1) & 0xFF
+        assert head_addr == 0x0058
+        assert head_written == bytes(expected)
+        assert clock_addr == 0x0088
+        assert len(clock_written) == 16
+
+    def test_the_slot_counters_wrap_at_a_byte(self):
+        cfg = get_device_config("HEM-7386T1")
+        memory = bytearray(0x400)
+        memory[0x0010 + 32] = 0xFF
+        memory[0x0010 + 36] = 0xFF
+        target = _session(cfg, memory=bytes(memory))
+        _commit(target)
+        _, head_written = target.writes[0]
+        assert head_written[32] == 0x00
+        assert head_written[36] == 0x00
+
+    def test_the_clock_block_is_the_shared_one(self):
+        """시계 블록 변환은 secure flow 와 같은 함수여야 한다 — 두 벌이면 갈라진다."""
+        cfg = get_device_config("HEM-7386T1")
+        target = _session(cfg)
+        _commit(target)
+        _, clock_written = target.writes[1]
+        # 플래그 비트, 6바이트 시각, 끝에서 두 번째 바이트의 가산 체크섬
+        assert clock_written[4] & 0x01
+        assert clock_written[14] == sum(clock_written[:14]) & 0xFF
+        now = datetime(2026, 9, 13, 8, 0, 0)
+        ref = clock_block(bytes(range(28)), now, 16)
+        assert ref[8:14] == bytes((26, 9, 13, 8, 0, 0))
+
+
+class TestDerivedFromTheProfile:
+    """주소가 상수로 굳어 있으면 다른 배치의 프로파일에서 엉뚱한 곳을 쓴다."""
+
+    def test_every_address_comes_from_the_catalog_fields(self):
+        cfg = get_device_config("HEM-7386T1")
+        layout = SettingsMirrorLayout(cfg)
+        assert layout.head_read_address == cfg.settings_read_address == 0x0010
+        assert layout.head_read_size == cfg.settings_time_sync_bytes[0] == 0x30
+        assert layout.head_write_address == cfg.settings_write_address == 0x0058
+        assert layout.clock_read_address == 0x0010 + 0x30 == 0x0040
+        assert layout.clock_write_address == 0x0058 + 0x30 == 0x0088
+        assert layout.clock_write_size == 0x40 - 0x30 == 16
+        # 38 = 인덱스 영역(0x1C) + 슬롯(10)
+        assert layout.head_write_size + 10 == 0x26
+
+    def test_a_shifted_profile_moves_the_writes_with_it(self):
+        cfg = SimpleNamespace(
+            model="synthetic",
+            pairing_registration_write=True,
+            settings_read_address=0x0100,
+            settings_write_address=0x0200,
+            settings_time_sync_bytes=[0x30, 0x40],
+            transmission_block_size=0x38,
+            index_pointer_layout={
+                "index_region_byte_size": 0x1C,
+                "users": [{"unread_counter_offset": 0x04}],
+            },
+        )
+        target = _session(cfg)
+        _commit(target)
+        assert [addr for addr, _ in target.writes] == [0x0200, 0x0230]
+
+    def test_the_driver_names_no_model(self):
+        source = (_COMPONENT / "omron_ble" / "omron_driver.py").read_text(encoding="utf-8")
+        assert "HEM-7386T1" not in source, (
+            "드라이버가 기종 이름으로 분기한다 — 프로파일 플래그로 표현할 것"
+        )
+        assert "resolve_profile_model_id" not in source
+
+    def test_the_flag_is_set_on_the_verified_family_only(self):
+        assert get_device_config("HEM-7386T1").pairing_registration_write is True
+        assert get_device_config("HEM-7382T1-AZAZ").pairing_registration_write is True
+        for other in ("HEM-7155T-MW3", "HEM-7380T1", "HEM-7188T1-LEO", "HEM-7142T2"):
+            assert get_device_config(other).pairing_registration_write is False, other
+
+
+class TestWhenItRuns:
+    def test_not_on_an_ordinary_session(self):
+        target = _session(get_device_config("HEM-7386T1"), pairing=False)
+        assert _commit(target) is False
+        assert target.writes == []
+
+    def test_not_on_a_profile_without_the_flag(self):
+        target = _session(get_device_config("HEM-7155T-MW3"))
+        assert _commit(target) is False
+        assert target.writes == []
+
+    def test_once_per_link(self):
+        """재시도된 readout 이 커프의 전송 카운터를 두 번 올리면 안 된다."""
+        target = _session(get_device_config("HEM-7386T1"))
+        assert _commit(target) is True
+        assert _commit(target) is False
+        assert len(target.writes) == 2
+
+    def test_needs_an_open_memory_session(self):
+        target = _session(get_device_config("HEM-7386T1"), memory_active=False)
+        with pytest.raises(ConnectionError, match="memory session"):
+            _commit(target)
+        assert target.writes == []
+
+
+class TestItNeverBlocksTheClose:
+    def test_close_memory_session_has_no_registration_hook(self):
+        """close 와 080f 사이에 무엇이 끼면, 그것이 실패할 때 080f 가 안 나간다."""
+        fn = _function(_COMPONENT / "omron_ble" / "omron_driver.py", "close_memory_session")
+        assert "registration" not in ast.unparse(fn).lower()
+
+    def test_the_call_site_swallows_failures(self):
+        fn = _function(_COMPONENT / "omron_ble" / "parser.py", "_poll_device_readout")
+        call = None
+        for node in ast.walk(fn):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "commit_pairing_registration"
+            ):
+                call = node
+        assert call is not None, "readout 이 등록을 커밋하지 않는다"
+        guarded = any(
+            isinstance(node, ast.Try)
+            and node.lineno <= call.lineno <= getattr(node, "end_lineno", node.lineno)
+            for node in ast.walk(fn)
+        )
+        assert guarded, "등록 실패가 폴을 통째로 실패시킨다"


### PR DESCRIPTION
## Summary

Fix pairing persistence for HEM-7386T1-family devices, specifically tested with the Omron BP5465 / HEM-7382T1-AZAZ.

## Problem

With upstream 2.9.3:

1. Fresh pairing succeeds.
2. The first subsequent retained-bond reconnect fails during link encryption.
3. The peripheral returns HCI status `0x06` (`PIN or Key Missing`).

The same behavior was reproduced after removing and recreating the BlueZ bond, ruling out a stale local bond.

## Investigation

A Samsung/Android HCI capture of a successful fresh pairing showed two additional application-level writes near the end of the pairing session:

- 38-byte write to `0x0058`
- 16-byte write to `0x0088`

followed by the normal `080f000000000007` session close.

The existing driver did not perform these registration/finalization writes.

## Fix

For the canonical `HEM-7386T1` profile, during the fresh pairing session only:

- read the corresponding settings/state blocks
- construct and write the 38-byte registration block to `0x0058`
- construct and write the 16-byte companion block to `0x0088`
- then continue with the existing normal memory-session close

The canonical profile is checked using `resolve_profile_model_id()` so variants such as `HEM-7382T1-AZAZ` map correctly.

## Validation

Tested on an Omron BP5465 identified by the integration as:

`HEM-7382T1-AZAZ`

Results:

- fresh pairing succeeds
- first retained-bond reconnect succeeds
- repeated subsequent measurements import correctly
- behavior remains successful with BlueZ controller privacy disabled
- full bare-metal power-cycle test also succeeded
- packaged HACS beta based on this change was installed fresh and successfully paired and imported multiple readings

No controller-level Bluetooth privacy change is required.

## Scope

This change is intentionally limited to the `HEM-7386T1` family and only runs during fresh pairing.