### PR TITLE
feat: run the pairing registration on HEM-7376T1 and HEM-7377T1

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -7,6 +7,7 @@ from .devices import (
     DeviceConfig,
     Endianness,
     HostPairingMode,
+    PairingRegistration,
     RecordParser,
     TimeSyncLayout,
     UnlockMode,
@@ -1122,6 +1123,13 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD3_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
         unlock_mode=UnlockMode.TOKEN_KEY,
+        # Same settings geometry as HEM-7386T1 -- 0x0010 -> 0x0058, [0x30, 0x40],
+        # 0x1C index region -- so the registration write lands on the same
+        # bytes at the same addresses as the one #175 verified there. Not yet
+        # confirmed on this model itself.
+        pairing_registration=PairingRegistration(
+            slot_offset=0x1C, index_flag_offset=0x11
+        ),
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0BCC],
         per_user_records_count=[60, 60],
@@ -1163,6 +1171,13 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         connect_type=ConnectType.WLD3_0,
         keep_notify_subscriptions=_WLD_KEEP_NOTIFY,
         unlock_mode=UnlockMode.TOKEN_KEY,
+        # Same settings geometry as HEM-7386T1 -- 0x0010 -> 0x0058, [0x30, 0x40],
+        # 0x1C index region -- so the registration write lands on the same
+        # bytes at the same addresses as the one #175 verified there. Not yet
+        # confirmed on this model itself.
+        pairing_registration=PairingRegistration(
+            slot_offset=0x1C, index_flag_offset=0x11
+        ),
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01CC, 0x080C],
         per_user_records_count=[100, 100],
@@ -1198,8 +1213,11 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # The cuff accepts the bond a fresh pairing makes and then refuses to
         # resume it (HCI 0x06) unless that session also wrote the settings
         # mirror the app writes before closing. Verified on a BP5465 over local
-        # BlueZ, through a power cycle (#175).
-        pairing_registration_write=True,
+        # BlueZ, through a power cycle (#175): slot right after the 0x1C index
+        # region, and byte 0x11 set to 0x80 as the capture showed.
+        pairing_registration=PairingRegistration(
+            slot_offset=0x1C, index_flag_offset=0x11
+        ),
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x080C, 0x0E4C],
         per_user_records_count=[100, 100],

--- a/custom_components/omron/omron_ble/devices.py
+++ b/custom_components/omron/omron_ble/devices.py
@@ -100,6 +100,28 @@ class TimeSyncLayout(StrEnum):
 _PEER_CLOSES_SESSION_SEC: float = 5.0
 
 
+@dataclass(frozen=True)
+class PairingRegistration:
+    """Where the pairing session's registration write lands in the settings mirror.
+
+    The app ends a fresh pairing by writing the index region plus one 10-byte
+    transfer slot back to the mirror, with the unread counter cleared and the
+    slot's two counters (+4, +8) stepped. WLD3.0 token-key cuffs refuse to
+    resume the bond on the next connection without it (#175, #91). The slot
+    does not always sit right after the index region -- an HEM-7155T-MW3 has
+    eight bytes between them (#67) -- so its offset is spelled out per profile
+    rather than derived. ``index_flag_offset`` is one byte the BP5465 capture
+    sets to 0x80 and the HEM-7155T-MW3 capture does not touch; its meaning is
+    not understood, so it is only written where it was seen.
+    """
+
+    # Offset of the transfer slot within the settings region. None means it
+    # follows the index region directly.
+    slot_offset: int | None = None
+    # Byte of the index region set to 0x80 in the write, or None to leave it.
+    index_flag_offset: int | None = None
+
+
 @dataclass
 class DeviceConfig:
     """Configuration for a specific Omron device model."""
@@ -157,7 +179,7 @@ class DeviceConfig:
     # Write the app's end-of-pairing settings mirror (index with the unread
     # counter cleared, one transfer slot, stamped clock) on the pairing session.
     # WLD3.0 token-key cuffs refuse to resume the bond without it (#175).
-    pairing_registration_write: bool = False
+    pairing_registration: PairingRegistration | None = None
 
     @property
     def pair_on_connect(self) -> bool:

--- a/custom_components/omron/omron_ble/omron_driver.py
+++ b/custom_components/omron/omron_ble/omron_driver.py
@@ -27,7 +27,6 @@ _LOGGER = logging.getLogger(__name__)
 # (#175 BP5465 capture; same shape in the #67 HEM-7155T-MW3 capture).
 _REGISTRATION_SLOT_SIZE: int = 10
 _REGISTRATION_SLOT_COUNTER_OFFSETS: tuple[int, ...] = (4, 8)
