### PR TITLE
feat: run the pairing registration on HEM-7380T1

### DIFF
--- a/custom_components/omron/omron_ble/device_catalog.py
+++ b/custom_components/omron/omron_ble/device_catalog.py
@@ -1089,6 +1089,16 @@ CANONICAL_DEVICE_PROFILES: dict[str, DeviceConfig] = {
         # Same protocol family as HEM-7386T1 and the same reported symptom
         # (issue #20), so it runs the same experiment rather than a variant.
         connect_settle_attempts=_WLD3_SINGLE_CONNECT_ATTEMPT,
+        # Its settings geometry is the HEM-7155T-MW3's, not the HEM-7386T1's:
+        # 0x44 between region and mirror, clock at [0x2C, 0x3C], and the #67
+        # MW3 capture puts the transfer slot at 0x18 -- which is also this
+        # profile's index region size. The index byte the BP5465 write sets is
+        # left alone: the MW3 capture does not touch it and no 7380 capture
+        # exists to say otherwise. Everything written is the mirror region's
+        # own bytes read back; records start at 0x01C4 and are not involved.
+        pairing_registration=PairingRegistration(
+            slot_offset=0x18, index_flag_offset=None
+        ),
         endianness=Endianness.LITTLE,
         user_start_addresses=[0x01C4, 0x0804],
         per_user_records_count=[100, 100],

--- a/tests/test_pairing_registration.py
+++ b/tests/test_pairing_registration.py
@@ -184,6 +184,29 @@ class TestDerivedFromTheProfile:
         for other in ("HEM-7155T-MW3", "HEM-7188T1-LEO", "HEM-7142T2", "HEM-7196T1"):
             assert get_device_config(other).pairing_registration is None, other
 
+    def test_hem_7380t1_uses_the_mw3_shaped_layout_without_the_flag(self):
+        """7380T1 은 7386T1 이 아니라 MW3 지오메트리다 — #67 캡처의 34바이트, 슬롯 0x18."""
+        cfg = get_device_config("HEM-7380T1")
+        assert cfg.pairing_registration == PairingRegistration(
+            slot_offset=0x18, index_flag_offset=None
+        )
+        memory = bytearray(0x400)
+        memory[0x0010 : 0x0010 + 0x2C] = bytes(range(0x2C))
+        target = _session(cfg, memory=bytes(memory))
+        _commit(target)
+        (head_addr, head), (clock_addr, clock) = target.writes
+        assert head_addr == 0x0054 and len(head) == 34
+        assert clock_addr == 0x0080 and len(clock) == 16
+        # 미러 영역 안에서만 쓴다: 레코드(0x01C4~)에는 닿지 않는다.
+        assert head_addr + len(head) <= 0x01C4 and clock_addr + len(clock) <= 0x01C4
+        # 읽은 그대로, 세 군데만 바뀐다.
+        expected = bytearray(range(0x2C))[:34]
+        expected[4:6] = (0x8000).to_bytes(2, "little")
+        expected[0x18 + 4] += 1
+        expected[0x18 + 8] += 1
+        assert head == bytes(expected)
+        assert head[0x11] == 0x11                          # 플래그 없음
+
     def test_the_slot_offset_is_not_assumed_from_the_index_size(self):
         """MW3 처럼 인덱스와 슬롯 사이에 패딩이 있는 배치를 위한 명시 오프셋."""
         cfg = SimpleNamespace(


### PR DESCRIPTION
Stacked on [#176](https://github.com/eigger/hass-omron/pull/176) — merge that first; this retargets to `master` on its own.

Turns on the pairing registration write for `HEM-7380T1`, the most-reported cuff with the refused reconnect ([#20](https://github.com/eigger/hass-omron/issues/20), [#133](https://github.com/eigger/hass-omron/issues/133) — "press the Bluetooth button first, then HA" is the retained-bond failure in user terms) and the one [#175](https://github.com/eigger/hass-omron/pull/175)'s write has not reached.

## Not the HEM-7386T1's layout

| | read | write | Δ | clock | index | slot |
|---|---|---|---|---|---|---|
| HEM-7386T1 (verified) | 0x0010 | 0x0058 | 0x48 | [0x30, 0x40] | 0x1C | 0x1C |
| **HEM-7380T1** | 0x0010 | 0x0054 | **0x44** | **[0x2C, 0x3C]** | 0x18 | **0x18** |
| HEM-7155T-MW3 (#67 capture) | 0x0260 | 0x02A4 | 0x44 | [0x2C, 0x3C] | 0x10 | 0x18 |

No capture of a 7380 exists anywhere. The #67 HEM-7155T-MW3 phone capture is the same-shape stand-in: the same 0x44 offset, the same clock window, and it puts the transfer slot at 0x18 — which is also this profile's index region size. That capture also does **not** touch the index byte the BP5465 write sets to 0x80, so `index_flag_offset=None` here.

## Is it harmless

What reaches the cuff:

- 34 bytes to `0x0054`: the settings region's own bytes read back, with three changes — user 1's unread counter cleared to `0x8000`, and the slot's two counters at `0x1C`/`0x20` stepped by one.
- 16 bytes to `0x0080`: the clock record stamped with the current time. This is the **same address the EEPROM time sync already writes** on this model when the clock drifts, so that half is already exercised.

Both land in the mirror region (`0x0054`–`0x008F`). Records start at `0x01C4` and are not involved. If the layout turns out wrong, the cost is transfer bookkeeping in the mirror and a reconnect that fails as it does today — not data.

A test pins the 34-byte output and that neither write reaches the record region.

## Who can confirm

@butzvarukt (#20, active yesterday) and @TheMiZMiZ (#133, offered to help). The question to them is the one that matters: after one fresh pairing, does the next scheduled poll — cuff untouched — read a measurement?

252 tests pass.

Refs #20, #133, #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)