-_REGISTRATION_INDEX_FLAG_OFFSET: int = 0x11
 _MEMORY_PROTOCOL_REPLY_TIMEOUT_SEC: float = 5.0
 _MEMORY_PROTOCOL_TX_MAX_RETRIES: int = 4
 _MEMORY_PROTOCOL_RETRY_BACKOFF_SEC: float = 0.25
@@ -1554,8 +1553,9 @@ class OmronDeviceSession:
         session. The caller logs.
         """
         cfg = self._config
+        registration = cfg.pairing_registration
         if (
-            not cfg.pairing_registration_write
+            registration is None
             or not self._pairing_session
             or self._pairing_registration_done
         ):
@@ -1568,8 +1568,12 @@ class OmronDeviceSession:
         from .settings_mirror import SettingsMirrorLayout, clock_block
 
         layout = SettingsMirrorLayout(cfg)
-        index_size = layout.head_write_size
-        head_size = index_size + _REGISTRATION_SLOT_SIZE
+        slot = (
+            registration.slot_offset
+            if registration.slot_offset is not None
+            else layout.head_write_size
+        )
+        head_size = slot + _REGISTRATION_SLOT_SIZE
         if layout.head_read_size < head_size:
             raise ConnectionError(
                 f"Settings region of {cfg.model} is {layout.head_read_size} bytes; "
@@ -1592,12 +1596,14 @@ class OmronDeviceSession:
         # marker the cuff itself uses (the phone does the same every transfer).
         unread = int(users[0]["unread_counter_offset"])
         block[unread : unread + 2] = (0x8000).to_bytes(2, "little")
-        # As captured, meaning unknown: byte 0x11 of the index region is set
-        # to 0x80 in the app's write. Reproduced rather than reasoned about.
-        block[_REGISTRATION_INDEX_FLAG_OFFSET] = 0x80
+        # As captured, meaning unknown: one byte of the index region the app's
+        # write sets to 0x80 on the profiles where it was seen. Reproduced
+        # rather than reasoned about, and only where the profile says so.
+        if registration.index_flag_offset is not None:
+            block[registration.index_flag_offset] = 0x80
         # The transfer slot's two counters step once per transfer.
         for offset in _REGISTRATION_SLOT_COUNTER_OFFSETS:
-            at = index_size + offset
+            at = slot + offset
             block[at] = (block[at] + 1) & 0xFF
         await self.write_memory_range(
             layout.head_write_address, block, block_size=len(block)

--- a/tests/test_pairing_registration.py
+++ b/tests/test_pairing_registration.py
@@ -24,7 +24,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from custom_components.omron.omron_ble.devices import get_device_config
+from custom_components.omron.omron_ble.devices import (
+    PairingRegistration,
+    get_device_config,
+)
 from custom_components.omron.omron_ble.omron_driver import OmronDeviceSession
 from custom_components.omron.omron_ble.settings_mirror import (
     SettingsMirrorLayout,
@@ -137,7 +140,7 @@ class TestDerivedFromTheProfile:
     def test_a_shifted_profile_moves_the_writes_with_it(self):
         cfg = SimpleNamespace(
             model="synthetic",
-            pairing_registration_write=True,
+            pairing_registration=PairingRegistration(slot_offset=0x1C, index_flag_offset=0x11),
             settings_read_address=0x0100,
             settings_write_address=0x0200,
             settings_time_sync_bytes=[0x30, 0x40],
@@ -158,11 +161,53 @@ class TestDerivedFromTheProfile:
         )
         assert "resolve_profile_model_id" not in source
 
-    def test_the_flag_is_set_on_the_verified_family_only(self):
-        assert get_device_config("HEM-7386T1").pairing_registration_write is True
-        assert get_device_config("HEM-7382T1-AZAZ").pairing_registration_write is True
-        for other in ("HEM-7155T-MW3", "HEM-7380T1", "HEM-7188T1-LEO", "HEM-7142T2"):
-            assert get_device_config(other).pairing_registration_write is False, other
+    def test_the_verified_layout_is_shared_by_the_identical_profiles(self):
+        """7376T1/7377T1 은 7386T1 과 설정 지오메트리가 같으므로 같은 바이트가 간다."""
+        verified = get_device_config("HEM-7386T1")
+        assert verified.pairing_registration == PairingRegistration(
+            slot_offset=0x1C, index_flag_offset=0x11
+        )
+        assert get_device_config("HEM-7382T1-AZAZ").pairing_registration == verified.pairing_registration
+        for sibling in ("HEM-7376T1", "HEM-7377T1"):
+            cfg = get_device_config(sibling)
+            assert cfg.pairing_registration == verified.pairing_registration, sibling
+            # 같은 레이아웃이 같은 주소·크기로 이어져야 "동일"이 성립한다.
+            for attr in (
+                "settings_read_address",
+                "settings_write_address",
+                "settings_time_sync_bytes",
+            ):
+                assert getattr(cfg, attr) == getattr(verified, attr), (sibling, attr)
+            assert cfg.index_pointer_layout["index_region_byte_size"] == 0x1C
+
+    def test_profiles_without_evidence_stay_off(self):
+        for other in ("HEM-7155T-MW3", "HEM-7188T1-LEO", "HEM-7142T2", "HEM-7196T1"):
+            assert get_device_config(other).pairing_registration is None, other
+
+    def test_the_slot_offset_is_not_assumed_from_the_index_size(self):
+        """MW3 처럼 인덱스와 슬롯 사이에 패딩이 있는 배치를 위한 명시 오프셋."""
+        cfg = SimpleNamespace(
+            model="padded",
+            pairing_registration=PairingRegistration(slot_offset=0x18, index_flag_offset=None),
+            settings_read_address=0x0260,
+            settings_write_address=0x02A4,
+            settings_time_sync_bytes=[0x2C, 0x3C],
+            transmission_block_size=0x38,
+            index_pointer_layout={
+                "index_region_byte_size": 0x10,
+                "users": [{"unread_counter_offset": 0x04}],
+            },
+        )
+        memory = bytearray(0x400)
+        memory[0x0260 : 0x0260 + 0x2C] = bytes(range(0x2C))
+        target = _session(cfg, memory=bytes(memory))
+        _commit(target)
+        addr, written = target.writes[0]
+        assert addr == 0x02A4
+        assert len(written) == 0x18 + 10 == 34          # #67 캡처의 쓰기 길이
+        assert written[0x18 + 4] == 0x18 + 4 + 1         # 슬롯 +4 증가
+        assert written[0x18 + 8] == 0x18 + 8 + 1         # 슬롯 +8 증가
+        assert written[0x11] == 0x11                     # 플래그 없음: 읽은 그대로
 
 
 class TestWhenItRuns:


### PR DESCRIPTION
Turns on the pairing registration write from [#175](https://github.com/eigger/hass-omron/pull/175) for `HEM-7376T1` and `HEM-7377T1`.

## Why these two

They share `HEM-7386T1`'s settings geometry byte for byte:

| | read | write | clock | index region |
|---|---|---|---|---|
| HEM-7386T1 (verified, #175) | 0x0010 | 0x0058 | [0x30, 0x40] | 0x1C |
| HEM-7376T1 | 0x0010 | 0x0058 | [0x30, 0x40] | 0x1C |
| HEM-7377T1 | 0x0010 | 0x0058 | [0x30, 0x40] | 0x1C |

So the write that fixed the BP5465's refused reconnect lands on the same bytes at the same addresses on these. The 090ca5c experiment noted the shared 0x0058 mirror base back in August. A test pins the three profiles to the same layout *and* the same geometry, so the claim cannot drift.

What this does **not** establish is that these cuffs refuse the bond for the same reason. That needs a unit — [#62](https://github.com/eigger/hass-omron/issues/62) (HEM-7376T1-ACACD6) is the one to ask.

## The gate becomes a layout

`pairing_registration_write: bool` → `pairing_registration: PairingRegistration | None` with two fields:

- `slot_offset` — where the 10-byte transfer slot sits. It is **not** a function of the index region size: the #67 HEM-7155T-MW3 capture shows eight bytes between the index region and the slot. Spelled out per profile.
- `index_flag_offset` — the one index byte the BP5465 write sets to `0x80`. The MW3 capture does not touch it. Its meaning is not understood (asked on #175), so it is only written where it was seen.

The three profiles on it today carry `slot_offset=0x1C, index_flag_offset=0x11` — the values #175 verified. Bytes to the cuff are unchanged for HEM-7386T1; a test pins the transform.

251 tests pass.

Refs #62, #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
